### PR TITLE
Remove the dead .kai format

### DIFF
--- a/src/main/handlers/editorHandlers.js
+++ b/src/main/handlers/editorHandlers.js
@@ -13,7 +13,7 @@ import { STEM_MP4_FORMAT } from '../../shared/formatUtils.js';
  */
 export function registerEditorHandlers(mainApp) {
   // Load song file for editing (KAI or M4A)
-  ipcMain.handle('editor:loadKai', async (event, filePath) => {
+  ipcMain.handle('editor:load', async (event, filePath) => {
     try {
       log('Load song file for editing:', filePath);
 
@@ -37,27 +37,22 @@ export function registerEditorHandlers(mainApp) {
   });
 
   // Save song file (KAI or M4A)
-  ipcMain.handle('editor:saveKai', async (event, kaiData, originalPath) => {
+  ipcMain.handle('editor:save', async (event, songData, originalPath) => {
     try {
       log('Save song file request:', originalPath);
-      log('Updated lyrics:', kaiData.lyrics?.length || 0, 'lines');
+      log('Updated lyrics:', songData.lyrics?.length || 0, 'lines');
 
-      // Determine format from file extension
       const lowerPath = originalPath.toLowerCase();
-      let format;
-      if (lowerPath.endsWith('.kai')) {
-        format = 'kai';
-      } else if (lowerPath.endsWith('.m4a') || lowerPath.endsWith('.mp4')) {
-        format = STEM_MP4_FORMAT;
-      } else {
+      if (!lowerPath.endsWith('.m4a') && !lowerPath.endsWith('.mp4')) {
         throw new Error('Unsupported file format');
       }
+      const format = STEM_MP4_FORMAT;
 
       const editorService = await import('../../shared/services/editorService.js');
       const _result = await editorService.saveSong(originalPath, {
         format: format,
-        metadata: kaiData.song || kaiData.metadata || {},
-        lyrics: kaiData.lyrics,
+        metadata: songData.song || songData.metadata || {},
+        lyrics: songData.lyrics,
       });
 
       log(`${format.toUpperCase()} file saved successfully`);
@@ -68,22 +63,16 @@ export function registerEditorHandlers(mainApp) {
     }
   });
 
-  // Reload song file in player (KAI or M4A)
-  ipcMain.handle('editor:reloadKai', async (event, filePath) => {
+  // Reload song file in player
+  ipcMain.handle('editor:reload', async (event, filePath) => {
     try {
       log('Reload song file request:', filePath);
 
-      // Determine format and call appropriate loader
       const lowerPath = filePath.toLowerCase();
-      let result;
-
-      if (lowerPath.endsWith('.kai')) {
-        result = await mainApp.loadKaiFile(filePath);
-      } else if (lowerPath.endsWith('.m4a') || lowerPath.endsWith('.mp4')) {
-        result = await mainApp.loadM4AFile(filePath);
-      } else {
+      if (!lowerPath.endsWith('.m4a') && !lowerPath.endsWith('.mp4')) {
         throw new Error('Unsupported file format');
       }
+      const result = await mainApp.loadM4AFile(filePath);
 
       if (result && result.success) {
         log('Song file reloaded successfully');

--- a/src/main/handlers/fileHandlers.js
+++ b/src/main/handlers/fileHandlers.js
@@ -11,25 +11,21 @@ import { validateSongPath } from '../utils/pathValidator.js';
  * @param {Object} mainApp - Main application instance
  */
 export function registerFileHandlers(mainApp) {
-  // Open file dialog to select karaoke file (Stem MP4 or KAI)
-  ipcMain.handle('file:openKai', async () => {
+  // Open file dialog to select a karaoke file
+  ipcMain.handle('file:openSong', async () => {
     const result = await dialog.showOpenDialog(mainApp.mainWindow, {
-      filters: [
-        { name: 'Karaoke Files', extensions: ['mp4', 'm4a', 'kai'] },
-        { name: 'Stem MP4 (recommended)', extensions: ['mp4', 'm4a'] },
-        { name: 'KAI Files (legacy)', extensions: ['kai'] },
-      ],
+      filters: [{ name: 'Stem MP4', extensions: ['mp4', 'm4a'] }],
       properties: ['openFile'],
     });
 
     if (!result.canceled && result.filePaths.length > 0) {
-      return await mainApp.loadKaiFile(result.filePaths[0]);
+      return await mainApp.loadSongFile(result.filePaths[0]);
     }
     return null;
   });
 
-  // Load KAI file from path (with path traversal protection)
-  ipcMain.handle('file:loadKaiFromPath', async (event, filePath) => {
+  // Load a song file from path (with path traversal protection)
+  ipcMain.handle('file:loadSongFromPath', async (event, filePath) => {
     // Get the songs folder from settings
     const songsFolder = mainApp.settings?.getSongsFolder?.();
 
@@ -40,6 +36,6 @@ export function registerFileHandlers(mainApp) {
       return { error: validation.error };
     }
 
-    return await mainApp.loadKaiFile(validation.resolvedPath);
+    return await mainApp.loadSongFile(validation.resolvedPath);
   });
 }

--- a/src/main/handlers/queueHandlers.js
+++ b/src/main/handlers/queueHandlers.js
@@ -25,7 +25,7 @@ export function registerQueueHandlers(mainApp) {
       log(`🎵 Queue was empty, auto-loading "${result.queueItem.title}"`);
       try {
         // Use the returned queueItem which has the generated ID
-        await mainApp.loadKaiFile(result.queueItem.path, result.queueItem.id);
+        await mainApp.loadSongFile(result.queueItem.path, result.queueItem.id);
         log('✅ Successfully auto-loaded song from queue');
       } catch (error) {
         console.error('❌ Failed to auto-load song from queue:', error);

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -628,16 +628,18 @@ class KaiPlayerApp {
         label: 'File',
         submenu: [
           {
-            label: 'Open KAI File...',
+            label: 'Open Song File...',
             accelerator: 'CmdOrCtrl+O',
             click: async () => {
               const result = await dialog.showOpenDialog(this.mainWindow, {
-                filters: [{ name: 'KAI Files', extensions: ['kai'] }],
+                filters: [
+                  { name: 'Karaoke Files', extensions: ['mp4', 'm4a', 'mp3', 'kar', 'zip'] },
+                ],
                 properties: ['openFile'],
               });
 
               if (!result.canceled && result.filePaths.length > 0) {
-                await this.loadKaiFile(result.filePaths[0]);
+                await this.loadSongFile(result.filePaths[0]);
               }
             },
           },
@@ -1262,7 +1264,7 @@ class KaiPlayerApp {
     return metadata;
   }
 
-  async loadKaiFile(filePath, queueItemId = null) {
+  async loadSongFile(filePath, queueItemId = null) {
     // Detect format and load accordingly
     const format = await this.detectSongFormat(filePath);
 
@@ -1324,7 +1326,7 @@ class KaiPlayerApp {
 
       const cdgData = await CDGLoader.load(mp3Path, cdgPath, format);
 
-      // TODO: Load CDG into audio engine (different path than KAI)
+      // TODO: Load CDG into audio engine (different path than stem-mp4)
       // For now, just set current song and notify renderer
       // Add requester to cdgData so it's available in renderer
       cdgData.requester = requester;
@@ -1502,7 +1504,7 @@ class KaiPlayerApp {
 
       // First, quickly count all files
       log('📊 Counting files...');
-      const allFiles = await this.findAllKaiFiles(songsFolder);
+      const allFiles = await this.findAllSongFiles(songsFolder);
       const totalFiles = allFiles.length;
       log(`📊 Found ${totalFiles} files to process`);
 
@@ -1707,7 +1709,7 @@ class KaiPlayerApp {
     return files;
   }
 
-  async findAllKaiFiles(folderPath) {
+  async findAllSongFiles(folderPath) {
     const allFiles = [];
     const processedPairs = new Set();
 
@@ -2267,7 +2269,7 @@ class KaiPlayerApp {
       log(`🎵 Queue was empty, auto-loading "${result.queueItem.title}"`);
       try {
         // Use the returned queueItem which has the generated ID
-        await this.loadKaiFile(result.queueItem.path, result.queueItem.id);
+        await this.loadSongFile(result.queueItem.path, result.queueItem.id);
         log('✅ Successfully auto-loaded song from queue');
       } catch (error) {
         console.error('❌ Failed to auto-load song from queue:', error);

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -7,8 +7,8 @@ const api = {
   },
 
   file: {
-    openKai: () => ipcRenderer.invoke('file:openKai'),
-    loadKaiFromPath: (filePath) => ipcRenderer.invoke('file:loadKaiFromPath', filePath),
+    openSong: () => ipcRenderer.invoke('file:openSong'),
+    loadSongFromPath: (filePath) => ipcRenderer.invoke('file:loadSongFromPath', filePath),
   },
 
   audio: {
@@ -75,9 +75,9 @@ const api = {
   },
 
   editor: {
-    loadKai: (filePath) => ipcRenderer.invoke('editor:loadKai', filePath),
-    saveKai: (kaiData, originalPath) => ipcRenderer.invoke('editor:saveKai', kaiData, originalPath),
-    reloadKai: (filePath) => ipcRenderer.invoke('editor:reloadKai', filePath),
+    load: (filePath) => ipcRenderer.invoke('editor:load', filePath),
+    save: (songData, originalPath) => ipcRenderer.invoke('editor:save', songData, originalPath),
+    reload: (filePath) => ipcRenderer.invoke('editor:reload', filePath),
   },
 
   window: {

--- a/src/main/webServer.js
+++ b/src/main/webServer.js
@@ -1122,30 +1122,7 @@ class WebServer {
         const editorService = await import('../shared/services/editorService.js');
         const result = await editorService.loadSong(validatedPath);
 
-        // For KAI files, add download URLs for audio playback
-        if (result.format === 'kai') {
-          const audioFiles = result.kaiData.audio.sources.map((source) => {
-            const filename = source.filename || source.name;
-            const fileId = Buffer.from(`${validatedPath}:${filename}`).toString('base64url');
-
-            return {
-              name: source.name,
-              filename: filename,
-              downloadUrl: `/admin/editor/kai-audio/${fileId}`,
-            };
-          });
-
-          res.json({
-            success: true,
-            data: {
-              format: 'kai',
-              metadata: result.kaiData.metadata || {},
-              lyrics: result.kaiData.lyrics || [],
-              audioFiles: audioFiles,
-              songJson: result.kaiData.originalSongJson || {},
-            },
-          });
-        } else if (isStemMp4Format(result.format)) {
+        if (isStemMp4Format(result.format)) {
           // For Stem MP4 files, add download URLs for extracted audio tracks
           const audioFiles = result.kaiData.audio.sources.map((source) => {
             const trackName = source.name;

--- a/src/renderer/adapters/ElectronBridge.js
+++ b/src/renderer/adapters/ElectronBridge.js
@@ -306,14 +306,14 @@ export class ElectronBridge extends BridgeInterface {
   }
 
   async loadSong(path) {
-    return await this.api.file.loadKaiFromPath(path);
+    return await this.api.file.loadSongFromPath(path);
   }
 
   // ===== Song Editor =====
 
   async loadSongForEditing(path) {
-    // Load the KAI file for editing (using editor.loadKai which doesn't affect playback)
-    const result = await this.api.editor.loadKai(path);
+    // Load the song for editing (editor.load doesn't affect playback)
+    const result = await this.api.editor.load(path);
     if (!result.success) {
       return { success: false, error: result.error };
     }
@@ -339,7 +339,7 @@ export class ElectronBridge extends BridgeInterface {
     return {
       success: true,
       data: {
-        format: 'kai',
+        format: 'stem-mp4',
         metadata: songData.metadata || {},
         lyrics: songData.lyrics || [],
         audioFiles: audioFiles,
@@ -351,8 +351,8 @@ export class ElectronBridge extends BridgeInterface {
   async saveSongEdits(updates) {
     const { path, metadata, lyrics, format } = updates;
 
-    if (format === 'kai') {
-      // Build the song object for KaiWriter
+    if (format === 'stem-mp4') {
+      // Build the song object for the editor save
       const songData = {
         song: {
           title: metadata.title,
@@ -393,7 +393,7 @@ export class ElectronBridge extends BridgeInterface {
         }
       }
 
-      const result = await this.api.editor.saveKai(songData, path);
+      const result = await this.api.editor.save(songData, path);
       return result;
     }
 

--- a/src/renderer/js/karaokeRenderer.js
+++ b/src/renderer/js/karaokeRenderer.js
@@ -2862,11 +2862,7 @@ export class KaraokeRenderer {
     ctx.save();
 
     // Get song info from various possible locations
-    const title =
-      songData.title ||
-      songData.metadata?.title ||
-      songData.name?.replace('.kai', '') ||
-      'Unknown Title';
+    const title = songData.title || songData.metadata?.title || songData.name || 'Unknown Title';
     const artist = songData.artist || songData.metadata?.artist || 'Unknown Artist';
     const requester = songData.requester;
 

--- a/src/shared/components/QuickSearch.jsx
+++ b/src/shared/components/QuickSearch.jsx
@@ -39,7 +39,7 @@ export function QuickSearch({ bridge, requester = 'KJ' }) {
   const handleAddFromSearch = async (song) => {
     const queueItem = {
       path: song.path,
-      title: song.title || song.name.replace('.kai', ''),
+      title: song.title || song.name,
       artist: song.artist || 'Unknown Artist',
       duration: song.duration,
       requester: requester,

--- a/src/shared/components/SongEditor.jsx
+++ b/src/shared/components/SongEditor.jsx
@@ -375,7 +375,7 @@ export function SongEditor({ bridge }) {
         });
 
         // Populate lyrics if KAI or M4A file - server sends actual array with timing
-        const hasLyrics = result.data.format === 'kai' || isStemMp4Format(result.data.format);
+        const hasLyrics = isStemMp4Format(result.data.format);
         if (hasLyrics) {
           const lyrics = result.data.lyrics || [];
           // Sort lyrics by start time to ensure proper order
@@ -811,7 +811,7 @@ export function SongEditor({ bridge }) {
           suggestions,
         },
         // Include lyrics for both KAI and Stem MP4 formats
-        ...((songData.format === 'kai' || isStemMp4Format(songData.format)) && {
+        ...(isStemMp4Format(songData.format) && {
           lyrics: sortedLyrics,
         }),
       };
@@ -1097,7 +1097,7 @@ export function SongEditor({ bridge }) {
           </div>
 
           {/* Tab navigation for KAI and Stem MP4 files */}
-          {(songData.format === 'kai' || isStemMp4Format(songData.format)) && (
+          {isStemMp4Format(songData.format) && (
             <div className="flex gap-1 border-b-2 border-gray-200 dark:border-gray-700 pb-0">
               <button
                 className={`px-6 py-3 bg-transparent border-none border-b-[3px] font-semibold text-[15px] cursor-pointer transition-all -mb-0.5 ${activeTab === 'lyrics' ? 'text-blue-600 border-b-blue-600' : 'text-gray-600 dark:text-gray-400 border-b-transparent hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-700'}`}
@@ -1191,188 +1191,187 @@ export function SongEditor({ bridge }) {
           )}
 
           {/* Lyrics editor for KAI and Stem MP4 files */}
-          {(songData.format === 'kai' || isStemMp4Format(songData.format)) &&
-            activeTab === 'lyrics' && (
-              <>
-                {/* Waveform canvas */}
-                <LyricsEditorCanvas
-                  lyricsData={lyricsData}
-                  selectedLineIndex={selectedLineIndex}
-                  onLineSelect={setSelectedLineIndex}
-                  vocalsWaveform={vocalsWaveform}
-                  songDuration={songDuration}
-                  currentPosition={currentPosition}
-                  isPlaying={isPlaying}
-                />
+          {isStemMp4Format(songData.format) && activeTab === 'lyrics' && (
+            <>
+              {/* Waveform canvas */}
+              <LyricsEditorCanvas
+                lyricsData={lyricsData}
+                selectedLineIndex={selectedLineIndex}
+                onLineSelect={setSelectedLineIndex}
+                vocalsWaveform={vocalsWaveform}
+                songDuration={songDuration}
+                currentPosition={currentPosition}
+                isPlaying={isPlaying}
+              />
 
-                {/* Line detail canvas - zoomed view of selected line */}
-                <LineDetailCanvas
-                  selectedLine={selectedLineIndex !== null ? lyricsData[selectedLineIndex] : null}
-                  vocalsWaveform={vocalsWaveform}
-                  songDuration={songDuration}
-                  currentPosition={currentPosition}
-                  isPlaying={isPlaying}
-                />
+              {/* Line detail canvas - zoomed view of selected line */}
+              <LineDetailCanvas
+                selectedLine={selectedLineIndex !== null ? lyricsData[selectedLineIndex] : null}
+                vocalsWaveform={vocalsWaveform}
+                songDuration={songDuration}
+                currentPosition={currentPosition}
+                isPlaying={isPlaying}
+              />
 
-                {/* Audio playback controls */}
-                {audioElements.length > 0 && (
-                  <div className="flex items-center gap-2 px-2 py-1.5 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded flex-shrink-0">
-                    <button
-                      onClick={togglePlayback}
-                      className="flex items-center gap-1.5 px-3 py-1 bg-blue-600 border-blue-600 rounded text-white cursor-pointer text-xs transition-colors hover:bg-blue-700"
-                    >
-                      <span className="material-icons text-base">
-                        {isPlaying ? 'pause' : 'play_arrow'}
-                      </span>
-                      {isPlaying ? 'Pause' : 'Play'}
-                    </button>
-                    {/* Elapsed time (issue #67 request): tenths so lyric timing can be
-                        checked against the start/end numbers while playing. */}
-                    <span
-                      className="font-mono text-xs text-gray-900 dark:text-white tabular-nums px-1.5 whitespace-nowrap"
-                      title={`${currentPosition.toFixed(2)}s`}
-                    >
-                      {formatEditorTime(currentPosition)}
-                      <span className="text-gray-500 dark:text-gray-400">
-                        {' / '}
-                        {formatEditorTime(songDuration)}
-                      </span>
+              {/* Audio playback controls */}
+              {audioElements.length > 0 && (
+                <div className="flex items-center gap-2 px-2 py-1.5 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded flex-shrink-0">
+                  <button
+                    onClick={togglePlayback}
+                    className="flex items-center gap-1.5 px-3 py-1 bg-blue-600 border-blue-600 rounded text-white cursor-pointer text-xs transition-colors hover:bg-blue-700"
+                  >
+                    <span className="material-icons text-base">
+                      {isPlaying ? 'pause' : 'play_arrow'}
                     </span>
-                    <div className="flex gap-1.5 flex-wrap flex-1 items-center">
-                      {audioElements.map((el, index) => (
-                        <div
-                          key={index}
-                          className="flex items-center gap-1 px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded"
+                    {isPlaying ? 'Pause' : 'Play'}
+                  </button>
+                  {/* Elapsed time (issue #67 request): tenths so lyric timing can be
+                        checked against the start/end numbers while playing. */}
+                  <span
+                    className="font-mono text-xs text-gray-900 dark:text-white tabular-nums px-1.5 whitespace-nowrap"
+                    title={`${currentPosition.toFixed(2)}s`}
+                  >
+                    {formatEditorTime(currentPosition)}
+                    <span className="text-gray-500 dark:text-gray-400">
+                      {' / '}
+                      {formatEditorTime(songDuration)}
+                    </span>
+                  </span>
+                  <div className="flex gap-1.5 flex-wrap flex-1 items-center">
+                    {audioElements.map((el, index) => (
+                      <div
+                        key={index}
+                        className="flex items-center gap-1 px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded"
+                      >
+                        <span className="text-[11px] font-semibold text-gray-900 dark:text-white min-w-[45px]">
+                          {el.name}
+                        </span>
+                        <button
+                          onClick={() => toggleMute(index)}
+                          className={`flex items-center justify-center w-6 h-6 p-0.5 rounded cursor-pointer transition-colors ${el.muted ? 'bg-red-600 text-white hover:bg-red-700' : 'bg-green-600 text-white hover:bg-green-700'}`}
+                          title={el.muted ? 'Unmute' : 'Mute'}
                         >
-                          <span className="text-[11px] font-semibold text-gray-900 dark:text-white min-w-[45px]">
-                            {el.name}
+                          <span className="material-icons text-sm">
+                            {el.muted ? 'volume_off' : 'volume_up'}
                           </span>
-                          <button
-                            onClick={() => toggleMute(index)}
-                            className={`flex items-center justify-center w-6 h-6 p-0.5 rounded cursor-pointer transition-colors ${el.muted ? 'bg-red-600 text-white hover:bg-red-700' : 'bg-green-600 text-white hover:bg-green-700'}`}
-                            title={el.muted ? 'Unmute' : 'Mute'}
-                          >
-                            <span className="material-icons text-sm">
-                              {el.muted ? 'volume_off' : 'volume_up'}
-                            </span>
-                          </button>
-                        </div>
-                      ))}
-                    </div>
-                    <button
-                      onClick={handleExportLyrics}
-                      className="flex items-center gap-1.5 px-3 py-1 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white cursor-pointer text-xs transition-colors hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
-                      disabled={!lyricsData || lyricsData.length === 0}
-                      title="Export lyrics as text file"
-                    >
-                      <span className="material-icons text-base">download</span>
-                      Export
-                    </button>
-                    <button
-                      onClick={handleResetLyrics}
-                      className="flex items-center gap-1.5 px-3 py-1 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white cursor-pointer text-xs transition-colors hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
-                      disabled={!hasChanges}
-                      title="Reset to original lyrics"
-                    >
-                      <span className="material-icons text-base">restore</span>
-                      Reset
-                    </button>
-                    <button
-                      onClick={handleAddLineAtStart}
-                      className="flex items-center gap-1.5 px-3 py-1 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white cursor-pointer text-xs transition-colors hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
-                      disabled={!canAddLineAtStart()}
-                      title={
-                        canAddLineAtStart()
-                          ? 'Add line at beginning'
-                          : 'Not enough space (need 0.6s gap)'
-                      }
-                    >
-                      <span className="material-icons text-base">add</span>
-                      Add First Line
-                    </button>
-                  </div>
-                )}
-
-                {/* Scrollable container for lyrics and corrections */}
-                <div className="flex-1 overflow-y-auto overflow-x-hidden min-h-0">
-                  {/* Lyrics lines */}
-                  <div className="flex flex-col gap-0 p-3 overflow-y-auto flex-1">
-                    {lyricsData && lyricsData.length > 0 ? (
-                      lyricsData.map((line, index) => (
-                        <LyricLine
-                          key={`lyric-${index}`}
-                          line={line}
-                          index={index}
-                          isSelected={selectedLineIndex === index}
-                          onSelect={setSelectedLineIndex}
-                          onUpdate={handleLineUpdate}
-                          onDelete={handleLineDelete}
-                          onAddAfter={handleAddLineAfter}
-                          onSplit={handleLineSplit}
-                          onPlaySection={handlePlayLineSection}
-                          onAdjustStartTime={(delta) => {
-                            setSelectedLineIndex(index);
-                            const currentStart = line.start || line.startTimeSec || 0;
-                            const newStart = Math.max(0, currentStart + delta);
-                            handleLineUpdate(index, {
-                              ...line,
-                              start: newStart,
-                              startTimeSec: newStart,
-                            });
-                          }}
-                          onAdjustEndTime={(delta) => {
-                            setSelectedLineIndex(index);
-                            const currentEnd = line.end || line.endTimeSec || 0;
-                            const newEnd = Math.max(0, currentEnd + delta);
-                            handleLineUpdate(index, {
-                              ...line,
-                              end: newEnd,
-                              endTimeSec: newEnd,
-                            });
-                          }}
-                          canAddAfter={canAddLineAfter(index)}
-                          canSplit={canSplit(index)}
-                          hasOverlap={checkOverlap(index)}
-                        />
-                      ))
-                    ) : (
-                      <div className="text-center p-10 text-gray-500 dark:text-gray-400 text-base">
-                        No lyrics available. Load a KAI file with lyrics to edit.
+                        </button>
                       </div>
-                    )}
+                    ))}
                   </div>
+                  <button
+                    onClick={handleExportLyrics}
+                    className="flex items-center gap-1.5 px-3 py-1 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white cursor-pointer text-xs transition-colors hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                    disabled={!lyricsData || lyricsData.length === 0}
+                    title="Export lyrics as text file"
+                  >
+                    <span className="material-icons text-base">download</span>
+                    Export
+                  </button>
+                  <button
+                    onClick={handleResetLyrics}
+                    className="flex items-center gap-1.5 px-3 py-1 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white cursor-pointer text-xs transition-colors hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                    disabled={!hasChanges}
+                    title="Reset to original lyrics"
+                  >
+                    <span className="material-icons text-base">restore</span>
+                    Reset
+                  </button>
+                  <button
+                    onClick={handleAddLineAtStart}
+                    className="flex items-center gap-1.5 px-3 py-1 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white cursor-pointer text-xs transition-colors hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                    disabled={!canAddLineAtStart()}
+                    title={
+                      canAddLineAtStart()
+                        ? 'Add line at beginning'
+                        : 'Not enough space (need 0.6s gap)'
+                    }
+                  >
+                    <span className="material-icons text-base">add</span>
+                    Add First Line
+                  </button>
+                </div>
+              )}
 
-                  {/* AI Corrections Section */}
-                  {(rejections.length > 0 || suggestions.length > 0) && (
-                    <div className="mb-6 p-4 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md">
-                      <h3 className="text-base font-semibold m-0 mb-4 text-gray-900 dark:text-white">
-                        AI Corrections & Suggestions
-                      </h3>
-
-                      {rejections.map((rejection, rejectionIndex) => (
-                        <LyricRejection
-                          key={`rejection-${rejectionIndex}`}
-                          rejection={rejection}
-                          rejectionIndex={rejectionIndex}
-                          onAccept={handleAcceptRejection}
-                          onDelete={handleDeleteRejection}
-                        />
-                      ))}
-
-                      {suggestions.map((suggestion, suggestionIndex) => (
-                        <LyricSuggestion
-                          key={`suggestion-${suggestionIndex}`}
-                          suggestion={suggestion}
-                          suggestionIndex={suggestionIndex}
-                          onAccept={handleAcceptSuggestion}
-                          onDelete={handleDeleteSuggestion}
-                        />
-                      ))}
+              {/* Scrollable container for lyrics and corrections */}
+              <div className="flex-1 overflow-y-auto overflow-x-hidden min-h-0">
+                {/* Lyrics lines */}
+                <div className="flex flex-col gap-0 p-3 overflow-y-auto flex-1">
+                  {lyricsData && lyricsData.length > 0 ? (
+                    lyricsData.map((line, index) => (
+                      <LyricLine
+                        key={`lyric-${index}`}
+                        line={line}
+                        index={index}
+                        isSelected={selectedLineIndex === index}
+                        onSelect={setSelectedLineIndex}
+                        onUpdate={handleLineUpdate}
+                        onDelete={handleLineDelete}
+                        onAddAfter={handleAddLineAfter}
+                        onSplit={handleLineSplit}
+                        onPlaySection={handlePlayLineSection}
+                        onAdjustStartTime={(delta) => {
+                          setSelectedLineIndex(index);
+                          const currentStart = line.start || line.startTimeSec || 0;
+                          const newStart = Math.max(0, currentStart + delta);
+                          handleLineUpdate(index, {
+                            ...line,
+                            start: newStart,
+                            startTimeSec: newStart,
+                          });
+                        }}
+                        onAdjustEndTime={(delta) => {
+                          setSelectedLineIndex(index);
+                          const currentEnd = line.end || line.endTimeSec || 0;
+                          const newEnd = Math.max(0, currentEnd + delta);
+                          handleLineUpdate(index, {
+                            ...line,
+                            end: newEnd,
+                            endTimeSec: newEnd,
+                          });
+                        }}
+                        canAddAfter={canAddLineAfter(index)}
+                        canSplit={canSplit(index)}
+                        hasOverlap={checkOverlap(index)}
+                      />
+                    ))
+                  ) : (
+                    <div className="text-center p-10 text-gray-500 dark:text-gray-400 text-base">
+                      No lyrics available. Load a KAI file with lyrics to edit.
                     </div>
                   )}
                 </div>
-              </>
-            )}
+
+                {/* AI Corrections Section */}
+                {(rejections.length > 0 || suggestions.length > 0) && (
+                  <div className="mb-6 p-4 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md">
+                    <h3 className="text-base font-semibold m-0 mb-4 text-gray-900 dark:text-white">
+                      AI Corrections & Suggestions
+                    </h3>
+
+                    {rejections.map((rejection, rejectionIndex) => (
+                      <LyricRejection
+                        key={`rejection-${rejectionIndex}`}
+                        rejection={rejection}
+                        rejectionIndex={rejectionIndex}
+                        onAccept={handleAcceptRejection}
+                        onDelete={handleDeleteRejection}
+                      />
+                    ))}
+
+                    {suggestions.map((suggestion, suggestionIndex) => (
+                      <LyricSuggestion
+                        key={`suggestion-${suggestionIndex}`}
+                        suggestion={suggestion}
+                        suggestionIndex={suggestionIndex}
+                        onAccept={handleAcceptSuggestion}
+                        onDelete={handleDeleteSuggestion}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            </>
+          )}
         </div>
       )}
 

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -9,8 +9,8 @@ export const IPC_CHANNELS = {
   APP_GET_STATE: 'app:getState',
 
   // File
-  FILE_OPEN_KAI: 'file:openKai',
-  FILE_LOAD_KAI_FROM_PATH: 'file:loadKaiFromPath',
+  FILE_OPEN_SONG: 'file:openSong',
+  FILE_LOAD_SONG_FROM_PATH: 'file:loadSongFromPath',
 
   // Audio
   AUDIO_GET_DEVICES: 'audio:getDevices',
@@ -27,8 +27,8 @@ export const IPC_CHANNELS = {
   PLAYER_SEEK: 'player:seek',
 
   // Editor
-  EDITOR_SAVE_KAI: 'editor:saveKai',
-  EDITOR_RELOAD_KAI: 'editor:reloadKai',
+  EDITOR_SAVE: 'editor:save',
+  EDITOR_RELOAD: 'editor:reload',
 
   // Settings
   SETTINGS_GET: 'settings:get',

--- a/src/shared/ipcContracts.js
+++ b/src/shared/ipcContracts.js
@@ -26,8 +26,8 @@ export const APP_CHANNELS = {
 // ============================================================================
 
 export const FILE_CHANNELS = {
-  OPEN_KAI: 'file:openKai',
-  LOAD_KAI_FROM_PATH: 'file:loadKaiFromPath',
+  OPEN_SONG: 'file:openSong',
+  LOAD_SONG_FROM_PATH: 'file:loadSongFromPath',
 };
 
 // ============================================================================
@@ -95,8 +95,8 @@ export const SONG_CHANNELS = {
 // ============================================================================
 
 export const EDITOR_CHANNELS = {
-  SAVE_KAI: 'editor:saveKai',
-  RELOAD_KAI: 'editor:reloadKai',
+  SAVE: 'editor:save',
+  RELOAD: 'editor:reload',
 };
 
 // ============================================================================

--- a/src/shared/services/libraryService.js
+++ b/src/shared/services/libraryService.js
@@ -157,7 +157,7 @@ export async function scanLibrary(mainApp, progressCallback) {
     }
 
     // Get total file count for progress
-    const allFiles = (await mainApp.findAllKaiFiles?.(songsFolder)) || [];
+    const allFiles = (await mainApp.findAllSongFiles?.(songsFolder)) || [];
     const totalFiles = allFiles.length;
 
     if (progressCallback) {

--- a/src/shared/services/libraryService.test.js
+++ b/src/shared/services/libraryService.test.js
@@ -15,7 +15,7 @@ class MockMainApp {
     this.webServer = null;
     this.scanForKaiFiles = vi.fn();
     this.scanForKaiFilesWithProgress = vi.fn();
-    this.findAllKaiFiles = vi.fn();
+    this.findAllSongFiles = vi.fn();
     this.scanFilesystemForSync = vi.fn();
     this.parseMetadataWithProgress = vi.fn();
     this.extractM4AMetadata = vi.fn();
@@ -139,7 +139,7 @@ describe('libraryService', () => {
         { title: 'Song 2', path: '/music/song2.kai' },
       ];
       mainApp.settings.getSongsFolder.mockReturnValue('/music/karaoke');
-      mainApp.findAllKaiFiles.mockResolvedValue(mockFiles);
+      mainApp.findAllSongFiles.mockResolvedValue(mockFiles);
       mainApp.scanForKaiFilesWithProgress.mockResolvedValue(mockFiles);
 
       const result = await libraryService.scanLibrary(mainApp);
@@ -154,7 +154,7 @@ describe('libraryService', () => {
     it('should call progress callback during scan', async () => {
       const mockFiles = [{ title: 'Song 1', path: '/music/song1.kai' }];
       mainApp.settings.getSongsFolder.mockReturnValue('/music/karaoke');
-      mainApp.findAllKaiFiles.mockResolvedValue(mockFiles);
+      mainApp.findAllSongFiles.mockResolvedValue(mockFiles);
       mainApp.scanForKaiFilesWithProgress.mockResolvedValue(mockFiles);
 
       const progressCallback = vi.fn();
@@ -175,7 +175,7 @@ describe('libraryService', () => {
 
     it('should handle scan errors gracefully', async () => {
       mainApp.settings.getSongsFolder.mockReturnValue('/music/karaoke');
-      mainApp.findAllKaiFiles.mockRejectedValue(new Error('Access denied'));
+      mainApp.findAllSongFiles.mockRejectedValue(new Error('Access denied'));
 
       const result = await libraryService.scanLibrary(mainApp);
 

--- a/src/shared/services/playerService.js
+++ b/src/shared/services/playerService.js
@@ -100,7 +100,7 @@ export async function loadSong(mainApp, filePath) {
       };
     }
 
-    const result = await mainApp.loadKaiFile(filePath);
+    const result = await mainApp.loadSongFile(filePath);
 
     if (result && result.success) {
       return {
@@ -152,7 +152,7 @@ export async function playNext(mainApp) {
     const newQueue = mainApp.appState.getQueue();
     if (newQueue.length > 0) {
       const nextSong = newQueue[0];
-      await mainApp.loadKaiFile(nextSong.path, nextSong.id);
+      await mainApp.loadSongFile(nextSong.path, nextSong.id);
 
       return {
         success: true,

--- a/src/shared/services/playerService.test.js
+++ b/src/shared/services/playerService.test.js
@@ -30,7 +30,7 @@ class MockMainApp {
     };
     this.songQueue = [];
     this.currentSong = null;
-    this.loadKaiFile = vi.fn();
+    this.loadSongFile = vi.fn();
   }
 }
 
@@ -144,7 +144,7 @@ describe('playerService', () => {
 
   describe('loadSong', () => {
     it('should load a song successfully', async () => {
-      mainApp.loadKaiFile.mockResolvedValue({
+      mainApp.loadSongFile.mockResolvedValue({
         success: true,
         song: { title: 'Test Song', artist: 'Test Artist' },
       });
@@ -154,7 +154,7 @@ describe('playerService', () => {
       expect(result.success).toBe(true);
       expect(result.song.title).toBe('Test Song');
       expect(result.message).toBe('Song loaded successfully');
-      expect(mainApp.loadKaiFile).toHaveBeenCalledWith('/music/test.kai');
+      expect(mainApp.loadSongFile).toHaveBeenCalledWith('/music/test.kai');
     });
 
     it('should return error when file path is missing', async () => {
@@ -162,11 +162,11 @@ describe('playerService', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('File path is required');
-      expect(mainApp.loadKaiFile).not.toHaveBeenCalled();
+      expect(mainApp.loadSongFile).not.toHaveBeenCalled();
     });
 
     it('should return error when load fails', async () => {
-      mainApp.loadKaiFile.mockResolvedValue({
+      mainApp.loadSongFile.mockResolvedValue({
         success: false,
       });
 
@@ -177,7 +177,7 @@ describe('playerService', () => {
     });
 
     it('should handle exceptions', async () => {
-      mainApp.loadKaiFile.mockRejectedValue(new Error('File not found'));
+      mainApp.loadSongFile.mockRejectedValue(new Error('File not found'));
 
       const result = await playerService.loadSong(mainApp, '/music/test.kai');
 
@@ -200,7 +200,7 @@ describe('playerService', () => {
       mainApp.appState.getQueue.mockReturnValueOnce(mockQueue);
       mainApp.appState.getQueue.mockReturnValueOnce([mockQueue[1]]);
       mainApp.appState.getQueue.mockReturnValueOnce([mockQueue[1]]);
-      mainApp.loadKaiFile.mockResolvedValue({ success: true });
+      mainApp.loadSongFile.mockResolvedValue({ success: true });
 
       const result = await playerService.playNext(mainApp);
 
@@ -209,7 +209,7 @@ describe('playerService', () => {
       expect(result.song.title).toBe('Song 2');
       expect(result.message).toBe('Playing next song');
       expect(mainApp.appState.removeFromQueue).toHaveBeenCalledWith(1);
-      expect(mainApp.loadKaiFile).toHaveBeenCalledWith('/music/song2.kai', 2);
+      expect(mainApp.loadSongFile).toHaveBeenCalledWith('/music/song2.kai', 2);
     });
 
     it('should return error when queue is empty', async () => {
@@ -243,7 +243,7 @@ describe('playerService', () => {
         .mockReturnValueOnce(mockQueue)
         .mockReturnValueOnce(queueAfterRemoval)
         .mockReturnValueOnce(queueAfterRemoval);
-      mainApp.loadKaiFile.mockRejectedValue(new Error('Load failed'));
+      mainApp.loadSongFile.mockRejectedValue(new Error('Load failed'));
 
       const result = await playerService.playNext(mainApp);
 

--- a/src/shared/services/queueService.js
+++ b/src/shared/services/queueService.js
@@ -164,7 +164,7 @@ export function reorderQueue(appState, songId, newIndex) {
 
 /**
  * Load a song from the queue by ID
- * @param {Object} mainApp - Main app instance with loadKaiFile method
+ * @param {Object} mainApp - Main app instance with loadSongFile method
  * @param {string|number} itemId - Queue item ID to load
  * @returns {Object} Result with success status
  */
@@ -201,7 +201,7 @@ export async function loadFromQueue(mainApp, itemId) {
     // Load via the universal dispatcher. This used to keep its OWN extension
     // check that only knew .kai and .cdg/.mp3 — so queue-loading a .stem.mp4
     // (the PRIMARY format) threw a bogus 'Unsupported file format' even though
-    // the same file loads fine from the library. main.loadKaiFile detects the
+    // the same file loads fine from the library. main.loadSongFile detects the
     // real format (CDG pairs, m4a/stem.mp4) and errors properly for genuinely
     // unknown files; don't second-guess it here.
     const ext = item.path.toLowerCase();
@@ -212,7 +212,7 @@ export async function loadFromQueue(mainApp, itemId) {
       await mainApp.loadCDGFile(`${basePath}.mp3`, `${basePath}.cdg`, 'cdg-pair', item.id);
     } else {
       console.log('🎵 Loading song from queue:', item.path, 'queueItemId:', item.id);
-      await mainApp.loadKaiFile(item.path, item.id);
+      await mainApp.loadSongFile(item.path, item.id);
     }
 
     return {

--- a/src/shared/services/queueService.test.js
+++ b/src/shared/services/queueService.test.js
@@ -292,14 +292,14 @@ describe('queueService', () => {
 
       const mainApp = {
         appState,
-        loadKaiFile: vi.fn().mockResolvedValue(true),
+        loadSongFile: vi.fn().mockResolvedValue(true),
       };
 
       const result = await queueService.loadFromQueue(mainApp, song.id);
 
       expect(result.success).toBe(true);
       expect(result.song).toBeDefined();
-      expect(mainApp.loadKaiFile).toHaveBeenCalledWith('/music/song.kai', song.id);
+      expect(mainApp.loadSongFile).toHaveBeenCalledWith('/music/song.kai', song.id);
     });
 
     it('should load a CDG file from queue (mp3 path)', async () => {
@@ -354,13 +354,13 @@ describe('queueService', () => {
 
       const mainApp = {
         appState,
-        loadKaiFile: vi.fn().mockResolvedValue(true),
+        loadSongFile: vi.fn().mockResolvedValue(true),
       };
 
       const result = await queueService.loadFromQueue(mainApp, song.id);
 
       expect(result.success).toBe(true);
-      expect(mainApp.loadKaiFile).toHaveBeenCalled();
+      expect(mainApp.loadSongFile).toHaveBeenCalled();
     });
 
     it('should handle numeric itemId as string', async () => {
@@ -371,30 +371,30 @@ describe('queueService', () => {
 
       const mainApp = {
         appState,
-        loadKaiFile: vi.fn().mockResolvedValue(true),
+        loadSongFile: vi.fn().mockResolvedValue(true),
       };
 
       const result = await queueService.loadFromQueue(mainApp, String(song.id));
 
       expect(result.success).toBe(true);
-      expect(mainApp.loadKaiFile).toHaveBeenCalled();
+      expect(mainApp.loadSongFile).toHaveBeenCalled();
     });
 
     it('should return error when song not found in queue', async () => {
       const mainApp = {
         appState,
-        loadKaiFile: vi.fn(),
+        loadSongFile: vi.fn(),
       };
 
       const result = await queueService.loadFromQueue(mainApp, 99999);
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('Song not found in queue');
-      expect(mainApp.loadKaiFile).not.toHaveBeenCalled();
+      expect(mainApp.loadSongFile).not.toHaveBeenCalled();
     });
 
     it('propagates the loader error for genuinely unsupported files', async () => {
-      // Format judgment lives in main.loadKaiFile (the universal dispatcher) now;
+      // Format judgment lives in main.loadSongFile (the universal dispatcher) now;
       // the queue service no longer keeps its own extension list (it used to, and
       // its list was missing .stem.mp4 — the PRIMARY format — so queue loads threw
       // a bogus 'Unsupported file format').
@@ -405,14 +405,14 @@ describe('queueService', () => {
 
       const mainApp = {
         appState,
-        loadKaiFile: vi.fn().mockRejectedValue(new Error('Unsupported file format: song.txt')),
+        loadSongFile: vi.fn().mockRejectedValue(new Error('Unsupported file format: song.txt')),
       };
 
       const result = await queueService.loadFromQueue(mainApp, song.id);
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Unsupported file format');
-      expect(mainApp.loadKaiFile).toHaveBeenCalledWith('/music/song.txt', song.id);
+      expect(mainApp.loadSongFile).toHaveBeenCalledWith('/music/song.txt', song.id);
     });
 
     it('should handle loader errors gracefully', async () => {
@@ -423,7 +423,7 @@ describe('queueService', () => {
 
       const mainApp = {
         appState,
-        loadKaiFile: vi.fn().mockRejectedValue(new Error('File not found')),
+        loadSongFile: vi.fn().mockRejectedValue(new Error('File not found')),
       };
 
       const result = await queueService.loadFromQueue(mainApp, song.id);
@@ -442,11 +442,11 @@ describe('loadFromQueue: stem.mp4 (the primary format)', () => {
           { id: 42, path: "/music/The Beatles - Can't Buy Me Love.stem.mp4", title: 'CBML' },
         ],
       },
-      loadKaiFile: vi.fn().mockResolvedValue(true),
+      loadSongFile: vi.fn().mockResolvedValue(true),
     };
     const result = await queueService.loadFromQueue(mainApp, 42);
     expect(result.success).toBe(true);
-    expect(mainApp.loadKaiFile).toHaveBeenCalledWith(
+    expect(mainApp.loadSongFile).toHaveBeenCalledWith(
       "/music/The Beatles - Can't Buy Me Love.stem.mp4",
       42
     );
@@ -455,10 +455,10 @@ describe('loadFromQueue: stem.mp4 (the primary format)', () => {
   it('routes .m4a the same way', async () => {
     const mainApp = {
       appState: { getQueue: () => [{ id: 7, path: '/music/song.m4a', title: 'S' }] },
-      loadKaiFile: vi.fn().mockResolvedValue(true),
+      loadSongFile: vi.fn().mockResolvedValue(true),
     };
     const result = await queueService.loadFromQueue(mainApp, 7);
     expect(result.success).toBe(true);
-    expect(mainApp.loadKaiFile).toHaveBeenCalledWith('/music/song.m4a', 7);
+    expect(mainApp.loadSongFile).toHaveBeenCalledWith('/music/song.m4a', 7);
   });
 });


### PR DESCRIPTION
Closes #71.

The `.kai` container is gone but its skeleton was everywhere. This sweep removes the dead code paths and misleading names:

- **`main.loadKaiFile` → `loadSongFile`** — it was always the universal dispatcher (stem-mp4 + CDG pair/archive). All callers updated: menu, queueService, playerService, queueHandlers, fileHandlers.
- **`findAllKaiFiles` → `findAllSongFiles`** (library scan).
- **File menu**: "Open KAI File..." with a `.kai`-only filter → "Open Song File..." filtering mp4/m4a/mp3/kar/zip.
- **File dialogs**: dropped the `kai` extension and the "KAI Files (legacy)" filter entry.
- **IPC channels renamed together across preload/handlers/contracts/bridge**: `editor:loadKai`/`saveKai`/`reloadKai` → `editor:load`/`save`/`reload`; `file:openKai`/`loadKaiFromPath` → `file:openSong`/`loadSongFromPath`.
- **Deleted real `.kai` branches**: editorHandlers save/reload extension checks, the webServer `/admin/editor/load` kai response (whose `kai-audio` download URLs pointed at a route that never existed), and ElectronBridge's KaiWriter save path (KaiWriter itself is long gone). The Electron editor bridge now labels editor data `stem-mp4` like the web path does.
- **SongEditor**: dropped the four `format === 'kai' ||` escape hatches.

Left alone deliberately, called out for the record: the renderer's internal playback token (`'kai'` vs `'cdg'` in player/PlayerInterface/songLoaders and mixer `songType`) — renaming it crosses the mixer state contract that the stem-bus-mixer branch rides on, so it should happen after that merges — and the `kaiAPI`/`KAIPlayer`/`kaiData` naming, which is cosmetic churn across every file for zero behavior change.

Verified live: queue load + playback through the renamed dispatcher (song loads, plays, viewer streams), and the renamed editor IPC round trip in the Electron app (`load` returns 31 lyric lines, `save` succeeds against the real file, `reload` succeeds). 345/345 tests pass; renderer + web bundles build clean.

Note for merging: this renames IPC channels, so `npm run build:renderer` (or `npm run dev`) after pulling — old dist bundles call the old channel names.