### PR TITLE
Single-instance lock: second launch focuses the running app

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -2461,7 +2461,25 @@ class KaiPlayerApp {
   }
 }
 
+// One Loukai at a time. Without this lock a second launch fights the first
+// for port 3069 and the Chromium profile lock and dies in confusing ways
+// (looks like the app 'won't fire up'). Instead: tell the user, focus the
+// running window, and exit cleanly.
+if (!app.requestSingleInstanceLock()) {
+  console.error('Loukai is already running - focusing the existing window and exiting.');
+  app.quit();
+  process.exit(0);
+}
+
 const kaiApp = new KaiPlayerApp();
+
+app.on('second-instance', () => {
+  const win = kaiApp.mainWindow;
+  if (win && !win.isDestroyed()) {
+    if (win.isMinimized()) win.restore();
+    win.focus();
+  }
+});
 
 // Handle uncaught exceptions and errors without showing alert dialogs
 process.on('uncaughtException', (error) => {


### PR DESCRIPTION
The "won't fire up" loop had a mundane cause on top of the env fixes: there is no single-instance guard, so launching while a previous instance is still alive (a leftover session, a background test instance, anything) fights over port 3069 and the Chromium profile lock and dies confusingly.

Now: `app.requestSingleInstanceLock()` at boot. A second launch prints `Loukai is already running - focusing the existing window and exiting.`, focuses the running window, and exits cleanly. The running instance is untouched.

Verified live: with instance A serving admin on 3069, a second `npm start` prints the message and exits; A stays healthy and receives focus.