### PR TITLE
Fix green browser viewer: Vulkan breaks canvas capture on Wayland

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -53,13 +53,20 @@ const __dirname = dirname(__filename);
 // the actual Dawn backend (without it WebGPU is "super slow" or absent).
 // On macOS → Metal, Windows → D3D12, Linux → Vulkan, all under the hood.
 app.commandLine.appendSwitch('enable-unsafe-webgpu');
-app.commandLine.appendSwitch('enable-features', 'Vulkan');
 // On Linux the Vulkan backend is incompatible with the Wayland ozone backend
-// (vkAcquireNextImageKHR hangs / GPU process crash), so WebGPU needs X11 ozone.
-// Gated behind LOUKAI_WEBGPU=1 because X11 mode has the dropdown popup bug noted
-// above; default Wayland users fall back to WASM until Electron fixes Wayland.
-if (process.platform === 'linux' && process.env.LOUKAI_WEBGPU === '1') {
-  app.commandLine.appendSwitch('ozone-platform', 'x11');
+// (vkAcquireNextImageKHR hangs / GPU process crash) — AND, worse, Vulkan under
+// Wayland breaks canvas captureStream(): every frame fails with 'Could not find
+// or create a backing for stream kSkia', so the WebRTC browser viewer renders a
+// solid green video. So on Linux, Vulkan is only enabled together with X11 ozone
+// (LOUKAI_WEBGPU=1); the default Wayland run gets NO Vulkan — WebGPU falls back
+// to WASM there anyway, and the viewer stream works.
+if (process.platform === 'linux') {
+  if (process.env.LOUKAI_WEBGPU === '1') {
+    app.commandLine.appendSwitch('enable-features', 'Vulkan');
+    app.commandLine.appendSwitch('ozone-platform', 'x11');
+  }
+} else {
+  app.commandLine.appendSwitch('enable-features', 'Vulkan');
 }
 
 class KaiPlayerApp {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -53,15 +53,20 @@ const __dirname = dirname(__filename);
 // the actual Dawn backend (without it WebGPU is "super slow" or absent).
 // On macOS → Metal, Windows → D3D12, Linux → Vulkan, all under the hood.
 app.commandLine.appendSwitch('enable-unsafe-webgpu');
-// On Linux the Vulkan backend is incompatible with the Wayland ozone backend
-// (vkAcquireNextImageKHR hangs / GPU process crash) — AND, worse, Vulkan under
-// Wayland breaks canvas captureStream(): every frame fails with 'Could not find
-// or create a backing for stream kSkia', so the WebRTC browser viewer renders a
-// solid green video. So on Linux, Vulkan is only enabled together with X11 ozone
-// (LOUKAI_WEBGPU=1); the default Wayland run gets NO Vulkan — WebGPU falls back
-// to WASM there anyway, and the viewer stream works.
+// Linux GPU mode. X11 ozone + Vulkan is the ONLY combination where BOTH of these
+// work at the same time (verified live on Wayland-session hardware):
+//   1. Real-GPU WebGPU for the creator (Demucs/Whisper; needs the Vulkan feature —
+//      without it the adapter is SwiftShader CPU emulation, whose missing shader-f16
+//      also crashes the fp16 chained model), and
+//   2. The WebRTC browser viewer (canvas captureStream) — under Wayland ozone,
+//      Vulkan breaks capture per-frame ('Could not find or create a backing for
+//      stream kSkia') and viewers get a solid green video.
+// So X11+Vulkan is the DEFAULT. XWayland select-popup quirks are mitigated by
+// PortalSelect. LOUKAI_WAYLAND=1 is the escape hatch: native Wayland ozone with NO
+// Vulkan — the viewer works, creation falls back to WASM (SwiftShader is rejected
+// by detectWebGpu).
 if (process.platform === 'linux') {
-  if (process.env.LOUKAI_WEBGPU === '1') {
+  if (process.env.LOUKAI_WAYLAND !== '1') {
     app.commandLine.appendSwitch('enable-features', 'Vulkan');
     app.commandLine.appendSwitch('ozone-platform', 'x11');
   }

--- a/src/shared/creator/creatorLibs.js
+++ b/src/shared/creator/creatorLibs.js
@@ -126,12 +126,20 @@ export async function loadCreatorLibs(onLog = () => {}) {
   return cached;
 }
 
-/** Probe WebGPU availability (adapter present). Used to pick the EP. */
+/** Probe WebGPU availability (REAL adapter present). Used to pick the EP. */
 export async function detectWebGpu() {
   try {
     if (!navigator.gpu) return false;
     const adapter = await navigator.gpu.requestAdapter({ powerPreference: 'high-performance' });
-    return Boolean(adapter);
+    if (!adapter) return false;
+    // Reject software adapters: on Wayland (no Vulkan) Chromium offers SwiftShader,
+    // a CPU emulation. Running Demucs/Whisper on it is slower than the WASM path
+    // while claiming to be 'webgpu' — treat it as no GPU so the WASM fallback wins.
+    if (adapter.isFallbackAdapter) return false;
+    const vendor = (adapter.info?.vendor || '').toLowerCase();
+    const arch = (adapter.info?.architecture || '').toLowerCase();
+    if (vendor.includes('swiftshader') || arch.includes('swiftshader')) return false;
+    return true;
   } catch {
     return false;
   }


### PR DESCRIPTION
The popout browser viewer streamed a solid green video from both the Electron window and the web admin, and (discovered while testing) GPU creation and the viewer could not both work in any single launch mode.

Root cause: Vulkan was enabled unconditionally while X11 ozone was gated behind LOUKAI_WEBGPU=1, so default Wayland launches ran Vulkan+Wayland — under which canvas captureStream() fails every frame (kSkia backing errors) and viewers get green video. Turning Vulkan off on Wayland fixes the viewer but leaves WebGPU on SwiftShader (CPU emulation, no shader-f16 — which also crashes the fp16 chained demucs, as seen in testing).

Verified live over CDP on Wayland-session hardware:
- Wayland+Vulkan: green viewer, kSkia flood
- Wayland, no Vulkan: viewer OK, adapter = SwiftShader (no f16, no real GPU compute)
- X11+Vulkan: adapter = amd rdna-3 with shader-f16 AND the viewer streams the real canvas (title card, Butterchurn, QR, next-up overlay), zero kSkia errors

Changes:
1. Linux default is now X11 ozone + Vulkan (both GPU creation and the viewer work). The XWayland select-popup quirk that motivated the old gate is already mitigated by PortalSelect. LOUKAI_WAYLAND=1 is the escape hatch (native Wayland, no Vulkan: viewer works, creation falls back to WASM).
2. detectWebGpu() rejects SwiftShader/fallback adapters, so CPU-emulated WebGPU is never chosen over the WASM path.
3. Other platforms unchanged.