### PR TITLE
Route npm run dev through the env-repair launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "./",
   "scripts": {
     "start": "node scripts/start-electron.mjs . --no-sandbox",
-    "dev": "npm run build:all && electron . --dev --no-sandbox",
+    "dev": "npm run build:all && node scripts/start-electron.mjs . --dev --no-sandbox",
     "build": "npm run build:all && electron-builder && node scripts/rename-artifacts.js",
     "build:all": "npm run vendor:webgpu && npm run build:renderer && npm run build:web",
     "vendor:webgpu": "node scripts/vendor-webgpu-assets.js",

--- a/src/shared/creator/createKaraoke.js
+++ b/src/shared/creator/createKaraoke.js
@@ -120,7 +120,9 @@ export async function createKaraoke(
     if (device !== 'webgpu') {
       throw new Error(
         'WebGPU is required for stem separation (no real GPU adapter available). ' +
-          'Refusing the CPU/WASM demucs path.'
+          'Refusing the CPU/WASM demucs path. On Linux this usually means the app ' +
+          'was launched without the X11/Vulkan environment - relaunch via npm start ' +
+          'or the desktop entry.'
       );
     }
     let modelDef = [


### PR DESCRIPTION
#74 wired only `npm start` through `scripts/start-electron.mjs`. `npm run dev` still spawned `electron .` directly, so from a shell with a stale `XAUTHORITY` (tmux) the app silently lands in the Wayland fallback: window and WebGL work, playback works, but WebGPU is SwiftShader-only, and since #75 stem separation correctly refuses to run there.

Captured live on such a launch:

```
host create starting — EP: wasm
WebGPU is required for stem separation (no real GPU adapter available). Refusing the CPU/WASM demucs path.
```

- `npm run dev` now goes through the launcher (env repaired before Electron spawns, same as `npm start`).
- The refusal error now tells you what to do: relaunch via `npm start` or the desktop entry.

With this + #76 merged and a rebuild, host-create runs demucs on the real adapter again.