### PR TITLE
Docs: reflect vendored creator libs (follow-up to #63)

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -100,19 +100,30 @@ presets distributed under that package.
 
 ---
 
-## Runtime-fetched Creator components
+## Vendored Creator libraries (shipped in packages)
 
-The in-browser Creator fetches the following at first use from jsdelivr /
-Hugging Face via the app's same-origin caching proxy
-(`src/main/creator/webgpuAssets.js`); they are cached locally and re-served by
-the app rather than bundled via npm:
+The in-browser Creator's JS/wasm libraries are downloaded at build time by
+`scripts/vendor-webgpu-assets.js` (pinned versions in
+`src/main/creator/webgpuAssets.js`) into `static/webgpu/` and shipped inside
+the installers and the npm package:
 
 - **onnxruntime-web** (Microsoft) — MIT — https://github.com/microsoft/onnxruntime
 - **@huggingface/transformers** (transformers.js) — Apache-2.0 —
-  https://github.com/huggingface/transformers.js — including OpenAI **Whisper**
-  model weights (MIT) via onnx-community exports
+  https://github.com/huggingface/transformers.js
 - **@ffmpeg/core** (ffmpeg.wasm core) — MIT wrapper around **FFmpeg**
   (LGPL-2.1+) — https://github.com/ffmpegwasm/ffmpeg.wasm — https://ffmpeg.org
+
+(Builds produced without network access — e.g. the Flathub-from-source build —
+omit them; there the app fetches the same pinned files at runtime through its
+same-origin caching proxy instead.)
+
+## Runtime-fetched Creator models
+
+The ML models are fetched at first Creator use from Hugging Face via the app's
+same-origin caching proxy, cached locally, and re-served by the app:
+
+- **Whisper** speech-to-text model weights (OpenAI) — MIT — via onnx-community
+  timestamped exports
 - **Demucs / htdemucs** stem-separation models (Meta AI) — MIT —
   https://github.com/facebookresearch/demucs — ONNX exports served from
   Hugging Face (incl. `monteslu/htdemucs-ft-webgpu`; provenance in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -173,7 +173,7 @@ graph LR
 
 **Components:**
 - `src/shared/creator/createKaraoke.js` (+ `.worker.js`) - Orchestrates the in-browser pipeline
-- `webgpuAssets.js` - Same-origin caching proxy (`/webgpu-assets`): downloads onnxruntime-web, transformers.js, @ffmpeg/core wasm, and ONNX models once from jsdelivr/Hugging Face, then serves them offline
+- `webgpuAssets.js` - Same-origin asset server (`/webgpu-assets`): serves the vendored libs (onnxruntime-web, transformers.js, @ffmpeg/core wasm — bundled into static/webgpu at build time by `scripts/vendor-webgpu-assets.js`) and proxies+caches the ONNX models from Hugging Face on first use, then serves everything offline
 - `creatorJob.js` - Single observable job descriptor shared by the Electron tab and web admins
 - `systemChecker.js` - Cache-directory helper (`getCacheDir`)
 - `stemBuilder.js` - Creates .stem.mp4 with NI Stems + karaoke atoms

--- a/flatpak/PERMISSIONS.md
+++ b/flatpak/PERMISSIONS.md
@@ -35,9 +35,11 @@ commonly accept it for media-library apps with a clear rationale.
 ## Creator runtime deps
 
 The Creator runs entirely in-browser (WebGPU via onnxruntime-web, WASM fallback) —
-no Python, PyTorch, native modules, or system ffmpeg. On first use it downloads JS
-libraries, wasm binaries, and ONNX models (onnxruntime-web, transformers.js /
-Whisper, htdemucs ONNX, @ffmpeg/core wasm) through the app's same-origin caching
-proxy (`src/main/creator/webgpuAssets.js`) into the user cache dir; subsequent
-runs are fully offline. `--share=network` covers these one-time CDN (jsdelivr) /
-Hugging Face fetches.
+no Python, PyTorch, native modules, or system ffmpeg. Its JS/wasm libraries are
+vendored into the package at build time when the build has network access
+(`scripts/vendor-webgpu-assets.js`); in the offline Flathub build they are instead
+fetched at first use through the app's same-origin caching proxy
+(`src/main/creator/webgpuAssets.js`), like the ONNX models (Whisper, htdemucs,
+Silero VAD) always are. Everything is cached in the user cache dir; subsequent
+runs are fully offline. `--share=network` covers these one-time pinned-version
+CDN (jsdelivr) / Hugging Face fetches.


### PR DESCRIPTION
Small follow-up: the vendoring commit in #63 landed *after* that PR's docs pass, leaving three spots still describing the old fetch-everything-at-runtime behavior.

- **THIRD-PARTY-NOTICES** — split into "Vendored Creator libraries (shipped in packages)" (onnxruntime-web, transformers.js, @ffmpeg/core, with the offline-build caveat) and "Runtime-fetched Creator models" (Whisper, htdemucs, Silero VAD)
- **docs/architecture.md** — `webgpuAssets.js` described as serving vendored libs + proxying models
- **flatpak/PERMISSIONS.md** — libs vendored in network-built packages; runtime-fetched in the offline Flathub build