### PR TITLE
Fix LAN web song requests (field mismatch: path vs id)

### DIFF
--- a/src/web/pages/SongRequestPage.jsx
+++ b/src/web/pages/SongRequestPage.jsx
@@ -174,7 +174,7 @@ export function SongRequestPage() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          songId: selectedSong.path,
+          songId: selectedSong.id,
           requesterName: userName,
           message: requestMessage,
         }),
@@ -319,7 +319,7 @@ export function SongRequestPage() {
               ) : (
                 quickSearchResults.slice(0, 8).map((song) => (
                   <div
-                    key={song.path}
+                    key={song.id}
                     className="p-3.5 cursor-pointer border-b border-gray-200 dark:border-gray-600 flex justify-between items-start gap-3 transition-colors hover:bg-gray-200 dark:hover:bg-gray-600 last:border-b-0"
                     onClick={() => {
                       handleRequestSong(song);
@@ -408,7 +408,7 @@ export function SongRequestPage() {
             ) : (
               songs.map((song) => (
                 <div
-                  key={song.path}
+                  key={song.id}
                   className="flex justify-between items-start p-4 bg-gray-100 dark:bg-gray-700 rounded-md mb-2 transition-colors gap-4"
                 >
                   <div className="flex-1 flex flex-col items-start">


### PR DESCRIPTION
## Problem

Fixes #60. On the LAN web remote, submitting a song request always failed with *"Song ID and requester name are required"* even though the popup showed the song name and requester name filled in. Reported in Firefox and Edge, but it's actually browser-independent.

## Root cause

`SongRequestPage.jsx` built the POST body from `selectedSong.path`:

```js
body: JSON.stringify({ songId: selectedSong.path, ... })
```

But songs returned to LAN clients go through `sanitizeSongForPublic()` in `src/main/webServer.js`, which **deliberately strips `path`** (so filesystem paths are never exposed) and returns an opaque `id` instead. So `selectedSong.path` was always `undefined`; `JSON.stringify` dropped the key; and the server's validation at `webServer.js:562` rejected the request. Title/artist/requester rendered fine because those fields survive sanitization — that's why the popup *looked* complete.

## Fix

- `songId: selectedSong.path` → `selectedSong.id` (the server already accepts opaque IDs directly).
- Fixed the song-list React `key={song.path}` props, which had the same undefined-`path` bug.

No server change needed. `src/web/dist/` is gitignored and rebuilt by CI/packaging.