### PR TITLE
Refresh the Electron Library tab after a song is created

### DIFF
--- a/src/shared/services/libraryService.js
+++ b/src/shared/services/libraryService.js
@@ -498,6 +498,12 @@ export async function updateLibraryCache(mainApp, files) {
       }
     }
 
+    // Notify the Electron renderer too - its LibraryPanel keeps a local copy
+    // and only reloads on this event. Without it, a song created via
+    // host-create or the creator panel is searchable in the web admin but
+    // invisible in the app's Library tab until a manual sync.
+    mainApp.sendToRenderer?.('library:scanComplete', { count: files.length });
+
     // Save to disk cache (Electron only)
     if (mainApp.settings?.getSongsFolder) {
       const path = await import('path');


### PR DESCRIPTION
After a create, `syncLibrary` runs and the **web admin** learns about it (socket `library-refreshed` + search index reset), but the **Electron renderer** never does. Its LibraryPanel keeps a local copy of the library and only reloads on the `library:scanComplete` IPC event, which manual sync and background scans emit, but `updateLibraryCache` did not. Result: a freshly created song is instantly searchable in the web admin while the app's Library tab can't see it until a manual sync. No manual sync or index rebuild should ever be needed after a create.

`updateLibraryCache` now also sends `library:scanComplete` to the renderer, which covers host-create, the creator panel save, offsite imports, and web-admin syncs in one place.

Verified live on this branch: searched "fixverify" in the Electron Library tab (no results), ran a host-create titled "FixVerify Song" from the web admin, searched again with no manual sync: found. Also confirmed the web-admin path was already fine (`/admin/library/search` returns a new song immediately after create completes).

Main-process change only; no renderer rebuild needed.
