### PR TITLE
Fix queue Load for .stem.mp4 (stale format list in queueService)

### DIFF
--- a/src/shared/services/queueService.js
+++ b/src/shared/services/queueService.js
@@ -198,18 +198,21 @@ export async function loadFromQueue(mainApp, itemId) {
   console.log('✅ Found item in queue:', item);
 
   try {
-    // Determine file format and call appropriate loader
+    // Load via the universal dispatcher. This used to keep its OWN extension
+    // check that only knew .kai and .cdg/.mp3 — so queue-loading a .stem.mp4
+    // (the PRIMARY format) threw a bogus 'Unsupported file format' even though
+    // the same file loads fine from the library. main.loadKaiFile detects the
+    // real format (CDG pairs, m4a/stem.mp4) and errors properly for genuinely
+    // unknown files; don't second-guess it here.
     const ext = item.path.toLowerCase();
-    if (ext.endsWith('.kai')) {
-      console.log('🎵 Loading KAI file:', item.path, 'queueItemId:', item.id);
-      await mainApp.loadKaiFile(item.path, item.id);
-    } else if (ext.endsWith('.cdg') || ext.endsWith('.mp3')) {
+    if (ext.endsWith('.cdg') || ext.endsWith('.mp3')) {
       console.log('💿 Loading CDG file:', item.path, 'queueItemId:', item.id);
       // For CDG, the path might be .mp3 or .cdg, loadCDGFile handles both
       const basePath = item.path.replace(/\.(mp3|cdg)$/i, '');
       await mainApp.loadCDGFile(`${basePath}.mp3`, `${basePath}.cdg`, 'cdg-pair', item.id);
     } else {
-      throw new Error(`Unsupported file format: ${item.path}`);
+      console.log('🎵 Loading song from queue:', item.path, 'queueItemId:', item.id);
+      await mainApp.loadKaiFile(item.path, item.id);
     }
 
     return {

--- a/src/shared/services/queueService.test.js
+++ b/src/shared/services/queueService.test.js
@@ -393,7 +393,11 @@ describe('queueService', () => {
       expect(mainApp.loadKaiFile).not.toHaveBeenCalled();
     });
 
-    it('should return error for unsupported file format', async () => {
+    it('propagates the loader error for genuinely unsupported files', async () => {
+      // Format judgment lives in main.loadKaiFile (the universal dispatcher) now;
+      // the queue service no longer keeps its own extension list (it used to, and
+      // its list was missing .stem.mp4 — the PRIMARY format — so queue loads threw
+      // a bogus 'Unsupported file format').
       const song = appState.addToQueue({
         path: '/music/song.txt',
         title: 'Test Song',
@@ -401,13 +405,14 @@ describe('queueService', () => {
 
       const mainApp = {
         appState,
-        loadKaiFile: vi.fn(),
+        loadKaiFile: vi.fn().mockRejectedValue(new Error('Unsupported file format: song.txt')),
       };
 
       const result = await queueService.loadFromQueue(mainApp, song.id);
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Unsupported file format');
+      expect(mainApp.loadKaiFile).toHaveBeenCalledWith('/music/song.txt', song.id);
     });
 
     it('should handle loader errors gracefully', async () => {
@@ -426,5 +431,34 @@ describe('queueService', () => {
       expect(result.success).toBe(false);
       expect(result.error).toBe('File not found');
     });
+  });
+});
+
+describe('loadFromQueue: stem.mp4 (the primary format)', () => {
+  it('routes .stem.mp4 through the universal loader instead of throwing', async () => {
+    const mainApp = {
+      appState: {
+        getQueue: () => [
+          { id: 42, path: "/music/The Beatles - Can't Buy Me Love.stem.mp4", title: 'CBML' },
+        ],
+      },
+      loadKaiFile: vi.fn().mockResolvedValue(true),
+    };
+    const result = await queueService.loadFromQueue(mainApp, 42);
+    expect(result.success).toBe(true);
+    expect(mainApp.loadKaiFile).toHaveBeenCalledWith(
+      "/music/The Beatles - Can't Buy Me Love.stem.mp4",
+      42
+    );
+  });
+
+  it('routes .m4a the same way', async () => {
+    const mainApp = {
+      appState: { getQueue: () => [{ id: 7, path: '/music/song.m4a', title: 'S' }] },
+      loadKaiFile: vi.fn().mockResolvedValue(true),
+    };
+    const result = await queueService.loadFromQueue(mainApp, 7);
+    expect(result.success).toBe(true);
+    expect(mainApp.loadKaiFile).toHaveBeenCalledWith('/music/song.m4a', 7);
   });
 });


### PR DESCRIPTION
Clicking Load on a queued .stem.mp4 threw a bogus 'Unsupported file format' (queueService kept its own extension list that predates the m4a era: only .kai and .cdg/.mp3). It now delegates to main.loadKaiFile, the universal dispatcher that detects CDG pairs and m4a/stem.mp4 and errors properly for genuinely unknown files.

Reported log confirmed the throw at queueService.js:212. Note: loadKaiFile's name is historical; .kai is a dead format and a wider rename/cleanup is tracked separately.

Tests: queue loads of .stem.mp4/.m4a route through the dispatcher; the unsupported-format case now asserts error propagation. 369 pass.