### PR TITLE
Chained demucs: shader-f16 gate + fp32 monolith runtime fallback

### DIFF
--- a/src/shared/creator/createKaraoke.js
+++ b/src/shared/creator/createKaraoke.js
@@ -159,7 +159,25 @@ export async function createKaraoke(
       // Chain requires the full-GPU path; on wasm (or if the pieces aren't
       // reachable) fall back to the old fp32 monolith.
       let chain = null;
+      // The chained split is MIXED PRECISION (fp16): it requires the WebGPU device
+      // to support shader-f16, or ORT fails at the first Cast node ('Program Cast
+      // requires f16 but the device does not support it'). Real GPUs without f16
+      // (some iGPUs/older drivers) and software adapters must use the fp32 monolith.
+      let deviceHasF16 = false;
       if (device === 'webgpu') {
+        try {
+          const adapter = await navigator.gpu?.requestAdapter({
+            powerPreference: 'high-performance',
+          });
+          deviceHasF16 = Boolean(adapter?.features?.has('shader-f16'));
+        } catch {
+          deviceHasF16 = false;
+        }
+        if (!deviceHasF16) {
+          onLog('GPU has no shader-f16 — using the fp32 monolith instead of the fp16 chain');
+        }
+      }
+      if (device === 'webgpu' && deviceHasF16) {
         try {
           const manifest = await fetch('/webgpu-models/htdemucs_split_manifest.json').then((r) => {
             if (!r.ok) throw new Error(`manifest fetch ${r.status}`);
@@ -264,7 +282,33 @@ export async function createKaraoke(
       onLog(
         `separating — ${chain ? `htdemucs chain (${chain.pieces.length} pieces${gentle ? ', gentle' : ''})` : 'htdemucs (single)'} on EP: ${device} …`
       );
-      result = await proc.separate(audio.left, audio.right);
+      try {
+        result = await proc.separate(audio.left, audio.right);
+      } catch (e) {
+        if (!chain) throw e;
+        // Chain died at RUNTIME (driver/f16 quirks the probe missed). Recover with
+        // the fp32 monolith rather than failing the whole job.
+        onLog(
+          `chained model failed at runtime (${String(e.message).slice(0, 160)}) — retrying with the fp32 monolith`
+        );
+        const monoBuf = await fetch('/webgpu-models/htdemucs.onnx').then((res) => {
+          if (!res.ok) throw new Error(`model fetch ${res.status}`);
+          return res.arrayBuffer();
+        });
+        const proc2 = new DemucsProcessor({
+          ort,
+          sessionOptions: { executionProviders: device === 'webgpu' ? ['webgpu'] : ['wasm'] },
+          gentle,
+          shouldCancel: emit.shouldCancel,
+          onProgress: ({ progress }) =>
+            onStemProgress(STEMS.reduce((a, s) => ({ ...a, [s]: progress || 0 }), {})),
+          onLog: (phase, m) => onLog(`[${phase}] ${m}`),
+        });
+        emit.onSeparator?.(proc2);
+        await proc2.loadModel(monoBuf);
+        modeLabel = 'htdemucs (fp32 fallback)';
+        result = await proc2.separate(audio.left, audio.right);
+      }
     }
     const sec = (performance.now() - t0) / 1000;
     const realtime = audio.duration / sec;

--- a/src/shared/creator/demucs/processor.js
+++ b/src/shared/creator/demucs/processor.js
@@ -267,14 +267,21 @@ export class DemucsProcessor {
       try {
         return await this.gpu.separate(leftChannel, rightChannel);
       } catch (e) {
+        const wasChain = !this.modelBuffer;
+        void this.gpu.session?.release?.().catch(() => {});
+        this.gpu = null;
+        if (wasChain) {
+          // A chained split has no monolith buffer to fall back to; fail loudly
+          // (the caller retries with the fp32 monolith). The old message claimed
+          // 'falling back to WASM DSP' and then threw anyway.
+          this.onLog('gpu', `GPU separation failed (${String(e).slice(0, 300)})`);
+          throw e;
+        }
         this.onLog(
           'gpu',
           `GPU separation failed (${String(e).slice(0, 300)}) \u2014 falling back to WASM DSP`
         );
-        void this.gpu.session?.release?.().catch(() => {});
-        this.gpu = null;
         this.dspMode = 'wasm';
-        if (!this.modelBuffer) throw e;
         await this.loadCpuSession(this.modelBuffer);
       }
     }


### PR DESCRIPTION
A device without WebGPU shader-f16 (SwiftShader on Wayland; some iGPUs/older drivers) loads the fp16 chained model fine and then crashes on the first run ('Program Cast requires f16 but the device does not support it'), with a misleading 'falling back to WASM DSP' log before a hard job failure (a chain has no monolith buffer for the WASM path).

1. Probe adapter shader-f16 BEFORE choosing the chain; without it the fp32 monolith runs on webgpu.
2. If the chain still dies at runtime, recover by fetching the fp32 monolith and retrying instead of failing the job.
3. processor no longer claims a WASM fallback for chains; it fails loudly and the caller owns recovery.

Complements #72 (which makes X11+Vulkan the Linux default so the real GPU with f16 is used in the first place).