### PR TITLE
Linux: Wayland window + Vulkan WebGPU + software compositing

### DIFF
--- a/scripts/start-electron.mjs
+++ b/scripts/start-electron.mjs
@@ -1,18 +1,14 @@
 /**
- * Launch Electron with a USABLE display environment (Linux). The x11+Vulkan GPU
- * default needs DISPLAY and a VALID XAUTHORITY before the process starts —
- * Chromium's zygotes fork before any app JS runs, so main.js cannot repair the
- * env (children inherit the broken one and the window comes up dead with
- * 'Authorization required, but no authorization protocol specified').
+ * Launch Electron with a usable display environment (Linux). Chromium's zygotes
+ * fork before any app JS runs, so display env vars must be correct BEFORE the
+ * electron binary spawns — main.js cannot repair them.
  *
- * Real-world launch envs this fixes:
- *  - tmux/screen shells carrying a STALE XAUTHORITY from a previous session
- *    (mutter's Xwayland cookie filename changes each boot)
- *  - shells with no XAUTHORITY exported at all (mutter does not export it)
- *  - shells with no DISPLAY (probe the XWayland socket)
- * If X still is not usable, LOUKAI_WAYLAND=1 is exported so main.js picks the
- * Wayland fallback (working window + viewer, WASM creation) instead of a
- * broken X window.
+ * The app runs on the session's native ozone platform (Wayland on a Wayland
+ * desktop — forcing x11 there creates NO toplevel window at all). What this
+ * launcher fixes is stale/missing env in long-lived shells (tmux/screen):
+ *  - WAYLAND_DISPLAY missing → probe the runtime dir for the wayland socket
+ *  - DISPLAY/XAUTHORITY missing or stale → repair for XWayland fallback
+ *    (mutter's cookie filename changes every boot)
  */
 import { spawnSync } from 'node:child_process';
 import { existsSync, readdirSync } from 'node:fs';
@@ -22,19 +18,25 @@ const require = createRequire(import.meta.url);
 const electron = require('electron'); // resolves to the binary path
 
 const env = { ...process.env };
-if (process.platform === 'linux' && env.LOUKAI_WAYLAND !== '1') {
-  let ok = true;
-  if (!env.DISPLAY) {
-    if (existsSync('/tmp/.X11-unix/X0')) env.DISPLAY = ':0';
-    else ok = false;
+if (process.platform === 'linux') {
+  const runDir = env.XDG_RUNTIME_DIR || `/run/user/${process.getuid()}`;
+  env.XDG_RUNTIME_DIR = env.XDG_RUNTIME_DIR || runDir;
+
+  if (!env.WAYLAND_DISPLAY) {
+    try {
+      const sock = readdirSync(runDir).find((n) => /^wayland-\d+$/.test(n));
+      if (sock) env.WAYLAND_DISPLAY = sock;
+    } catch {
+      /* not a wayland session */
+    }
   }
-  if (ok && (!env.XAUTHORITY || !existsSync(env.XAUTHORITY))) {
-    // Discover mutter's current XWayland cookie (GNOME) or a classic Xauthority.
+
+  if (!env.DISPLAY && existsSync('/tmp/.X11-unix/X0')) env.DISPLAY = ':0';
+  if (env.DISPLAY && (!env.XAUTHORITY || !existsSync(env.XAUTHORITY))) {
     let cookie = null;
     try {
-      const dir = `/run/user/${process.getuid()}`;
-      const f = readdirSync(dir).find((n) => n.startsWith('.mutter-Xwaylandauth'));
-      if (f) cookie = `${dir}/${f}`;
+      const f = readdirSync(runDir).find((n) => n.startsWith('.mutter-Xwaylandauth'));
+      if (f) cookie = `${runDir}/${f}`;
     } catch {
       /* keep looking */
     }
@@ -42,11 +44,6 @@ if (process.platform === 'linux' && env.LOUKAI_WAYLAND !== '1') {
       cookie = `${env.HOME}/.Xauthority`;
     }
     if (cookie) env.XAUTHORITY = cookie;
-    else ok = false;
-  }
-  if (!ok) {
-    console.warn('[start] X11 not usable from this environment — falling back to Wayland mode');
-    env.LOUKAI_WAYLAND = '1';
   }
 }
 

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -53,48 +53,22 @@ const __dirname = dirname(__filename);
 // the actual Dawn backend (without it WebGPU is "super slow" or absent).
 // On macOS → Metal, Windows → D3D12, Linux → Vulkan, all under the hood.
 app.commandLine.appendSwitch('enable-unsafe-webgpu');
-// Linux GPU mode. X11 ozone + Vulkan is the ONLY combination where BOTH of these
-// work at the same time (verified live on Wayland-session hardware):
-//   1. Real-GPU WebGPU for the creator (Demucs/Whisper; needs the Vulkan feature —
-//      without it the adapter is SwiftShader CPU emulation, whose missing shader-f16
-//      also crashes the fp16 chained model), and
-//   2. The WebRTC browser viewer (canvas captureStream) — under Wayland ozone,
-//      Vulkan breaks capture per-frame ('Could not find or create a backing for
-//      stream kSkia') and viewers get a solid green video.
-// So X11+Vulkan is the DEFAULT. XWayland select-popup quirks are mitigated by
-// PortalSelect. LOUKAI_WAYLAND=1 is the escape hatch: native Wayland ozone with NO
-// Vulkan — the viewer works, creation falls back to WASM (SwiftShader is rejected
-// by detectWebGpu).
-// X11 must actually be REACHABLE for the x11 ozone default, or the app comes up
-// windowless ('Authorization required, but no authorization protocol specified' /
-// xcb_connection_has_error). Two real-world gaps on Wayland desktops:
-//  - DISPLAY may be unset in the launching shell -> probe the XWayland socket.
-//  - GNOME/mutter does not export XAUTHORITY to app environments; its XWayland
-//    auth cookie lives at /run/user/<uid>/.mutter-Xwaylandauth.* -> discover it.
-// If X is not usable, fall back to Wayland ozone without Vulkan (viewer works,
-// creation uses WASM) instead of launching a broken window.
-function x11Usable() {
-  // VALIDATE only — do not mutate env here: Chromium's zygotes fork before app JS
-  // runs, so children would inherit the unfixed env anyway (dead window). The dev
-  // launcher (scripts/start-electron.mjs) repairs the env BEFORE Electron spawns;
-  // desktop/session launches carry a correct env already. If this env cannot do
-  // X11, take the Wayland fallback (working window + viewer, WASM creation).
-  try {
-    if (!process.env.DISPLAY) return false;
-    if (process.env.XAUTHORITY && !fs.existsSync(process.env.XAUTHORITY)) return false;
-    return true;
-  } catch {
-    return false;
-  }
-}
-
+app.commandLine.appendSwitch('enable-features', 'Vulkan');
 if (process.platform === 'linux') {
-  if (process.env.LOUKAI_WAYLAND !== '1' && x11Usable()) {
-    app.commandLine.appendSwitch('enable-features', 'Vulkan');
-    app.commandLine.appendSwitch('ozone-platform', 'x11');
-  }
-} else {
-  app.commandLine.appendSwitch('enable-features', 'Vulkan');
+  // The window rides the session's native ozone platform (Wayland on a Wayland
+  // desktop) - forcing ozone x11 there creates NO toplevel window at all
+  // (verified with xwininfo: only the hidden clipboard helper exists; mochamix
+  // hit the same wall as 'GetGeometry failed for window 1').
+  //
+  // Vulkan must stay ON: it is what gives Dawn the real hardware adapter
+  // (without it WebGPU is SwiftShader, no shader-f16, demucs refuses to run).
+  // But Vulkan COMPOSITING breaks canvas captureStream per-frame ('Could not
+  // find or create a backing for stream kSkia' - green/empty WebRTC viewers).
+  // Software compositing sidesteps that path entirely: WebGPU compute and
+  // WebGL still run on the GPU; only final surface composition is CPU.
+  // Verified on rdna-3/Wayland: adapter amd rdna-3 + shader-f16, viewer
+  // streams real frames, zero kSkia errors.
+  app.commandLine.appendSwitch('disable-gpu-compositing');
 }
 
 class KaiPlayerApp {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -421,6 +421,17 @@ class KaiPlayerApp {
       this.canvasWindow.show();
       // Don't start streaming immediately - wait for child to signal ready
     });
+    // ready-to-show is not guaranteed on every platform/compositor combo
+    // (notably Wayland with software compositing). If it never fires the
+    // window exists invisibly and every further popout click just focuses
+    // the phantom. Force the show after a beat.
+    const showFallback = setTimeout(() => {
+      if (this.canvasWindow && !this.canvasWindow.isDestroyed() && !this.canvasWindow.isVisible()) {
+        log('canvas window: ready-to-show never fired - showing anyway');
+        this.canvasWindow.show();
+      }
+    }, 1200);
+    this.canvasWindow.once('closed', () => clearTimeout(showFallback));
 
     this.canvasWindow.on('closed', () => {
       log('🔴 Child window closed, stopping streaming and cleanup');


### PR DESCRIPTION
The forced-x11 default from #72/#74 was wrong on a Wayland desktop: **no toplevel window is ever created** (xwininfo shows only the hidden Chromium clipboard helper) while the renderer, web server, and WebRTC capture all keep running. That's the "won't fire up" that kept recurring: the app was alive and headless. mochamix documented this exact wall and I overrode it; my earlier verifications went through CDP and the web admin, which work fine without a mapped window, so I never caught it.

The full Linux matrix, measured on rdna-3 this session:

| config | window | WebGPU adapter | captureStream (viewers) |
|---|---|---|---|
| Wayland, no Vulkan | OK | SwiftShader, no f16 → demucs refuses | OK |
| Wayland + `use-vulkan` switch | OK | still SwiftShader | — |
| forced x11 + Vulkan | **never created** | real, f16 | OK (headless!) |
| Wayland + Vulkan | OK | real, f16 | broken (kSkia per frame, green) |
| Wayland + Vulkan + `disable-gpu-compositing` | OK | **real, f16** | **real frames, zero kSkia** |

So: Vulkan stays on (it's what gives Dawn the hardware adapter), the window rides the session's native ozone platform, and compositing goes to software, which takes the broken Vulkan frame-backing path out of the capture pipeline. WebGPU compute and WebGL still run on the GPU; only final surface composition is CPU. `disable-accelerated-2d-canvas` and disabling `CanvasOopRasterization` were tested and do NOT fix capture; they're not included.

Launcher updates: also repairs `WAYLAND_DISPLAY` (stale tmux shells), keeps the `XAUTHORITY` repair for XWayland fallback, drops the now-unread `LOUKAI_WAYLAND` handling. Mac/Windows flags unchanged.

Verified on the final code: adapter `amd rdna-3` with `shader-f16: true`, browser viewer streaming lyrics + Butterchurn (screenshot-pixel verified), zero kSkia errors, zero X auth errors.