### PR TITLE
v0.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ npm run build:mac
 npm start
 ```
 
+Notes:
+
+- On Linux, `npm start` / `npm run dev` launch through `scripts/start-electron.mjs`, which repairs stale display env vars (`WAYLAND_DISPLAY`, `DISPLAY`, `XAUTHORITY`) before Electron spawns — so launching from long-lived tmux/screen shells just works.
+- Only one instance runs at a time; a second launch focuses the existing window and exits.
+- Song creation (stem separation) requires a working WebGPU adapter (a real GPU). There is no CPU fallback.
+
 ---
 
 ## Architecture

--- a/com.loukai.app.metainfo.xml
+++ b/com.loukai.app.metainfo.xml
@@ -48,6 +48,19 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="0.7.2" date="2026-07-18">
+      <description>
+        <p>Rock-solid Linux launch and a smarter creator</p>
+        <ul>
+          <li>Linux: the app now runs on native Wayland with GPU creation AND casting to phones/browser viewers working at the same time</li>
+          <li>Launching from a terminal always brings up the window; a second launch focuses the running app instead of failing</li>
+          <li>Better default lyrics model (Whisper large-v3-turbo, multilingual with language auto-detect)</li>
+          <li>Stem separation runs on the GPU or fails fast with a clear message - no more silent hour-long CPU runs</li>
+          <li>Newly created songs appear in the app library instantly - no manual sync</li>
+          <li>Queue Load works for .stem.mp4 files; editor timestamp fields no longer eat keystrokes</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.7.0" date="2026-07-17">
       <description>
         <p>WebGPU creator everywhere, AIFF support, and a fully pure-JS runtime</p>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,7 +162,7 @@ Two distinct React SPAs served by the Express server:
 
 ### 4. Creator Pipeline
 
-Song creation runs **entirely in-browser** (renderer or web page) on WebGPU via onnxruntime-web, with WASM fallback — no Python, native modules, or system ffmpeg. Main-process code only proxies/caches assets, tracks job status, and muxes/saves output. A web-admin "host-create" path lets a phone upload audio to `POST /admin/creator/host-create`; the desktop player's renderer then runs the GPU creation (see `hostCreateRelay.js`).
+Song creation runs **entirely in-browser** (renderer or web page) on WebGPU via onnxruntime-web — no Python, native modules, or system ffmpeg. Stem separation REQUIRES a real WebGPU adapter (no WASM fallback: a broken GPU environment fails fast with a clear error instead of grinding the CPU for an hour). Whisper may still use the wasm EP for lyrics-only and stem-reuse runs. Main-process code only proxies/caches assets, tracks job status, and muxes/saves output. A web-admin "host-create" path lets a phone upload audio to `POST /admin/creator/host-create`; the desktop player's renderer then runs the GPU creation (see `hostCreateRelay.js`).
 
 ```mermaid
 graph LR
@@ -507,13 +507,23 @@ Channels organized by domain:
 - **Butterchurn 2** - Visualizations
 - **Canvas API** - Graphics rendering
 
-### AI/ML (Creator) — 100% in-browser, WebGPU with WASM fallback
-- **Demucs** - Stem separation (htdemucs ONNX via onnxruntime-web; optional htdemucs_ft ensemble)
-- **Whisper** - Speech-to-text (@huggingface/transformers, timestamped ONNX models)
+### AI/ML (Creator) — 100% in-browser on WebGPU
+- **Demucs** - Stem separation (htdemucs ONNX via onnxruntime-web; optional htdemucs_ft ensemble). WebGPU-only: no CPU/WASM fallback
+- **Whisper** - Speech-to-text (@huggingface/transformers, timestamped ONNX models; default `whisper-large-v3-turbo_timestamped`, multilingual with auto-detect)
 - **CREPE** - Pitch/key detection (crepe_tiny.onnx bundled in static/webgpu)
 - **AAC encode** - ffmpeg-wasm (@ffmpeg/core single-thread, in a web worker)
 - **aubiojs** - Realtime pitch tracking
 - **OpenAI/Anthropic/Google** - LLM lyrics correction
+
+### Linux graphics configuration
+
+Chromium flags on Linux (`src/main/main.js`) are the product of a measured matrix on Wayland/RDNA3 and each one is load-bearing:
+
+- **Native ozone platform** (Wayland on a Wayland desktop). Forcing `ozone-platform=x11` creates NO toplevel window at all while the renderer and web server keep running — the app looks dead but serves the admin.
+- **`enable-features=Vulkan`** gives Dawn the real hardware WebGPU adapter (`shader-f16` for the fp16 demucs chain). Without it the adapter is SwiftShader and separation refuses to run.
+- **`disable-gpu-compositing`** because Vulkan compositing breaks `canvas.captureStream()` per-frame (kSkia backing errors → green/empty WebRTC viewers). WebGPU compute and WebGL still run on the GPU; only final surface composition is CPU.
+
+`npm start` / `npm run dev` go through `scripts/start-electron.mjs`, which repairs `WAYLAND_DISPLAY` / `DISPLAY` / `XAUTHORITY` before Electron spawns (Chromium zygotes fork before app JS runs, so main.js cannot fix a stale tmux environment). The app holds a single-instance lock: a second launch focuses the running window and exits.
 
 ### Build & Distribution
 - **electron-builder 26** - Packaging

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loukai-app",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loukai-app",
-      "version": "0.7.0",
+      "version": "0.7.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loukai-app",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "type": "module",
   "description": "Loukai Karaoke - Free and open source karaoke system for playing and creating stem-based karaoke files",
   "main": "src/main/main.js",


### PR DESCRIPTION
Release prep for v0.7.2. Everything since v0.7.1 is already on main (#70, #72-#81); this PR is docs + version bump only.

- **README**: production notes — launcher env repair on Linux, single-instance behavior, WebGPU requirement for creation
- **docs/architecture.md**: new "Linux graphics configuration" section documenting the measured flag matrix (native Wayland ozone, Vulkan for the Dawn adapter, `disable-gpu-compositing` for captureStream) so nobody re-litigates these flags without the history; creator section updated for WebGPU-only separation and the turbo-v3 whisper default
- **metainfo**: 0.7.2 release notes (user-facing)
- **version**: 0.7.0 → 0.7.2 in package.json + lock (the 0.7.1 bump never landed on main)

After merge: tag `v0.7.2` on main to fire the Build and Release workflow, publish when the artifacts look good.
