### PR TITLE
Fix whisper crash on English-only models

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -357,7 +357,10 @@ class KaiPlayerApp {
     // Prevent JavaScript errors from showing as alert dialogs
     this.mainWindow.webContents.on('console-message', (event, level, message, line, sourceId) => {
       if (level === 3) {
-        // Error level
+        // onnxruntime logs EVERYTHING through console.error, including its
+        // info/warning-severity lines ([I:...]/[W:...] tags). Only real ORT
+        // errors deserve the siren; the rest drowned out actual failures.
+        if (/\[[IWV]:onnxruntime/.test(message)) return;
         console.error(`🚨 Renderer error at ${sourceId}:${line}:`, message);
         event.preventDefault();
       }

--- a/src/shared/creator/createKaraoke.js
+++ b/src/shared/creator/createKaraoke.js
@@ -86,7 +86,10 @@ export async function createKaraoke(
   const onRtf = emit.onRtf || (() => {});
 
   const {
-    asrModel,
+    // Same default as the panel and offsite creator. Without one, host-create
+    // (which only sends language) fell through to transformers.js's built-in
+    // pipeline default: whisper-tiny.en — tiny AND English-only.
+    asrModel = 'onnx-community/whisper-large-v3-turbo_timestamped',
     demucsModel,
     ftAvailable = true,
     device = 'wasm',

--- a/src/shared/creator/transcribeVocals.js
+++ b/src/shared/creator/transcribeVocals.js
@@ -298,11 +298,21 @@ export async function transcribeVocals(input, opts = {}, emit = {}) {
   const SR16 = 16000;
   const totalSamples = mono.length;
   const allChunks = [];
+  // English-only models (whisper-*.en) REJECT language/task outright
+  // ('Cannot specify `task` or `language` for an English-only model'), while
+  // multilingual models need the resolved language passed explicitly (omitting
+  // it silently forces English). Pass it only where it is accepted.
+  const multilingual = Boolean(
+    asr?.model?.generation_config?.is_multilingual ?? asr?.model?.generation_config?.lang_to_id
+  );
+  if (!multilingual && effectiveLanguage && effectiveLanguage !== 'en') {
+    onLog(
+      `model is English-only but language is '${effectiveLanguage}' - pick a multilingual whisper model for non-English lyrics`
+    );
+  }
   const baseOpts = {
     return_timestamps: useWordTs ? 'word' : true,
-    // Always pass the RESOLVED language ('auto' was detected above). Omitting it makes
-    // transformers.js silently force English — never rely on that default.
-    ...(effectiveLanguage ? { language: effectiveLanguage } : {}),
+    ...(effectiveLanguage && multilingual ? { language: effectiveLanguage } : {}),
     ...(promptIds ? { prompt_ids: promptIds } : promptText ? { prompt: promptText } : {}),
     repetition_penalty: 1.2,
     no_repeat_ngram_size: 3,


### PR DESCRIPTION
Host-create failed at the whisper step with `Cannot specify 'task' or 'language' for an English-only model` (this was the "demucs not working" report; demucs itself ran fine on WebGPU, and ORT's info lines forwarded as 🚨 Renderer errors made it look GPU-related).

Three fixes:

1. **Why an English-only model was even loaded**: the admin's host-create only sends `language` in its opts, so `asrModel` reached transformers.js `undefined` and its built-in pipeline default kicked in: `Xenova/whisper-tiny.en` — tiny AND English-only. `createKaraoke` now defaults to the same `onnx-community/whisper-large-v3-turbo_timestamped` the panel and offsite creator use; explicit model choices still pass through.
2. **The crash itself**: the language auto-detect change made transcription always pass the resolved `language` to `generate()`. Multilingual models need that (omitting it silently forces English), but English-only `*.en` models throw on it. Now `language` is passed only when the loaded model reports itself multilingual, with a log pointing at multilingual models when non-English lyrics are requested on an `.en` model.
3. **The misleading sirens**: the `🚨 Renderer error` forwarder now drops onnxruntime `[I:]`/`[W:]`/`[V:]` lines; ORT logs everything through `console.error` and the fake errors buried real failures.

Verified end to end on this branch: host-create of a 4-minute mp3 completes; demucs runs on WebGPU (rdna-3, f16), whisper transcribes, file lands in the library. First host-create after merge will download turbo v3 (~800MB, cached after that).

Note: `npm start` serves the last-built renderer bundle; after merging, run `npm run build:renderer` (or `npm run dev`) to pick this up.