### PR TITLE
fix: default Creator output to karaoke songs folder (#43)

### DIFF
--- a/src/shared/defaults.js
+++ b/src/shared/defaults.js
@@ -63,7 +63,7 @@ export const LLM_DEFAULTS = {
 };
 
 export const CREATOR_DEFAULTS = {
-  outputToSongsFolder: false,
+  outputToSongsFolder: true,
   whisperModel: 'large-v3-turbo',
   enableCrepe: true,
   llm: LLM_DEFAULTS,


### PR DESCRIPTION
## Summary

Changes `CREATOR_DEFAULTS.outputToSongsFolder` from `false` to `true` so processed files land in the karaoke songs folder by default.

Closes #43

## Changes

- `src/shared/defaults.js`: `outputToSongsFolder: false` → `outputToSongsFolder: true`

Users can still uncheck the option to save next to the source file. This just makes the common workflow (create → play) smoother since songs land where the player expects them.