### PR TITLE
Remove the demucs WASM fallback: stem separation is WebGPU-only

### DIFF
--- a/src/shared/creator/createKaraoke.js
+++ b/src/shared/creator/createKaraoke.js
@@ -55,7 +55,7 @@ const FP16_CPU_NODES = [
  * @param {string} opts.asrModel  Whisper model id
  * @param {string} opts.demucsModel  'htdemucs' | 'htdemucs_ft'
  * @param {boolean} opts.ftAvailable  whether the ft ensemble is installed
- * @param {('webgpu'|'wasm')} opts.device  inference EP
+ * @param {('webgpu'|'wasm')} opts.device  inference EP (wasm only valid for lyrics-only/stem-reuse runs; separation requires webgpu)
  * @param {string} opts.whisperDtype
  * @param {('segment'|'word')} opts.timestampMode
  * @param {string} opts.language
@@ -112,6 +112,14 @@ export async function createKaraoke(
   // --- Demucs stem separation (in-browser) --- (skipped when reusing / lyrics-only)
   if (!lyricsOnly && !reuseStems) {
     onPhase('separating');
+    // Product rule: stem separation runs on WebGPU or not at all. The WASM DSP
+    // is orders of magnitude slower and produces support tickets, not stems.
+    if (device !== 'webgpu') {
+      throw new Error(
+        'WebGPU is required for stem separation (no real GPU adapter available). ' +
+          'Refusing the CPU/WASM demucs path.'
+      );
+    }
     let modelDef = [
       { id: 'htdemucs', kind: 'single' },
       { id: 'htdemucs_ft', kind: 'ft' },
@@ -262,12 +270,9 @@ export async function createKaraoke(
         // (same 16 node names as ft_cpu_nodes.json); without the pin the fp16
         // graph is all-NaN on WebGPU. Monolith keeps the plain EP list.
         sessionOptions: {
-          executionProviders:
-            device !== 'webgpu'
-              ? ['wasm']
-              : chain
-                ? [{ name: 'webgpu', forceCpuNodeNames: FP16_CPU_NODES }]
-                : ['webgpu'],
+          executionProviders: chain
+            ? [{ name: 'webgpu', forceCpuNodeNames: FP16_CPU_NODES }]
+            : ['webgpu'],
         },
         gentle,
         shouldCancel: emit.shouldCancel,
@@ -297,7 +302,7 @@ export async function createKaraoke(
         });
         const proc2 = new DemucsProcessor({
           ort,
-          sessionOptions: { executionProviders: device === 'webgpu' ? ['webgpu'] : ['wasm'] },
+          sessionOptions: { executionProviders: ['webgpu'] },
           gentle,
           shouldCancel: emit.shouldCancel,
           onProgress: ({ progress }) =>

--- a/src/shared/creator/demucs/processor.js
+++ b/src/shared/creator/demucs/processor.js
@@ -112,8 +112,10 @@ export class DemucsProcessor {
     // Cooperative cancel: checked between segments; throws to abort the run
     // without tearing down the warmed worker/sessions.
     this.shouldCancel = options.shouldCancel ?? (() => false);
-    const gpuAvailable = typeof navigator !== 'undefined' && Boolean(navigator.gpu);
-    this.dspMode = options.dsp ?? (gpuAvailable ? 'webgpu' : 'wasm');
+    // Product rule: demucs NEVER runs on the CPU/WASM DSP. No auto-degrade;
+    // the wasm/js modes stay constructible only via an explicit `dsp` option
+    // (unit tests exercise the segment math through them).
+    this.dspMode = options.dsp ?? 'webgpu';
   }
   get gentle() {
     return this._gentle;
@@ -178,13 +180,11 @@ export class DemucsProcessor {
         this.onLog('model', 'Model loaded successfully (full-GPU path)');
         return this.session;
       } catch (e) {
-        if (isChain) throw e;
-        this.onLog(
-          'gpu',
-          `full-GPU path unavailable (${String(e).slice(0, 300)}) \u2014 using WASM DSP path`
-        );
+        // No WASM fallback: a broken GPU path fails the job loudly instead of
+        // silently grinding the CPU for an hour.
+        this.onLog('gpu', `full-GPU path unavailable (${String(e).slice(0, 300)})`);
         this.gpu = null;
-        this.dspMode = 'wasm';
+        throw e;
       }
     }
     if (isChain) throw new Error('chained split model requires the WebGPU DSP path');
@@ -267,22 +267,12 @@ export class DemucsProcessor {
       try {
         return await this.gpu.separate(leftChannel, rightChannel);
       } catch (e) {
-        const wasChain = !this.modelBuffer;
         void this.gpu.session?.release?.().catch(() => {});
         this.gpu = null;
-        if (wasChain) {
-          // A chained split has no monolith buffer to fall back to; fail loudly
-          // (the caller retries with the fp32 monolith). The old message claimed
-          // 'falling back to WASM DSP' and then threw anyway.
-          this.onLog('gpu', `GPU separation failed (${String(e).slice(0, 300)})`);
-          throw e;
-        }
-        this.onLog(
-          'gpu',
-          `GPU separation failed (${String(e).slice(0, 300)}) \u2014 falling back to WASM DSP`
-        );
-        this.dspMode = 'wasm';
-        await this.loadCpuSession(this.modelBuffer);
+        // Fail loudly; no WASM fallback. For the chained split the caller
+        // retries with the fp32 monolith (still WebGPU).
+        this.onLog('gpu', `GPU separation failed (${String(e).slice(0, 300)})`);
+        throw e;
       }
     }
     const session = this.session;


### PR DESCRIPTION
Demucs on the CPU/WASM DSP is never acceptable (near an hour per song) and only ever ran by accident, when a broken launch env left WebGPU as SwiftShader and the guard from #72 correctly rejected it. Now separation fails loudly instead of silently degrading:

- **createKaraoke**: hard gate where separation starts; `device` must be `webgpu` or the run errors with `WebGPU is required for stem separation`. Lyrics-only and stem-reuse runs are unaffected (whisper may still use the wasm EP there). The fp32 monolith retry from #73 stays, since it is still WebGPU.
- **DemucsProcessor**: no auto-degrade in the constructor, no load-time WASM fallback, no runtime "falling back to WASM DSP". The wasm/js DSP modes remain constructible only via an explicit `dsp` option, which unit tests use to exercise the segment math.

39/39 creator tests pass. Independent of #74 (no file overlap); merge in either order.