### PR TITLE
Fix editor-save freeze (#67), stalled LLM correction, editor time readout

### DIFF
--- a/src/main/creator/llmService.js
+++ b/src/main/creator/llmService.js
@@ -13,17 +13,24 @@ import { LLM_DEFAULTS } from '../../shared/defaults.js';
 /**
  * Get LLM provider instance based on settings
  */
+// Hard cap on any single LLM request. Without this the SDKs wait up to 10 MINUTES
+// (with retries on top), and a wedged endpoint — classically LM Studio running with no
+// model loaded, which accepts the request and never answers — stalled the whole
+// creation/save job with no visible error. On timeout the callers' try/catch keeps the
+// uncorrected lyrics and the job proceeds.
+const LLM_TIMEOUT_MS = 60_000;
+
 function getLLMProvider(settings) {
   const { provider, apiKey, baseUrl } = settings;
 
   switch (provider) {
     case 'anthropic':
       if (!apiKey) throw new Error('Anthropic API key required');
-      return new Anthropic({ apiKey });
+      return new Anthropic({ apiKey, timeout: LLM_TIMEOUT_MS, maxRetries: 1 });
 
     case 'openai':
       if (!apiKey) throw new Error('OpenAI API key required');
-      return new OpenAI({ apiKey });
+      return new OpenAI({ apiKey, timeout: LLM_TIMEOUT_MS, maxRetries: 1 });
 
     case 'gemini':
       if (!apiKey) throw new Error('Gemini API key required');
@@ -34,6 +41,8 @@ function getLLMProvider(settings) {
       return new OpenAI({
         apiKey: 'lm-studio', // dummy key
         baseURL: baseUrl || 'http://localhost:1234/v1',
+        timeout: LLM_TIMEOUT_MS,
+        maxRetries: 1,
       });
 
     default:
@@ -181,7 +190,11 @@ IMPORTANT ABOUT MISSING LINES:
 - DO NOT invent lyrics - only use what's in the reference
 - Return ONLY valid JSON, no markdown blocks, no additional text`;
 
-  // Call appropriate API
+  // Call appropriate API. Log BEFORE the request so a hang is visible in the job
+  // console as "calling … " with no reply (previously the job just went silent).
+  log(
+    `🤖 Calling ${providerType} (${model || 'default model'}), timeout ${LLM_TIMEOUT_MS / 1000}s …`
+  );
   if (providerType === 'anthropic') {
     const response = await provider.messages.create({
       model: model || 'claude-3-5-sonnet-20241022',
@@ -203,9 +216,10 @@ IMPORTANT ABOUT MISSING LINES:
     });
     return response.choices[0].message.content;
   } else if (providerType === 'gemini') {
-    const genModel = provider.getGenerativeModel({
-      model: model || 'gemini-2.0-flash-exp',
-    });
+    const genModel = provider.getGenerativeModel(
+      { model: model || 'gemini-2.0-flash-exp' },
+      { timeout: LLM_TIMEOUT_MS } // per-request cap (the Gemini client has no constructor timeout)
+    );
     const result = await genModel.generateContent({
       contents: [{ role: 'user', parts: [{ text: `${systemPrompt}\n\n${userPrompt}` }] }],
       generationConfig: {

--- a/src/main/webServer.js
+++ b/src/main/webServer.js
@@ -1329,8 +1329,11 @@ class WebServer {
         }
         const validatedPath = validation.resolvedPath;
 
-        // For KAI files, save metadata and lyrics
-        if (format === 'kai') {
+        // Stem MP4 saves (the editor's only loadable format). This used to gate on
+        // format === 'kai' — a legacy value the editor can no longer produce — so
+        // every web-admin lyric save for a .stem.mp4 fell through to the CDG/ID3
+        // branch below and failed with "Invalid file format".
+        if (isStemMp4Format(format)) {
           const editorService = await import('../shared/services/editorService.js');
           await editorService.saveSong(validatedPath, { format, metadata, lyrics });
 

--- a/src/shared/components/SongEditor.jsx
+++ b/src/shared/components/SongEditor.jsx
@@ -20,6 +20,15 @@ import { LyricRejection } from './LyricRejection.jsx';
 import { LyricSuggestion } from './LyricSuggestion.jsx';
 import { splitLine, canSplitLine } from '../utils/lyricsUtils.js';
 
+// m:ss.t readout for the playback transport (tenths: precise enough to line up
+// lyric timing by eye, stable enough not to flicker at rAF update rate).
+function formatEditorTime(sec) {
+  const s = Math.max(0, Number(sec) || 0);
+  const m = Math.floor(s / 60);
+  const rest = (s - m * 60).toFixed(1).padStart(4, '0');
+  return `${m}:${rest}`;
+}
+
 export function SongEditor({ bridge }) {
   const [searchTerm, setSearchTerm] = useState('');
   const [searchResults, setSearchResults] = useState([]);
@@ -1217,6 +1226,18 @@ export function SongEditor({ bridge }) {
                       </span>
                       {isPlaying ? 'Pause' : 'Play'}
                     </button>
+                    {/* Elapsed time (issue #67 request): tenths so lyric timing can be
+                        checked against the start/end numbers while playing. */}
+                    <span
+                      className="font-mono text-xs text-gray-900 dark:text-white tabular-nums px-1.5 whitespace-nowrap"
+                      title={`${currentPosition.toFixed(2)}s`}
+                    >
+                      {formatEditorTime(currentPosition)}
+                      <span className="text-gray-500 dark:text-gray-400">
+                        {' / '}
+                        {formatEditorTime(songDuration)}
+                      </span>
+                    </span>
                     <div className="flex gap-1.5 flex-wrap flex-1 items-center">
                       {audioElements.map((el, index) => (
                         <div

--- a/src/shared/services/editorService.js
+++ b/src/shared/services/editorService.js
@@ -58,18 +58,69 @@ export async function saveSong(path, updates) {
 
 /**
  * Save M4A song edits
+ *
+ * PERFORMANCE (issue #67): this used to call M4ALoader.load(), which reads the whole
+ * file AND extracts every audio track into memory (hundreds of MB of Buffer churn for
+ * a full-length .stem.mp4), then did THREE separate whole-file read-modify-write passes
+ * (kara atom, standard metadata, musical key). On big files that froze the entire app
+ * (main process event loop + GC pressure) for seconds to minutes AFTER the save toast.
+ * Now: ONE file read, all atom edits chained on the in-memory buffer, ONE file write.
+ * Everything the merge needs (lyrics/timing/singers/meta/tags) lives in the kara atom;
+ * standard metadata comes from music-metadata without touching the audio tracks.
+ *
  * @param {string} path - Path to M4A file
  * @param {Object} updates - Updates to apply
  * @returns {Promise<Object>} Save result
  */
 async function saveM4ASong(path, updates) {
   const { metadata, lyrics } = updates;
+  const fs = await import('fs/promises');
+  const pathMod = await import('path');
 
-  // Load existing M4A data
-  const m4aData = await M4ALoader.load(path);
+  // ONE full-file read; every atom operation below works on this buffer.
+  const fileBuffer = new Uint8Array(await fs.readFile(path));
 
-  // Merge metadata updates into the song data
-  const updatedMetadata = { ...m4aData.metadata };
+  // Existing karaoke data (lyrics, timing, singers, tags, corrections meta).
+  let existingKara = null;
+  try {
+    existingKara = Atoms.readKaraAtomBuffer(fileBuffer);
+  } catch {
+    /* no kara atom yet */
+  }
+  if (!existingKara) existingKara = { lines: [], singers: [] };
+
+  // Existing standard metadata (no audio decode - music-metadata parses atoms only).
+  const mm = await import('music-metadata');
+  let mmData = { common: {}, native: {} };
+  try {
+    mmData = await mm.parseBuffer(fileBuffer, { mimeType: 'audio/mp4' });
+  } catch {
+    /* fall back to update values below */
+  }
+  // Musical key lives in the iTunes initialkey freeform atom (same as M4ALoader).
+  let existingKey = 'C';
+  const keyAtom = mmData.native?.iTunes?.find(
+    (tag) => tag.id === '----:com.apple.iTunes:initialkey'
+  );
+  if (keyAtom && keyAtom.value) {
+    existingKey =
+      typeof keyAtom.value === 'string'
+        ? keyAtom.value.trim()
+        : Buffer.isBuffer(keyAtom.value)
+          ? keyAtom.value.toString('utf-8').trim()
+          : String(keyAtom.value).trim();
+  }
+
+  // Merge metadata updates over the existing values (same field semantics as before).
+  const updatedMetadata = {
+    title: mmData.common?.title || pathMod.basename(path, pathMod.extname(path)),
+    artist: mmData.common?.artist || '',
+    album: mmData.common?.album || '',
+    year: mmData.common?.year || null,
+    genre: mmData.common?.genre ? mmData.common.genre[0] : '',
+    key: existingKey,
+    tempo: existingKara.meter?.bpm || 120,
+  };
   if (metadata.title !== undefined) updatedMetadata.title = metadata.title;
   if (metadata.artist !== undefined) updatedMetadata.artist = metadata.artist;
   if (metadata.album !== undefined) updatedMetadata.album = metadata.album;
@@ -77,24 +128,26 @@ async function saveM4ASong(path, updates) {
   if (metadata.genre !== undefined) updatedMetadata.genre = metadata.genre;
   if (metadata.key !== undefined) updatedMetadata.key = metadata.key;
 
-  // NOTE: Standard metadata (title, artist, album, year, genre) is now written
-  // using proper MP4 atoms via addStandardMetadata() below, not FFmpeg
-
-  // Use updated lyrics array
-  let updatedLyrics = m4aData.lyrics;
+  // Use updated lyrics array; fall back to the file's existing lines.
+  let updatedLyrics = existingKara.lines || [];
   if (lyrics !== undefined && Array.isArray(lyrics)) {
     updatedLyrics = lyrics;
   }
 
-  // Prepare data to save
+  // Prepare data to save (shapes match what the kara build below consumes).
   const dataToSave = {
     metadata: updatedMetadata,
     lyrics: updatedLyrics,
-    audio: m4aData.audio, // Preserve audio configuration
-    features: m4aData.features, // Preserve features
-    singers: m4aData.singers, // Preserve singers
-    meta: m4aData.meta, // Preserve meta
-    tags: m4aData.tags || [], // Preserve existing tags
+    audio: {
+      timing: {
+        offsetSec: existingKara.timing?.offset_sec || 0,
+        encoderDelaySamples: existingKara.timing?.encoder_delay_samples || 0,
+      },
+    },
+    features: { tempo: existingKara.meter || null },
+    singers: existingKara.singers || [],
+    meta: existingKara.meta?.corrections ? { corrections: existingKara.meta.corrections } : {},
+    tags: existingKara.tags || [],
   };
 
   // Add 'edited' tag if not already present
@@ -175,16 +228,17 @@ async function saveM4ASong(path, updates) {
     }),
   };
 
-  // Save using stem-mp4
+  // Save using stem-mp4: chain every atom edit on the in-memory buffer, then write
+  // the file ONCE (the path-based Atoms.* each re-read + re-write the whole file).
   console.log('💾 Saving M4A kara atom:', path);
   console.log('📝 kara data prepared:', {
     lyricsCount: karaData.lines?.length || 0,
     tagsCount: karaData.tags?.length || 0,
   });
 
-  await Atoms.writeKaraAtom(path, karaData);
+  let outBuffer = Atoms.writeKaraAtomBuffer(fileBuffer, karaData);
 
-  // Write standard MP4 metadata atoms (title, artist, album, year, genre, BPM)
+  // Standard MP4 metadata atoms (title, artist, album, year, genre, BPM)
   const standardMetadata = {
     title: updatedMetadata.title,
     artist: updatedMetadata.artist,
@@ -193,20 +247,17 @@ async function saveM4ASong(path, updates) {
     genre: updatedMetadata.genre,
     tempo: updatedMetadata.tempo,
   };
-  await Atoms.addStandardMetadata(path, standardMetadata);
+  outBuffer = Atoms.addStandardMetadataBuffer(outBuffer, standardMetadata);
 
-  // Write musical key if changed (separate atom for DJ software)
+  // Musical key if changed (separate atom for DJ software)
   if (metadata.key !== undefined && updatedMetadata.key) {
     console.log(`🎹 Writing musical key: ${updatedMetadata.key}`);
-    await Atoms.addMusicalKey(path, updatedMetadata.key);
+    outBuffer = Atoms.addMusicalKeyBuffer(outBuffer, updatedMetadata.key);
   }
 
-  // Restore any preserved atoms that we didn't explicitly handle
-  if (m4aData._preservedAtoms && Object.keys(m4aData._preservedAtoms).length > 0) {
-    console.log(`📦 Restoring ${Object.keys(m4aData._preservedAtoms).length} preserved atoms`);
-    // Note: These atoms are already in the file and we didn't delete them,
-    // so they should still be there. This is just for logging.
-  }
+  // Atoms not explicitly rewritten above are inherently preserved: the buffer
+  // transforms rebuild only their target atoms and copy everything else through.
+  await fs.writeFile(path, outBuffer);
 
   console.log('✅ M4A file saved successfully');
 

--- a/src/shared/services/editorService.test.js
+++ b/src/shared/services/editorService.test.js
@@ -264,6 +264,62 @@ describe('editorService', () => {
       expect(Atoms.writeKaraAtomBuffer).not.toHaveBeenCalled();
     });
 
+    it('handles a file with no kara atom and no parseable metadata', async () => {
+      // Both readers fail → save still works from the update values + defaults.
+      Atoms.readKaraAtomBuffer.mockImplementation(() => {
+        throw new Error('no kara atom');
+      });
+      parseBuffer.mockRejectedValue(new Error('unparseable'));
+
+      const updates = {
+        format: 'stem-mp4',
+        metadata: { title: 'Fresh Title' },
+        lyrics: [{ start: 0, end: 1, text: 'First line' }],
+      };
+
+      const result = await editorService.saveSong('/music/test.m4a', updates);
+
+      expect(result.success).toBe(true);
+      expect(Atoms.writeKaraAtomBuffer).toHaveBeenCalledWith(
+        FILE_BYTES,
+        expect.objectContaining({
+          lines: [expect.objectContaining({ text: 'First line' })],
+        })
+      );
+      expect(Atoms.addStandardMetadataBuffer).toHaveBeenCalledWith(
+        KARA_OUT,
+        expect.objectContaining({ title: 'Fresh Title' })
+      );
+    });
+
+    it('preserves the existing iTunes musical key when the update has none', async () => {
+      parseBuffer.mockResolvedValue({
+        common: { title: 'T' },
+        native: {
+          iTunes: [{ id: '----:com.apple.iTunes:initialkey', value: Buffer.from('F#m') }],
+        },
+      });
+
+      const updates = { format: 'stem-mp4', metadata: { title: 'T2' }, lyrics: [] };
+      await editorService.saveSong('/music/test.m4a', updates);
+
+      // Key untouched in the update → no key atom rewrite (existing key stays in file).
+      expect(Atoms.addMusicalKeyBuffer).not.toHaveBeenCalled();
+      expect(writeFile).toHaveBeenCalledWith('/music/test.m4a', META_OUT);
+    });
+
+    it('falls back to the existing kara lines when no lyrics are passed', async () => {
+      const updates = { format: 'stem-mp4', metadata: { title: 'Only Meta' } };
+      await editorService.saveSong('/music/test.m4a', updates);
+
+      expect(Atoms.writeKaraAtomBuffer).toHaveBeenCalledWith(
+        FILE_BYTES,
+        expect.objectContaining({
+          lines: expect.arrayContaining([expect.objectContaining({ text: 'Line 1' })]),
+        })
+      );
+    });
+
     it('should propagate file read errors during save', async () => {
       readFile.mockRejectedValue(new Error('Failed to load'));
 

--- a/src/shared/services/editorService.test.js
+++ b/src/shared/services/editorService.test.js
@@ -5,7 +5,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import * as editorService from './editorService.js';
 
-// Mock M4ALoader and stem-mp4 Atoms
+// Mock M4ALoader (loadSong) and stem-mp4 Atoms (saveSong uses the BUFFER variants:
+// one file read, chained in-memory atom edits, one file write — issue #67).
 vi.mock('../../utils/m4aLoader.js', () => ({
   default: {
     load: vi.fn(),
@@ -14,14 +15,26 @@ vi.mock('../../utils/m4aLoader.js', () => ({
 
 vi.mock('stem-mp4', () => ({
   Atoms: {
-    writeKaraAtom: vi.fn(),
-    addStandardMetadata: vi.fn(),
-    addMusicalKey: vi.fn(),
+    readKaraAtomBuffer: vi.fn(),
+    writeKaraAtomBuffer: vi.fn(),
+    addStandardMetadataBuffer: vi.fn(),
+    addMusicalKeyBuffer: vi.fn(),
   },
+}));
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+vi.mock('music-metadata', () => ({
+  parseBuffer: vi.fn(),
 }));
 
 import M4ALoader from '../../utils/m4aLoader.js';
 import { Atoms } from 'stem-mp4';
+import { readFile, writeFile } from 'fs/promises';
+import { parseBuffer } from 'music-metadata';
 
 describe('editorService', () => {
   beforeEach(() => {
@@ -122,11 +135,33 @@ describe('editorService', () => {
       meta: {},
     };
 
+    const FILE_BYTES = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
+    const KARA_OUT = new Uint8Array([0x10]);
+    const META_OUT = new Uint8Array([0x20]);
+    const KEY_OUT = new Uint8Array([0x30]);
+
     beforeEach(() => {
-      M4ALoader.load.mockResolvedValue(mockM4AData);
-      Atoms.writeKaraAtom.mockResolvedValue();
-      Atoms.addStandardMetadata.mockResolvedValue();
-      Atoms.addMusicalKey.mockResolvedValue();
+      readFile.mockResolvedValue(FILE_BYTES);
+      writeFile.mockResolvedValue();
+      Atoms.readKaraAtomBuffer.mockReturnValue({
+        lines: mockM4AData.lyrics,
+        timing: { offset_sec: 0, encoder_delay_samples: 0 },
+        singers: [],
+        tags: [],
+      });
+      parseBuffer.mockResolvedValue({
+        common: {
+          title: 'Original Title',
+          artist: 'Original Artist',
+          album: 'Original Album',
+          year: 2020,
+          genre: ['Pop'],
+        },
+        native: {},
+      });
+      Atoms.writeKaraAtomBuffer.mockReturnValue(KARA_OUT);
+      Atoms.addStandardMetadataBuffer.mockReturnValue(META_OUT);
+      Atoms.addMusicalKeyBuffer.mockReturnValue(KEY_OUT);
     });
 
     it('should save M4A metadata updates successfully', async () => {
@@ -142,15 +177,22 @@ describe('editorService', () => {
       const result = await editorService.saveSong('/music/test.m4a', updates);
 
       expect(result.success).toBe(true);
-      expect(M4ALoader.load).toHaveBeenCalledWith('/music/test.m4a');
-      expect(Atoms.writeKaraAtom).toHaveBeenCalled();
-      expect(Atoms.addStandardMetadata).toHaveBeenCalledWith(
-        '/music/test.m4a',
+      // ONE read, ONE write — the whole point of the issue-67 fix.
+      expect(readFile).toHaveBeenCalledTimes(1);
+      expect(writeFile).toHaveBeenCalledTimes(1);
+      expect(Atoms.writeKaraAtomBuffer).toHaveBeenCalled();
+      expect(Atoms.addStandardMetadataBuffer).toHaveBeenCalledWith(
+        KARA_OUT,
         expect.objectContaining({
           title: 'New Title',
           artist: 'New Artist',
         })
       );
+      // No key in the updates → no key atom pass; the metadata output is written.
+      expect(Atoms.addMusicalKeyBuffer).not.toHaveBeenCalled();
+      expect(writeFile).toHaveBeenCalledWith('/music/test.m4a', META_OUT);
+      // The save must NOT run the full loader (audio track extraction).
+      expect(M4ALoader.load).not.toHaveBeenCalled();
     });
 
     it('should accept the legacy m4a-stems format on save', async () => {
@@ -163,8 +205,8 @@ describe('editorService', () => {
       const result = await editorService.saveSong('/music/test.m4a', updates);
 
       expect(result.success).toBe(true);
-      expect(Atoms.addStandardMetadata).toHaveBeenCalledWith(
-        '/music/test.m4a',
+      expect(Atoms.addStandardMetadataBuffer).toHaveBeenCalledWith(
+        KARA_OUT,
         expect.objectContaining({ title: 'Legacy Title' })
       );
     });
@@ -184,12 +226,25 @@ describe('editorService', () => {
 
       await editorService.saveSong('/music/test.m4a', updates);
 
-      expect(Atoms.writeKaraAtom).toHaveBeenCalledWith(
-        '/music/test.m4a',
+      expect(Atoms.writeKaraAtomBuffer).toHaveBeenCalledWith(
+        FILE_BYTES,
         expect.objectContaining({
           lines: expect.arrayContaining([expect.objectContaining({ text: 'Updated Line 1' })]),
         })
       );
+    });
+
+    it('should write the musical key atom when the key changes', async () => {
+      const updates = {
+        format: 'stem-mp4',
+        metadata: { key: 'Am' },
+        lyrics: mockM4AData.lyrics,
+      };
+
+      await editorService.saveSong('/music/test.m4a', updates);
+
+      expect(Atoms.addMusicalKeyBuffer).toHaveBeenCalledWith(META_OUT, 'Am');
+      expect(writeFile).toHaveBeenCalledWith('/music/test.m4a', KEY_OUT);
     });
 
     it('should throw error when path is missing', async () => {
@@ -197,7 +252,7 @@ describe('editorService', () => {
 
       await expect(editorService.saveSong('', updates)).rejects.toThrow('Path is required');
       await expect(editorService.saveSong(null, updates)).rejects.toThrow('Path is required');
-      expect(Atoms.writeKaraAtom).not.toHaveBeenCalled();
+      expect(Atoms.writeKaraAtomBuffer).not.toHaveBeenCalled();
     });
 
     it('should throw error for unsupported format', async () => {
@@ -206,30 +261,19 @@ describe('editorService', () => {
       await expect(editorService.saveSong('/music/test.cdg', updates)).rejects.toThrow(
         'Unsupported format: cdg. Only stem-mp4 format is supported.'
       );
-      expect(Atoms.writeKaraAtom).not.toHaveBeenCalled();
+      expect(Atoms.writeKaraAtomBuffer).not.toHaveBeenCalled();
     });
 
-    it('should write musical key when changed', async () => {
-      const updates = {
-        format: 'stem-mp4',
-        metadata: { key: 'Am' },
-        lyrics: [],
-      };
-
-      await editorService.saveSong('/music/test.m4a', updates);
-
-      expect(Atoms.addMusicalKey).toHaveBeenCalledWith('/music/test.m4a', 'Am');
-    });
-
-    it('should handle M4ALoader errors during save', async () => {
-      M4ALoader.load.mockRejectedValue(new Error('Failed to load'));
+    it('should propagate file read errors during save', async () => {
+      readFile.mockRejectedValue(new Error('Failed to load'));
 
       const updates = { format: 'stem-mp4', metadata: {}, lyrics: [] };
 
       await expect(editorService.saveSong('/music/test.m4a', updates)).rejects.toThrow(
         'Failed to load'
       );
-      expect(Atoms.writeKaraAtom).not.toHaveBeenCalled();
+      expect(Atoms.writeKaraAtomBuffer).not.toHaveBeenCalled();
+      expect(writeFile).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Fixes #67, plus a creator stall that presented as the job going silent instead of calling the LLM.

## 1. Editor save froze the whole app (#67)

Saving lyrics could freeze the app for seconds to minutes (sometimes needing a force close). The M4A save path was doing, per save:

- `M4ALoader.load()`: reads the whole file AND extracts every audio track into memory (hundreds of MB of Buffer churn on a full-length .stem.mp4), just to merge metadata
- `Atoms.writeKaraAtom(path)`: whole-file read + rewrite
- `Atoms.addStandardMetadata(path)`: whole-file read + rewrite again
- `Atoms.addMusicalKey(path)`: whole-file read + rewrite a third time

Four full reads plus three full writes, with the resulting allocation/GC pressure on the main process, which stalls every IPC in the app.

Now the save does ONE file read, chains the atom edits on the in-memory buffer (`writeKaraAtomBuffer` -> `addStandardMetadataBuffer` -> `addMusicalKeyBuffer`), and writes the file ONCE. Everything the merge needs (lyrics, timing, singers, tags, corrections meta) comes from the kara atom; standard tags come from `music-metadata` `parseBuffer` with no audio decode. Atoms not rewritten are copied through untouched by the buffer transforms.

Tests now assert exactly one read and one write and that the full loader (track extraction) is never invoked on save.

## 2. Creator stall instead of calling the LLM

LLM lyric correction had no request timeout. The SDK defaults wait up to 10 minutes (with retries on top), and a wedged endpoint silently stalled the whole creation/save job. The classic case is LM Studio running with no model loaded: it accepts the request and never answers.

- All providers now cap at 60s with 1 retry (Anthropic/OpenAI/LM Studio via client options, Gemini via per-request options)
- The provider/model is logged BEFORE the request, so a stall is visible in the job console instead of silence
- On timeout, the existing try/catch keeps the uncorrected lyrics and the job completes

## 3. Editor elapsed-time readout (requested in #67)

A monospace `m:ss.t / duration` readout next to the Play button, updating with the playhead (tenths precision), so lyric timing can be checked against the line start/end numbers while playing.

## Testing

- 340 tests pass (`npm run test:coverage`, CI's command); editorService tests rewritten for the buffer-based save + a new musical-key test
- Renderer and web bundles build
- Not yet reproduced against the reporter's library: the freeze scales with file size, so verification on a large .stem.mp4 (edit lyrics, save, confirm the app stays responsive) is the real acceptance test

## 4. Web-admin lyric saves were broken entirely (found while fixing #67)

The `/admin/editor/save` route only accepted `format === 'kai'`, a legacy value the editor can no longer load or produce (the load route returns `stem-mp4`). Every web-admin lyric save for a `.stem.mp4` fell through to the CDG/ID3 branch and failed with "Invalid file format". The route now gates on `isStemMp4Format()`, matching the load route and the service, so web saves use the same single-read/single-write path as the desktop editor.