### PR TITLE
Fix launch failure from shells with missing/stale XAUTHORITY

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "src/main/main.js",
   "homepage": "./",
   "scripts": {
-    "start": "electron . --no-sandbox",
+    "start": "node scripts/start-electron.mjs . --no-sandbox",
     "dev": "npm run build:all && electron . --dev --no-sandbox",
     "build": "npm run build:all && electron-builder && node scripts/rename-artifacts.js",
     "build:all": "npm run vendor:webgpu && npm run build:renderer && npm run build:web",

--- a/scripts/start-electron.mjs
+++ b/scripts/start-electron.mjs
@@ -1,0 +1,55 @@
+/**
+ * Launch Electron with a USABLE display environment (Linux). The x11+Vulkan GPU
+ * default needs DISPLAY and a VALID XAUTHORITY before the process starts —
+ * Chromium's zygotes fork before any app JS runs, so main.js cannot repair the
+ * env (children inherit the broken one and the window comes up dead with
+ * 'Authorization required, but no authorization protocol specified').
+ *
+ * Real-world launch envs this fixes:
+ *  - tmux/screen shells carrying a STALE XAUTHORITY from a previous session
+ *    (mutter's Xwayland cookie filename changes each boot)
+ *  - shells with no XAUTHORITY exported at all (mutter does not export it)
+ *  - shells with no DISPLAY (probe the XWayland socket)
+ * If X still is not usable, LOUKAI_WAYLAND=1 is exported so main.js picks the
+ * Wayland fallback (working window + viewer, WASM creation) instead of a
+ * broken X window.
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, readdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const electron = require('electron'); // resolves to the binary path
+
+const env = { ...process.env };
+if (process.platform === 'linux' && env.LOUKAI_WAYLAND !== '1') {
+  let ok = true;
+  if (!env.DISPLAY) {
+    if (existsSync('/tmp/.X11-unix/X0')) env.DISPLAY = ':0';
+    else ok = false;
+  }
+  if (ok && (!env.XAUTHORITY || !existsSync(env.XAUTHORITY))) {
+    // Discover mutter's current XWayland cookie (GNOME) or a classic Xauthority.
+    let cookie = null;
+    try {
+      const dir = `/run/user/${process.getuid()}`;
+      const f = readdirSync(dir).find((n) => n.startsWith('.mutter-Xwaylandauth'));
+      if (f) cookie = `${dir}/${f}`;
+    } catch {
+      /* keep looking */
+    }
+    if (!cookie && env.HOME && existsSync(`${env.HOME}/.Xauthority`)) {
+      cookie = `${env.HOME}/.Xauthority`;
+    }
+    if (cookie) env.XAUTHORITY = cookie;
+    else ok = false;
+  }
+  if (!ok) {
+    console.warn('[start] X11 not usable from this environment — falling back to Wayland mode');
+    env.LOUKAI_WAYLAND = '1';
+  }
+}
+
+const args = process.argv.slice(2);
+const r = spawnSync(electron, args, { stdio: 'inherit', env });
+process.exit(r.status ?? 1);

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -65,8 +65,31 @@ app.commandLine.appendSwitch('enable-unsafe-webgpu');
 // PortalSelect. LOUKAI_WAYLAND=1 is the escape hatch: native Wayland ozone with NO
 // Vulkan — the viewer works, creation falls back to WASM (SwiftShader is rejected
 // by detectWebGpu).
+// X11 must actually be REACHABLE for the x11 ozone default, or the app comes up
+// windowless ('Authorization required, but no authorization protocol specified' /
+// xcb_connection_has_error). Two real-world gaps on Wayland desktops:
+//  - DISPLAY may be unset in the launching shell -> probe the XWayland socket.
+//  - GNOME/mutter does not export XAUTHORITY to app environments; its XWayland
+//    auth cookie lives at /run/user/<uid>/.mutter-Xwaylandauth.* -> discover it.
+// If X is not usable, fall back to Wayland ozone without Vulkan (viewer works,
+// creation uses WASM) instead of launching a broken window.
+function x11Usable() {
+  // VALIDATE only — do not mutate env here: Chromium's zygotes fork before app JS
+  // runs, so children would inherit the unfixed env anyway (dead window). The dev
+  // launcher (scripts/start-electron.mjs) repairs the env BEFORE Electron spawns;
+  // desktop/session launches carry a correct env already. If this env cannot do
+  // X11, take the Wayland fallback (working window + viewer, WASM creation).
+  try {
+    if (!process.env.DISPLAY) return false;
+    if (process.env.XAUTHORITY && !fs.existsSync(process.env.XAUTHORITY)) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 if (process.platform === 'linux') {
-  if (process.env.LOUKAI_WAYLAND !== '1') {
+  if (process.env.LOUKAI_WAYLAND !== '1' && x11Usable()) {
     app.commandLine.appendSwitch('enable-features', 'Vulkan');
     app.commandLine.appendSwitch('ozone-platform', 'x11');
   }


### PR DESCRIPTION
## Problem

After merging #72 (Linux x11+Vulkan default), `npm start` from a tmux/older shell wouldn't fire up: the window came up dead with `Authorization required, but no authorization protocol specified` / `xcb_connection_has_error()`.

Root cause: mutter's XWayland auth cookie filename changes every session (`/run/user/1000/.mutter-Xwaylandauth.XXXXXX`), so a shell carrying a stale `XAUTHORITY` (or none at all, since mutter doesn't export it to non-session shells) can't authenticate to X. And this **cannot** be fixed inside `main.js`: Chromium's zygote processes fork before any app JS runs, so env repairs there never reach the GPU/renderer children (verified: 30 auth errors persisted with an in-process fix).

## Fix

- **`scripts/start-electron.mjs`**: launcher that repairs `DISPLAY`/`XAUTHORITY` *before* Electron spawns (probes `/tmp/.X11-unix/X0`, globs mutter's cookie in `/run/user/<uid>`, falls back to `~/.Xauthority`). If X still isn't usable it exports `LOUKAI_WAYLAND=1` so the app comes up on a working Wayland window instead of a broken X one.
- **`package.json`**: `npm start` goes through the launcher.
- **`main.js`**: the x11 gate is now validate-only (`x11Usable()`): unset `DISPLAY` or an `XAUTHORITY` pointing at a nonexistent file → Wayland fallback. No env mutation (pointless per above).

Packaged/desktop launches are unaffected: the session env carries a correct `XAUTHORITY` (confirmed via `systemctl --user show-environment`), so they keep the x11+Vulkan default. Mac/Windows untouched (all changes inside `platform === 'linux'` / the launcher's linux branch).

## Verification

Launched with `XAUTHORITY=/nonexistent/stale-cookie` (exact failure class):
- zero `Authorization required` / `xcb` errors in the log
- window mode: x11+Vulkan (no fallback triggered)
- admin reachable (200)
- browser viewer popout streams lyrics + visuals, no green frames
- 245/245 service tests pass

Release blocker for v0.7.2.