### PR TITLE
Stem×bus mixer: per-stem gain/mute on PA and IEM buses

### DIFF
--- a/src/main/handlers/mixerHandlers.js
+++ b/src/main/handlers/mixerHandlers.js
@@ -22,43 +22,18 @@ export function registerMixerHandlers(mainApp) {
     return mixerService.toggleMasterMute(mainApp, bus);
   });
 
-  // Toggle stem mute
-  ipcMain.handle('mixer:toggleMute', (event, stemId, bus) => {
-    if (mainApp.audioEngine) {
-      return mainApp.audioEngine.toggleMute(stemId, bus);
-    }
-    return false;
+  // Per-bus per-stem mixer (stem×bus mixer, #49). Replaces the dormant ghost-mixer
+  // channels (toggleMute/toggleSolo/setGain/applyPreset/recallScene) that routed to
+  // the state-only main-process audioEngine stub and never reached audio.
+  ipcMain.handle(MIXER_CHANNELS.SET_STEM_GAIN, (event, bus, stem, gain) => {
+    return mixerService.setStemGain(mainApp, bus, stem, gain);
   });
 
-  // Toggle stem solo
-  ipcMain.handle('mixer:toggleSolo', (event, stemId) => {
-    if (mainApp.audioEngine) {
-      return mainApp.audioEngine.toggleSolo(stemId);
-    }
-    return false;
+  ipcMain.handle(MIXER_CHANNELS.SET_STEM_MUTE, (event, bus, stem, muted) => {
+    return mixerService.setStemMute(mainApp, bus, stem, muted);
   });
 
-  // Set stem gain
-  ipcMain.handle('mixer:setGain', (event, stemId, gainDb) => {
-    if (mainApp.audioEngine) {
-      return mainApp.audioEngine.setGain(stemId, gainDb);
-    }
-    return false;
-  });
-
-  // Apply mixer preset
-  ipcMain.handle('mixer:applyPreset', (event, presetId) => {
-    if (mainApp.audioEngine) {
-      return mainApp.audioEngine.applyPreset(presetId);
-    }
-    return false;
-  });
-
-  // Recall mixer scene
-  ipcMain.handle('mixer:recallScene', (event, sceneId) => {
-    if (mainApp.audioEngine) {
-      return mainApp.audioEngine.recallScene(sceneId);
-    }
-    return false;
+  ipcMain.handle(MIXER_CHANNELS.TOGGLE_STEM_MUTE, (event, bus, stem) => {
+    return mixerService.toggleStemMute(mainApp, bus, stem);
   });
 }

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -27,7 +27,10 @@ const api = {
   mixer: {
     setMasterGain: (bus, gainDb) => ipcRenderer.invoke('mixer:setMasterGain', bus, gainDb),
     toggleMasterMute: (bus) => ipcRenderer.invoke('mixer:toggleMasterMute', bus),
-    toggleMute: (stemId, bus) => ipcRenderer.invoke('mixer:toggleMute', stemId, bus),
+    // Per-bus per-stem mixer (stem×bus mixer, #49)
+    setStemGain: (bus, stem, gain) => ipcRenderer.invoke('mixer:setStemGain', bus, stem, gain),
+    setStemMute: (bus, stem, muted) => ipcRenderer.invoke('mixer:setStemMute', bus, stem, muted),
+    toggleStemMute: (bus, stem) => ipcRenderer.invoke('mixer:toggleStemMute', bus, stem),
 
     onStateChange: (callback) => ipcRenderer.on('mixer:state', callback),
     removeStateListener: (callback) => ipcRenderer.removeListener('mixer:state', callback),
@@ -35,6 +38,8 @@ const api = {
     // Listen for commands from main process (for web admin)
     onSetMasterGain: (callback) => ipcRenderer.on('mixer:setMasterGain', callback),
     onToggleMasterMute: (callback) => ipcRenderer.on('mixer:toggleMasterMute', callback),
+    onStemGain: (callback) => ipcRenderer.on('mixer:stemGain', callback),
+    onStemMute: (callback) => ipcRenderer.on('mixer:stemMute', callback),
     onSetMasterMute: (callback) => ipcRenderer.on('mixer:setMasterMute', callback),
   },
 

--- a/src/main/webServer.js
+++ b/src/main/webServer.js
@@ -1529,6 +1529,25 @@ class WebServer {
     });
 
     // ===== NEW: Master Mixer Control Endpoints =====
+    // Per-bus per-stem mixer (stem×bus mixer, #49): {bus, stem, gain?} or
+    // {bus, stem, muted?} — gain and mute are independent controls.
+    this.app.post('/admin/mixer/stem', (req, res) => {
+      try {
+        const { bus, stem, gain, muted } = req.body;
+        let result;
+        if (typeof gain === 'number') {
+          result = mixerService.setStemGain(this.mainApp, bus, stem, gain);
+        } else if (muted !== undefined) {
+          result = mixerService.setStemMute(this.mainApp, bus, stem, Boolean(muted));
+        } else {
+          result = { success: false, error: 'gain (number) or muted (boolean) required' };
+        }
+        res.json(result);
+      } catch (error) {
+        res.status(500).json({ success: false, error: error.message });
+      }
+    });
+
     this.app.post('/admin/mixer/master-gain', (req, res) => {
       try {
         const { bus, gainDb } = req.body;

--- a/src/renderer/adapters/ElectronBridge.js
+++ b/src/renderer/adapters/ElectronBridge.js
@@ -95,6 +95,23 @@ export class ElectronBridge extends BridgeInterface {
     return { success: false, error: 'Audio engine not initialized' };
   }
 
+  setStemGain(bus, stem, gain) {
+    // Apply locally - kaiPlayer reports back to main via reportMixerState()
+    const kaiPlayer = window.app?.player?.kaiPlayer;
+    if (kaiPlayer) {
+      return kaiPlayer.setStemGain(bus, stem, gain);
+    }
+    return { success: false, error: 'Audio engine not initialized' };
+  }
+
+  setStemMute(bus, stem, muted) {
+    const kaiPlayer = window.app?.player?.kaiPlayer;
+    if (kaiPlayer) {
+      return kaiPlayer.setStemMute(bus, stem, muted);
+    }
+    return { success: false, error: 'Audio engine not initialized' };
+  }
+
   setMasterMute(bus, muted) {
     // Apply locally - kaiPlayer will report back to main process via reportMixerState()
     const kaiPlayer = window.app?.player?.kaiPlayer;

--- a/src/renderer/components/App.jsx
+++ b/src/renderer/components/App.jsx
@@ -17,6 +17,7 @@ import { StatusBar } from './StatusBar.jsx';
 import { TabNavigation } from './TabNavigation.jsx';
 import { ServerTab } from './ServerTab.jsx';
 import { VisualizationSettings } from '../../shared/components/VisualizationSettings.jsx';
+import { PAQuickMix } from '../../shared/components/PAQuickMix.jsx';
 import { toggleCanvasFullscreen } from '../hooks/useKeyboardShortcuts.js';
 import WebGpuCreatorPanel from '../../shared/components/WebGpuCreatorPanel.jsx';
 import { useHostCreateListener } from '../hooks/useHostCreateListener.js';
@@ -222,6 +223,8 @@ export function App({ bridge }) {
           id="app-sidebar"
           className="w-80 bg-white dark:bg-gray-800 p-4 overflow-y-auto border-r border-gray-200 dark:border-gray-700 transition-all duration-300"
         >
+          {/* Mid-song PA mix first — the more urgent control while playing (§10.1) */}
+          <PAQuickMix bridge={bridge} />
           <VisualizationSettings bridge={bridge} />
         </div>
 

--- a/src/renderer/components/AudioDeviceSettings.jsx
+++ b/src/renderer/components/AudioDeviceSettings.jsx
@@ -14,6 +14,7 @@ import React from 'react';
 import { PortalSelect } from './PortalSelect.jsx';
 
 export function AudioDeviceSettings({
+  bus, // 'PA' | 'IEM' | 'mic' renders just that bus's slice (three-row Audio tab, #49); unset = legacy full block
   devices = { pa: [], iem: [], input: [] },
   selected = { pa: '', iem: '', input: '' },
   settings = { iemMonoVocals: true, micToSpeakers: true, enableMic: true },
@@ -45,6 +46,88 @@ export function AudioDeviceSettings({
       label: dev.label || dev.deviceId,
     })),
   ];
+
+  // Per-bus slices for the three-row Audio tab (#49 §3): each bus row hosts its
+  // own device picker (+ the IEM mono checkbox / mic options in their rows).
+  if (bus === 'PA') {
+    return (
+      <div className="w-full sm:w-64">
+        <label className="block mb-1 text-gray-600 dark:text-gray-400 text-sm">PA Output:</label>
+        <PortalSelect
+          id="paDeviceSelect"
+          value={selected.pa || ''}
+          onChange={(e) => onDeviceChange && onDeviceChange('pa', e.target.value)}
+          options={paOptions}
+          placeholder="Default"
+        />
+      </div>
+    );
+  }
+  if (bus === 'IEM') {
+    return (
+      <div className="w-full sm:w-64 flex flex-col gap-2">
+        <div>
+          <label className="block mb-1 text-gray-600 dark:text-gray-400 text-sm">IEM Output:</label>
+          <PortalSelect
+            id="iemDeviceSelect"
+            value={selected.iem || ''}
+            onChange={(e) => onDeviceChange && onDeviceChange('iem', e.target.value)}
+            options={iemOptions}
+            placeholder="Default"
+          />
+        </div>
+        <label
+          className="flex items-center cursor-pointer select-none text-gray-900 dark:text-gray-100 text-sm"
+          title="IEM is for in-ear monitoring; separate devices drift over long songs"
+        >
+          <input
+            type="checkbox"
+            id="iemMonoVocals"
+            className="w-4 h-4 mr-2 cursor-pointer"
+            checked={settings.iemMonoVocals ?? true}
+            onChange={(e) => onSettingChange && onSettingChange('iemMonoVocals', e.target.checked)}
+          />
+          Vocals in Mono (single earpiece)
+        </label>
+      </div>
+    );
+  }
+  if (bus === 'mic') {
+    return (
+      <div className="w-full sm:w-64 flex flex-col gap-2">
+        <div>
+          <label className="block mb-1 text-gray-600 dark:text-gray-400 text-sm">Mic Input:</label>
+          <PortalSelect
+            id="inputDeviceSelect"
+            value={selected.input || ''}
+            onChange={(e) => onDeviceChange && onDeviceChange('input', e.target.value)}
+            options={inputOptions}
+            placeholder="Default"
+          />
+        </div>
+        <label className="flex items-center cursor-pointer text-gray-900 dark:text-gray-100 select-none text-sm">
+          <input
+            type="checkbox"
+            id="micToSpeakers"
+            className="w-4 h-4 mr-2 cursor-pointer"
+            checked={settings.micToSpeakers ?? true}
+            onChange={(e) => onSettingChange && onSettingChange('micToSpeakers', e.target.checked)}
+          />
+          <span>Mic to Speakers</span>
+        </label>
+        <label className="flex items-center cursor-pointer text-gray-900 dark:text-gray-100 select-none text-sm">
+          <input
+            type="checkbox"
+            id="enableMic"
+            className="w-4 h-4 mr-2 cursor-pointer"
+            checked={settings.enableMic ?? true}
+            onChange={(e) => onSettingChange && onSettingChange('enableMic', e.target.checked)}
+          />
+          <span>Enable Mic</span>
+        </label>
+      </div>
+    );
+  }
 
   return (
     <>

--- a/src/renderer/components/MixerTab.jsx
+++ b/src/renderer/components/MixerTab.jsx
@@ -29,28 +29,28 @@ export function MixerTab({ bridge }) {
     if (!bridge) return;
 
     const unsubscribe = bridge.onMixerChanged?.((mixer) => {
-      // Extract only bus-level mixer (PA, IEM, mic) - ignore stem mixer properties
-      const busLevelMixer = {
+      // Keep the FULL mixer state: masters + stemMix + the song's stem list all
+      // render from this one subscription (stem×bus mixer, #49).
+      setMixerState({
         PA: mixer.PA || { gain: 0, muted: false },
         IEM: mixer.IEM || { gain: 0, muted: false },
         mic: mixer.mic || { gain: 0, muted: false },
-      };
-
-      setMixerState(busLevelMixer);
+        stemMix: mixer.stemMix,
+        stems: mixer.stems || [],
+      });
     });
 
     // Fetch initial state
     bridge
       .getMixerState?.()
       .then((state) => {
-        // Extract only bus-level mixer (PA, IEM, mic)
-        const busLevelMixer = {
+        setMixerState({
           PA: state.PA || { gain: 0, muted: false },
           IEM: state.IEM || { gain: 0, muted: false },
           mic: state.mic || { gain: 0, muted: false },
-        };
-
-        setMixerState(busLevelMixer);
+          stemMix: state.stemMix,
+          stems: state.stems || [],
+        });
       })
       .catch(console.error);
 
@@ -217,6 +217,8 @@ export function MixerTab({ bridge }) {
           mixerState={mixerState}
           onSetMasterGain={handleSetMasterGain}
           onToggleMasterMute={handleToggleMasterMute}
+          onSetStemGain={(bus, stem, gain) => bridge.setStemGain?.(bus, stem, gain)}
+          onSetStemMute={(bus, stem, muted) => bridge.setStemMute?.(bus, stem, muted)}
         />
       </div>
 

--- a/src/renderer/components/MixerTab.jsx
+++ b/src/renderer/components/MixerTab.jsx
@@ -37,6 +37,7 @@ export function MixerTab({ bridge }) {
         mic: mixer.mic || { gain: 0, muted: false },
         stemMix: mixer.stemMix,
         stems: mixer.stems || [],
+        songType: mixer.songType,
       });
     });
 
@@ -50,6 +51,7 @@ export function MixerTab({ bridge }) {
           mic: state.mic || { gain: 0, muted: false },
           stemMix: state.stemMix,
           stems: state.stems || [],
+          songType: state.songType,
         });
       })
       .catch(console.error);
@@ -209,27 +211,42 @@ export function MixerTab({ bridge }) {
       .catch(console.error);
   };
 
+  // One AudioDeviceSettings slice per bus row (three-row Audio tab, #49 §3).
+  const deviceProps = {
+    devices: audioDevices,
+    selected: selectedDevices,
+    settings: audioSettings,
+    onDeviceChange: handleDeviceChange,
+    onSettingChange: handleSettingChange,
+  };
+
   return (
     <div className="p-5 h-full overflow-y-auto">
       <div className="mb-8">
-        <h2 className="m-0 mb-5 text-2xl text-gray-900 dark:text-gray-100">Audio Mixer</h2>
+        <h2 className="m-0 mb-5 text-2xl text-gray-900 dark:text-gray-100 flex items-center justify-between">
+          Audio Mixer
+          <button
+            onClick={handleRefreshDevices}
+            className="px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white rounded transition-colors text-base"
+            title="Refresh device list"
+          >
+            ↻
+          </button>
+        </h2>
         <MixerPanel
           mixerState={mixerState}
           onSetMasterGain={handleSetMasterGain}
           onToggleMasterMute={handleToggleMasterMute}
           onSetStemGain={(bus, stem, gain) => bridge.setStemGain?.(bus, stem, gain)}
           onSetStemMute={(bus, stem, muted) => bridge.setStemMute?.(bus, stem, muted)}
+          songType={mixerState.songType}
+          busExtras={{
+            PA: <AudioDeviceSettings bus="PA" {...deviceProps} />,
+            IEM: <AudioDeviceSettings bus="IEM" {...deviceProps} />,
+            mic: <AudioDeviceSettings bus="mic" {...deviceProps} />,
+          }}
         />
       </div>
-
-      <AudioDeviceSettings
-        devices={audioDevices}
-        selected={selectedDevices}
-        settings={audioSettings}
-        onDeviceChange={handleDeviceChange}
-        onSettingChange={handleSettingChange}
-        onRefreshDevices={handleRefreshDevices}
-      />
     </div>
   );
 }

--- a/src/renderer/js/cdgPlayer.js
+++ b/src/renderer/js/cdgPlayer.js
@@ -579,13 +579,15 @@ export class CDGPlayer extends PlayerInterface {
    * are inherited from PlayerInterface base class
    */
 
-  async setAudioContext(audioContext, gainNode, analyserNode) {
+  async setAudioContext(audioContext, gainNode, analyserNode, micOutputNode = null) {
     this.audioContext = audioContext;
     this.gainNode = gainNode;
     this.analyserNode = analyserNode;
 
-    // Initialize microphone engine with PA context
-    this.micEngine = new MicrophoneEngine(audioContext, gainNode, {
+    // Initialize microphone engine with PA context. The mic outputs to
+    // micOutputNode (PA.masterGain) — NOT the CDG music gain node — so the new
+    // "music" fader is music-only and can never duck the singer's mic (#49 §8).
+    this.micEngine = new MicrophoneEngine(audioContext, micOutputNode || gainNode, {
       getCurrentPosition: () => this.getCurrentPosition(),
     });
 

--- a/src/renderer/js/kaiPlayer.js
+++ b/src/renderer/js/kaiPlayer.js
@@ -1,5 +1,12 @@
 import { PlayerInterface } from './PlayerInterface.js';
 import { MicrophoneEngine } from './microphoneEngine.js';
+import {
+  effectiveStemGain,
+  resolveStemEntry,
+  clampStemGain,
+  mergeStemMix,
+} from '../../shared/utils/stemGain.js';
+import { isVocalStem, isMixdownStem, isMelodicStem } from '../../shared/utils/stemClassify.js';
 
 export class KAIPlayer extends PlayerInterface {
   constructor() {
@@ -29,7 +36,6 @@ export class KAIPlayer extends PlayerInterface {
         gainNodes: new Map(),
         masterGain: null,
         analyser: null, // For butterchurn visualization
-        vocalsPAGain: null, // For backup:PA feature - vocals to PA routing
         streamDestination: null, // MediaStreamAudioDestinationNode for browser viewer streaming
       },
       IEM: {
@@ -65,6 +71,10 @@ export class KAIPlayer extends PlayerInterface {
         gain: 0, // dB
         muted: true, // Default muted - user must explicitly enable mic
       },
+      // Per-bus per-stem user mix (stem×bus mixer, #49): linear gain multiplier on the
+      // authored trim + independent mute, keyed [bus][stemName]. Seeded from the D1
+      // defaults; persisted state merges over it in loadDevicePreferences.
+      stemMix: mergeStemMix(undefined),
       // Per-song data (for internal use)
       stems: [],
       // Mic routing settings (deprecated - now in micEngine, kept for compatibility)
@@ -102,10 +112,8 @@ export class KAIPlayer extends PlayerInterface {
       this.outputNodes.PA.analyser.fftSize = 2048;
       this.outputNodes.PA.analyser.smoothingTimeConstant = 0.8;
 
-      // Create vocalsPAGain node for backup:PA feature (vocals to PA routing, muted by default)
-      this.outputNodes.PA.vocalsPAGain = this.audioContexts.PA.createGain();
-      this.outputNodes.PA.vocalsPAGain.gain.value = 0; // Muted by default
-      this.outputNodes.PA.vocalsPAGain.connect(this.outputNodes.PA.masterGain);
+      // (backup:PA punchthrough now rides the ordinary PA vocals gain node via the
+      // stem×bus mixer formula — the old dedicated vocalsPAGain node is gone.)
 
       // Parallel MediaStream destination for browser viewer streaming.
       // Connected to masterGain in addition to (not instead of) the audio device destination
@@ -250,6 +258,9 @@ export class KAIPlayer extends PlayerInterface {
           if (typeof appState.mixer.mic?.muted === 'boolean') {
             this.mixerState.mic.muted = appState.mixer.mic.muted;
           }
+          // Per-stem mix: merge persisted values over the D1 seed (handles old saved
+          // states with no stemMix at all, junk values, and unknown stem keys).
+          this.mixerState.stemMix = mergeStemMix(appState.mixer.stemMix);
         }
       }
     } catch (error) {
@@ -336,12 +347,13 @@ export class KAIPlayer extends PlayerInterface {
         this.outputNodes.PA.analyser.fftSize = 2048;
         this.outputNodes.PA.analyser.smoothingTimeConstant = 0.8;
 
-        // Recreate vocalsPAGain node for backup:PA feature
-        this.outputNodes.PA.vocalsPAGain = this.audioContexts.PA.createGain();
-        this.outputNodes.PA.vocalsPAGain.gain.value = this.vocalsPAEnabled
-          ? this.dbToLinear(this.mixerState.IEM.gain)
-          : 0;
-        this.outputNodes.PA.vocalsPAGain.connect(this.outputNodes.PA.masterGain);
+        // Recreate the streaming tap on the NEW context. This was the silent-viewers
+        // bug: the old streamDestination belonged to the closed context, so WebRTC
+        // viewers lost audio until the next song load. Consumers re-pull
+        // getPAStream() on song load; recreating here makes that pull correct.
+        this.outputNodes.PA.streamDestination =
+          this.audioContexts.PA.createMediaStreamDestination();
+        this.outputNodes.PA.masterGain.connect(this.outputNodes.PA.streamDestination);
       }
 
       // Clear old audio nodes
@@ -673,8 +685,61 @@ export class KAIPlayer extends PlayerInterface {
 
       this.outputNodes.IEM.gainNodes.set(stem.name, iemGainNode);
 
-      this.updateStemGain(stem);
+      // Initialize BOTH nodes from the single effective-gain formula (the graph is
+      // rebuilt on every play(), so this is the only init path — plan §11.2).
+      this.applyStemNodeGain('PA', stem.name);
+      this.applyStemNodeGain('IEM', stem.name);
     });
+  }
+
+  /**
+   * Compute + apply the effective gain for one stem's node on one bus, from the
+   * authored trim × the user's stemMix entry (× the backup:PA punchthrough overlay
+   * for PA vocals). Ramped to avoid zipper noise; resilient to no-song / unknown
+   * stem / mid-rebuild (state-only in those cases).
+   */
+  applyStemNodeGain(bus, stemName, rampSec = 0.03) {
+    const ctx = this.audioContexts[bus];
+    const gainNode = this.outputNodes[bus]?.gainNodes?.get(stemName);
+    if (!ctx || !gainNode) return; // state-only; applied at next createAudioGraph()
+
+    const stem = this.mixerState.stems.find((s) => s.name === stemName);
+    const entry = resolveStemEntry(this.mixerState.stemMix, bus, stemName);
+    const target = effectiveStemGain({
+      fileTrimDb: stem?.gain || 0,
+      userGain: entry.gain,
+      muted: entry.muted,
+      punchthroughActive: bus === 'PA' && this.vocalsPAEnabled && this.isVocalStem(stemName),
+    });
+
+    const now = ctx.currentTime;
+    gainNode.gain.cancelScheduledValues(now);
+    gainNode.gain.setValueAtTime(gainNode.gain.value, now);
+    gainNode.gain.linearRampToValueAtTime(target, now + rampSec);
+  }
+
+  /** Set a per-bus per-stem slider (0..1.5 linear, 1.0 = authored mix). */
+  setStemGain(bus, stemName, gain) {
+    if (bus !== 'PA' && bus !== 'IEM') return false;
+    if (!this.mixerState.stemMix[bus]) this.mixerState.stemMix[bus] = {};
+    const entry = resolveStemEntry(this.mixerState.stemMix, bus, stemName);
+    this.mixerState.stemMix[bus][stemName] = { ...entry, gain: clampStemGain(gain) };
+    this.applyStemNodeGain(bus, stemName);
+    return true;
+  }
+
+  /** Mute/unmute one stem on one bus (independent of the slider value). */
+  setStemMute(bus, stemName, muted) {
+    if (bus !== 'PA' && bus !== 'IEM') return false;
+    if (!this.mixerState.stemMix[bus]) this.mixerState.stemMix[bus] = {};
+    const entry = resolveStemEntry(this.mixerState.stemMix, bus, stemName);
+    this.mixerState.stemMix[bus][stemName] = { ...entry, muted: Boolean(muted) };
+    this.applyStemNodeGain(bus, stemName);
+    return true;
+  }
+
+  getStemMix() {
+    return this.mixerState.stemMix;
   }
 
   startAudioSources() {
@@ -703,59 +768,43 @@ export class KAIPlayer extends PlayerInterface {
           const offset = Math.min(this.currentPosition, audioBuffer.duration);
           const isVocals = this.isVocalStem(stem.name);
 
-          // Proper karaoke routing: vocals to IEM only, music/backing tracks to PA only
-          // Exception: backup:PA feature routes vocals to PA when enabled
-          if (isVocals) {
-            // Vocals go to IEM (singer's ears)
-            const iemSource = this.audioContexts.IEM.createBufferSource();
-            iemSource.buffer = audioBuffer;
-            iemSource.connect(iemGainNode);
-            iemSource.start(iemStart, offset);
-            this.outputNodes.IEM.sourceNodes.set(stem.name, iemSource);
+          // Stem×bus mixer (D4): EVERY stem gets an always-running source on BOTH
+          // buses; audibility is entirely the per-bus gain nodes' business (muted
+          // paths run at gain 0). Buffers are decoded once and shared, so the extra
+          // sources are near-free — and mute/unmute becomes a click-free ramp
+          // instead of a graph rebuild (the generalized backup:PA pattern).
+          const paSource = this.audioContexts.PA.createBufferSource();
+          paSource.buffer = audioBuffer;
+          paSource.connect(paGainNode);
 
-            // Also create PA source for backup:PA feature (muted by default via vocalsPAGain)
-            if (this.outputNodes.PA.vocalsPAGain) {
-              const paSource = this.audioContexts.PA.createBufferSource();
-              paSource.buffer = audioBuffer; // Reuse the same decoded buffer
-              paSource.connect(this.outputNodes.PA.vocalsPAGain);
-
-              // Connect vocals to pitch detection for auto-tune reference
-              // This enables real-time pitch tracking from the vocal stem
-              if (this.micEngine) {
-                this.micEngine.connectMusicSource(paSource);
-              }
-
-              paSource.start(paStart, offset);
-              this.outputNodes.PA.sourceNodes.set(stem.name + '_vocalsPA', paSource);
-            }
-          } else {
-            // Backing tracks go to PA only (audience)
-            const paSource = this.audioContexts.PA.createBufferSource();
-            paSource.buffer = audioBuffer;
-            paSource.connect(paGainNode);
-
-            // Connect to analyser for butterchurn visualization (before gain affects signal)
-            if (this.outputNodes.PA.analyser) {
-              paSource.connect(this.outputNodes.PA.analyser);
-            }
-
-            // If this is a melodic stem, connect to microphone engine for pitch detection
-            if (this.isMelodicStem(stem.name) && this.micEngine) {
-              this.micEngine.connectMusicSource(paSource);
-            }
-
-            paSource.start(paStart, offset);
-            this.outputNodes.PA.sourceNodes.set(stem.name, paSource);
-
-            // Add onended handler as backup to position monitoring
-            paSource.onended = () => {
-              if (this.isPlaying) {
-                // Let the position monitoring handle the cleanup
-                // This serves as a backup in case position monitoring misses it
-                setTimeout(() => this.checkForSongEnd(), 10);
-              }
-            };
+          // Butterchurn analyser taps the PA source PRE-gain: visuals react to the
+          // full mix (now including vocals) even when stems are muted for the room.
+          if (this.outputNodes.PA.analyser) {
+            paSource.connect(this.outputNodes.PA.analyser);
           }
+
+          // Auto-tune reference: vocal + melodic PA sources feed pitch detection,
+          // pre-gain, so correction keeps working when the user mutes them on PA.
+          if (this.micEngine && (isVocals || this.isMelodicStem(stem.name))) {
+            this.micEngine.connectMusicSource(paSource);
+          }
+
+          paSource.start(paStart, offset);
+          this.outputNodes.PA.sourceNodes.set(stem.name, paSource);
+
+          // End detection keys off PA sources only — PA is the position-truth
+          // clock; IEM device clocks can drift.
+          paSource.onended = () => {
+            if (this.isPlaying) {
+              setTimeout(() => this.checkForSongEnd(), 10);
+            }
+          };
+
+          const iemSource = this.audioContexts.IEM.createBufferSource();
+          iemSource.buffer = audioBuffer;
+          iemSource.connect(iemGainNode);
+          iemSource.start(iemStart, offset);
+          this.outputNodes.IEM.sourceNodes.set(stem.name, iemSource);
         } catch (error) {
           console.error(`Failed to start source for ${stem.name}:`, error);
         }
@@ -770,66 +819,18 @@ export class KAIPlayer extends PlayerInterface {
     // });
   }
 
+  // Classification heuristics live in shared/utils/stemClassify.js (unit-tested,
+  // shared with the mixer's runtime defaults); these wrappers keep the call sites.
   isVocalStem(stemName) {
-    const vocalsKeywords = ['vocals', 'vocal', 'voice', 'lead', 'singing', 'vox'];
-    const lowerName = stemName.toLowerCase();
-    return vocalsKeywords.some((keyword) => lowerName.includes(keyword));
+    return isVocalStem(stemName);
   }
 
   isMixdownStem(stemName) {
-    // Mixdown stems contain the full mix and should be skipped when individual stems are available
-    const mixdownKeywords = ['mixdown', 'mix', 'master', 'full mix', 'stereo mix'];
-    const lowerName = stemName.toLowerCase();
-    return mixdownKeywords.some(
-      (keyword) =>
-        lowerName === keyword ||
-        lowerName.includes(`_${keyword}`) ||
-        lowerName.includes(`${keyword}_`)
-    );
+    return isMixdownStem(stemName);
   }
 
   isMelodicStem(stemName) {
-    // Returns true for stems containing melodic instruments (typically "other")
-    // These are best for pitch detection as melody reference
-    const lowerName = stemName.toLowerCase();
-
-    // Explicitly melodic stems
-    if (
-      lowerName.includes('other') ||
-      lowerName.includes('music') ||
-      lowerName.includes('instrumental') ||
-      lowerName.includes('accompaniment') ||
-      lowerName.includes('melody')
-    ) {
-      return true;
-    }
-
-    // Exclude non-melodic stems
-    if (this.isVocalStem(stemName)) return false;
-    if (lowerName.includes('drum') || lowerName.includes('percussion')) return false;
-    if (lowerName.includes('bass')) return false;
-
-    // Default to true for unknown stems (likely melodic)
-    return true;
-  }
-
-  updateStemGain(stem) {
-    const paGainNode = this.outputNodes.PA.gainNodes.get(stem.name);
-    const iemGainNode = this.outputNodes.IEM.gainNodes.get(stem.name);
-    const isVocals = this.isVocalStem(stem.name);
-
-    if (!this.audioContexts.PA || !this.audioContexts.IEM) return;
-
-    // Convert stem gain from dB to linear (per-stem balancing)
-    const baseGain = Math.pow(10, stem.gain / 20);
-
-    // Simple routing: vocals to IEM, backing tracks to PA
-    // Master faders control overall output level
-    if (isVocals && iemGainNode) {
-      iemGainNode.gain.setValueAtTime(baseGain, this.audioContexts.IEM.currentTime);
-    } else if (!isVocals && paGainNode) {
-      paGainNode.gain.setValueAtTime(baseGain, this.audioContexts.PA.currentTime);
-    }
+    return isMelodicStem(stemName);
   }
 
   // New simple mixer controls
@@ -907,28 +908,24 @@ export class KAIPlayer extends PlayerInterface {
   }
 
   /**
-   * Enable/disable vocals routing to PA (for backup:PA feature)
-   * When a lyric line has singer="backup:PA", the original vocals should play through PA
-   * @param {boolean} enabled - Whether to route vocals to PA
-   * @param {number} fadeTime - Fade duration in seconds (default 50ms to avoid clicks)
+   * backup:PA punchthrough (lyric lines tagged singer="backup:PA"). Rides the
+   * ordinary PA vocals gain node via the mixer formula: while active, the node
+   * targets max(user's PA-vocals level, authored level) — the line can only ADD
+   * vocals, never fight the user (D2). User-muted vocals rise for the line and
+   * fall back after; a user already at/above authored level hears no change.
+   * @param {boolean} enabled - Whether the punchthrough overlay is active
+   * @param {number} fadeTime - Ramp duration in seconds (default 50ms, no clicks)
    */
   setVocalsPAEnabled(enabled, fadeTime = 0.05) {
-    if (!this.outputNodes.PA.vocalsPAGain || !this.audioContexts.PA) return;
-
-    // Avoid redundant changes
     if (this.vocalsPAEnabled === enabled) return;
     this.vocalsPAEnabled = enabled;
 
-    // Use IEM gain as reference for vocals volume (since that's where vocals normally go)
-    const targetGain = enabled ? this.dbToLinear(this.mixerState.IEM.gain) : 0;
-
-    // Smooth fade to avoid clicks/pops
-    const currentTime = this.audioContexts.PA.currentTime;
-    this.outputNodes.PA.vocalsPAGain.gain.cancelScheduledValues(currentTime);
-    this.outputNodes.PA.vocalsPAGain.gain.linearRampToValueAtTime(
-      targetGain,
-      currentTime + fadeTime
-    );
+    // Recompute every vocal stem's PA node (multi-vocal-stem files: all of them).
+    this.mixerState.stems.forEach((stem) => {
+      if (this.isVocalStem(stem.name)) {
+        this.applyStemNodeGain('PA', stem.name, fadeTime);
+      }
+    });
   }
 
   // Preset system removed - routing is now automatic with master faders

--- a/src/renderer/js/kaiPlayer.js
+++ b/src/renderer/js/kaiPlayer.js
@@ -718,23 +718,28 @@ export class KAIPlayer extends PlayerInterface {
     gainNode.gain.linearRampToValueAtTime(target, now + rampSec);
   }
 
-  /** Set a per-bus per-stem slider (0..1.5 linear, 1.0 = authored mix). */
-  setStemGain(bus, stemName, gain) {
+  /**
+   * Set a per-bus per-stem slider (0..1.5 linear, 1.0 = authored mix).
+   * report=false when applying a control-plane value from main (no-echo loops).
+   */
+  setStemGain(bus, stemName, gain, report = true) {
     if (bus !== 'PA' && bus !== 'IEM') return false;
     if (!this.mixerState.stemMix[bus]) this.mixerState.stemMix[bus] = {};
     const entry = resolveStemEntry(this.mixerState.stemMix, bus, stemName);
     this.mixerState.stemMix[bus][stemName] = { ...entry, gain: clampStemGain(gain) };
     this.applyStemNodeGain(bus, stemName);
+    if (report) this.reportMixerState();
     return true;
   }
 
   /** Mute/unmute one stem on one bus (independent of the slider value). */
-  setStemMute(bus, stemName, muted) {
+  setStemMute(bus, stemName, muted, report = true) {
     if (bus !== 'PA' && bus !== 'IEM') return false;
     if (!this.mixerState.stemMix[bus]) this.mixerState.stemMix[bus] = {};
     const entry = resolveStemEntry(this.mixerState.stemMix, bus, stemName);
     this.mixerState.stemMix[bus][stemName] = { ...entry, muted: Boolean(muted) };
     this.applyStemNodeGain(bus, stemName);
+    if (report) this.reportMixerState();
     return true;
   }
 

--- a/src/renderer/js/kaiPlayer.js
+++ b/src/renderer/js/kaiPlayer.js
@@ -398,6 +398,7 @@ export class KAIPlayer extends PlayerInterface {
 
   async loadSong(songData) {
     this.cdgMusicNode = null; // stems song replaces any CDG music-node registration
+    this.mixerState.songType = 'kai';
 
     this.songData = songData;
 
@@ -758,7 +759,11 @@ export class KAIPlayer extends PlayerInterface {
    */
   attachCdgMusicNode(gainNode) {
     this.cdgMusicNode = gainNode;
+    // The mixer UIs render the single-music-fader variant off this flag (it rides
+    // the same mixer broadcast every surface already subscribes to).
+    this.mixerState.songType = 'cdg';
     this.applyCdgMusicGain(0); // initialize from the persisted entry, no ramp
+    this.reportMixerState();
   }
 
   applyCdgMusicGain(rampSec = 0.03) {

--- a/src/renderer/js/kaiPlayer.js
+++ b/src/renderer/js/kaiPlayer.js
@@ -397,6 +397,8 @@ export class KAIPlayer extends PlayerInterface {
   }
 
   async loadSong(songData) {
+    this.cdgMusicNode = null; // stems song replaces any CDG music-node registration
+
     this.songData = songData;
 
     // Reset position using base class method
@@ -728,6 +730,7 @@ export class KAIPlayer extends PlayerInterface {
     const entry = resolveStemEntry(this.mixerState.stemMix, bus, stemName);
     this.mixerState.stemMix[bus][stemName] = { ...entry, gain: clampStemGain(gain) };
     this.applyStemNodeGain(bus, stemName);
+    if (bus === 'PA' && stemName === 'music') this.applyCdgMusicGain();
     if (report) this.reportMixerState();
     return true;
   }
@@ -739,12 +742,33 @@ export class KAIPlayer extends PlayerInterface {
     const entry = resolveStemEntry(this.mixerState.stemMix, bus, stemName);
     this.mixerState.stemMix[bus][stemName] = { ...entry, muted: Boolean(muted) };
     this.applyStemNodeGain(bus, stemName);
+    if (bus === 'PA' && stemName === 'music') this.applyCdgMusicGain();
     if (report) this.reportMixerState();
     return true;
   }
 
   getStemMix() {
     return this.mixerState.stemMix;
+  }
+
+  /**
+   * CDG mode (§8): the loaded CDG song's single music gain node, driven by the PA
+   * "music" strip through the same stemMix state (persists like any stem key).
+   * Registered by the CDG loader; cleared when a stems song loads.
+   */
+  attachCdgMusicNode(gainNode) {
+    this.cdgMusicNode = gainNode;
+    this.applyCdgMusicGain(0); // initialize from the persisted entry, no ramp
+  }
+
+  applyCdgMusicGain(rampSec = 0.03) {
+    if (!this.cdgMusicNode || !this.audioContexts.PA) return;
+    const entry = resolveStemEntry(this.mixerState.stemMix, 'PA', 'music');
+    const target = entry.muted ? 0 : entry.gain;
+    const now = this.audioContexts.PA.currentTime;
+    this.cdgMusicNode.gain.cancelScheduledValues(now);
+    this.cdgMusicNode.gain.setValueAtTime(this.cdgMusicNode.gain.value, now);
+    this.cdgMusicNode.gain.linearRampToValueAtTime(target, now + Math.max(rampSec, 0.001));
   }
 
   startAudioSources() {

--- a/src/renderer/js/songLoaders.js
+++ b/src/renderer/js/songLoaders.js
@@ -35,7 +35,13 @@ export async function loadCDGSong(app, songData, metadata) {
   cdgGainNode.connect(analyserNode);
 
   // Set audio context in CDG renderer (PA context for playback)
-  app.player.cdgPlayer.setAudioContext(paContext, cdgGainNode, analyserNode);
+  // micOutputNode = PA.masterGain: the mic must bypass the music fader (§8).
+  app.player.cdgPlayer.setAudioContext(paContext, cdgGainNode, analyserNode, paMasterGain);
+
+  // Register the CDG music node with the mixer: the PA "music" strip drives it
+  // through kaiPlayer.setStemGain/setStemMute (state lives in stemMix.PA.music and
+  // persists like any stem). Initialize from the persisted entry.
+  app.kaiPlayer.attachCdgMusicNode(cdgGainNode);
 
   // Load CDG data
   await app.player.cdgPlayer.loadSong(songData);

--- a/src/shared/components/MixerPanel.jsx
+++ b/src/shared/components/MixerPanel.jsx
@@ -5,6 +5,10 @@
  * Works with both ElectronBridge and WebBridge via callbacks
  */
 
+import { StemStrip } from './StemStrip.jsx';
+import { resolveStemEntry, orderStems, CANONICAL_STEMS } from '../utils/stemGain.js';
+import { isMixdownStem } from '../utils/stemClassify.js';
+
 export function MixerPanel({
   mixer, // Support both 'mixer' (web) and 'mixerState' (renderer)
   mixerState,
@@ -12,6 +16,8 @@ export function MixerPanel({
   onToggleMasterMute,
   onGainChange, // Alias for web compatibility
   onMuteToggle, // Alias for web compatibility
+  onSetStemGain, // (bus, stem, gain 0..1.5) — stem×bus mixer (#49)
+  onSetStemMute, // (bus, stem, muted)
   className = '',
 }) {
   // Support both prop names - prefer mixerState if provided, then mixer, then empty object
@@ -86,6 +92,37 @@ export function MixerPanel({
             >
               MUTE
             </button>
+
+            {/* Per-stem strip (PA/IEM only). Stems come from the loaded song; with no
+                song the canonical 4 render disabled, showing the persisted values. */}
+            {(bus.id === 'PA' || bus.id === 'IEM') && onSetStemGain && (
+              <div className="w-full border-t border-gray-200 dark:border-gray-700 pt-3 mt-1">
+                <div className="flex gap-2 justify-center flex-wrap">
+                  {(() => {
+                    const songStems = (state.stems || [])
+                      .map((st) => st.name)
+                      .filter((n) => n && !isMixdownStem(n));
+                    const names = songStems.length ? orderStems(songStems) : CANONICAL_STEMS;
+                    const disabled = songStems.length === 0;
+                    return names.map((name) => {
+                      const entry = resolveStemEntry(state.stemMix, bus.id, name);
+                      return (
+                        <StemStrip
+                          key={name}
+                          bus={bus.id}
+                          name={name}
+                          gain={entry.gain}
+                          muted={entry.muted}
+                          disabled={disabled}
+                          onGain={onSetStemGain}
+                          onMute={onSetStemMute}
+                        />
+                      );
+                    });
+                  })()}
+                </div>
+              </div>
+            )}
           </div>
         );
       })}

--- a/src/shared/components/MixerPanel.jsx
+++ b/src/shared/components/MixerPanel.jsx
@@ -69,10 +69,13 @@ export function MixerPanel({
               {busExtras?.[bus.id] || null}
             </div>
 
-            <div className="flex flex-col items-center gap-2 w-full">
+            {/* Compact master cluster on one line (a full-width slider + giant MUTE
+                bar read as broken; the fader is a trim, not the star of the row). */}
+            <div className="flex items-center gap-3 flex-wrap">
+              <span className="text-sm text-gray-600 dark:text-gray-400 w-14 shrink-0">Master</span>
               <input
                 type="range"
-                className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-600"
+                className="w-64 max-w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-600"
                 min="-60"
                 max="12"
                 step="0.5"
@@ -80,29 +83,29 @@ export function MixerPanel({
                 onChange={(e) => handleGainChangeLocal(bus.id, e.target.value)}
                 onDoubleClick={(e) => handleDoubleClick(bus.id, e)}
                 data-bus={bus.id}
+                title="Master (double-click = 0 dB)"
               />
-              <div className="text-sm font-mono text-gray-700 dark:text-gray-300">
+              <span className="text-sm font-mono text-gray-700 dark:text-gray-300 w-16">
                 {gain.toFixed(1)} dB
-              </div>
+              </span>
+              <button
+                className={`px-3 py-1 rounded text-sm font-semibold transition ${
+                  muted
+                    ? 'bg-red-600 hover:bg-red-700 text-white'
+                    : 'bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100'
+                }`}
+                onClick={() => handleMuteToggleLocal(bus.id)}
+                data-bus={bus.id}
+              >
+                {muted ? 'MUTED' : 'MUTE'}
+              </button>
             </div>
-
-            <button
-              className={`px-4 py-2 rounded-lg font-semibold transition ${
-                muted
-                  ? 'bg-red-600 hover:bg-red-700 text-white'
-                  : 'bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100'
-              }`}
-              onClick={() => handleMuteToggleLocal(bus.id)}
-              data-bus={bus.id}
-            >
-              MUTE
-            </button>
 
             {/* Per-stem strip (PA/IEM only). Stems come from the loaded song; with no
                 song the canonical 4 render disabled, showing the persisted values. */}
             {(bus.id === 'PA' || bus.id === 'IEM') && onSetStemGain && (
               <div className="w-full border-t border-gray-200 dark:border-gray-700 pt-3 mt-1">
-                <div className="flex gap-2 justify-center flex-wrap">
+                <div className="flex gap-3 justify-start flex-wrap">
                   {(() => {
                     // CDG (single mixdown, PA-only): one "music" strip on PA; IEM has
                     // no stems to offer (§8).

--- a/src/shared/components/MixerPanel.jsx
+++ b/src/shared/components/MixerPanel.jsx
@@ -18,6 +18,7 @@ export function MixerPanel({
   onMuteToggle, // Alias for web compatibility
   onSetStemGain, // (bus, stem, gain 0..1.5) — stem×bus mixer (#49)
   onSetStemMute, // (bus, stem, muted)
+  songType, // 'cdg' renders the single-music-fader variant (§8)
   className = '',
 }) {
   // Support both prop names - prefer mixerState if provided, then mixer, then empty object
@@ -99,6 +100,28 @@ export function MixerPanel({
               <div className="w-full border-t border-gray-200 dark:border-gray-700 pt-3 mt-1">
                 <div className="flex gap-2 justify-center flex-wrap">
                   {(() => {
+                    // CDG (single mixdown, PA-only): one "music" strip on PA; IEM has
+                    // no stems to offer (§8).
+                    if (songType === 'cdg') {
+                      if (bus.id === 'IEM') {
+                        return (
+                          <div className="text-xs text-gray-500 dark:text-gray-400 py-2">
+                            Stems available on M4A Stems songs
+                          </div>
+                        );
+                      }
+                      const entry = resolveStemEntry(state.stemMix, 'PA', 'music');
+                      return (
+                        <StemStrip
+                          bus="PA"
+                          name="music"
+                          gain={entry.gain}
+                          muted={entry.muted}
+                          onGain={onSetStemGain}
+                          onMute={onSetStemMute}
+                        />
+                      );
+                    }
                     const songStems = (state.stems || [])
                       .map((st) => st.name)
                       .filter((n) => n && !isMixdownStem(n));

--- a/src/shared/components/MixerPanel.jsx
+++ b/src/shared/components/MixerPanel.jsx
@@ -71,7 +71,7 @@ export function MixerPanel({
 
             {/* Compact master cluster on one line (a full-width slider + giant MUTE
                 bar read as broken; the fader is a trim, not the star of the row). */}
-            <div className="flex items-center gap-3 flex-wrap">
+            <div className="flex items-center gap-3 flex-wrap justify-center">
               <span className="text-sm text-gray-600 dark:text-gray-400 w-14 shrink-0">Master</span>
               <input
                 type="range"
@@ -105,7 +105,7 @@ export function MixerPanel({
                 song the canonical 4 render disabled, showing the persisted values. */}
             {(bus.id === 'PA' || bus.id === 'IEM') && onSetStemGain && (
               <div className="w-full border-t border-gray-200 dark:border-gray-700 pt-3 mt-1">
-                <div className="flex gap-3 justify-start flex-wrap">
+                <div className="flex gap-3 justify-center flex-wrap">
                   {(() => {
                     // CDG (single mixdown, PA-only): one "music" strip on PA; IEM has
                     // no stems to offer (§8).

--- a/src/shared/components/MixerPanel.jsx
+++ b/src/shared/components/MixerPanel.jsx
@@ -19,6 +19,7 @@ export function MixerPanel({
   onSetStemGain, // (bus, stem, gain 0..1.5) — stem×bus mixer (#49)
   onSetStemMute, // (bus, stem, muted)
   songType, // 'cdg' renders the single-music-fader variant (§8)
+  busExtras, // optional {PA?, IEM?, mic?} JSX per row (device pickers etc. — Electron only)
   className = '',
 }) {
   // Support both prop names - prefer mixerState if provided, then mixer, then empty object
@@ -49,7 +50,7 @@ export function MixerPanel({
   };
 
   return (
-    <div className={`flex gap-4 p-4 ${className}`}>
+    <div className={`flex flex-col gap-4 p-4 ${className}`}>
       {buses.map((bus) => {
         const gain = state[bus.id]?.gain ?? 0;
         const muted = state[bus.id]?.muted ?? false;
@@ -57,12 +58,15 @@ export function MixerPanel({
         return (
           <div
             key={bus.id}
-            className="flex-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4 flex flex-col items-center gap-3"
+            className="w-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4 flex flex-col gap-3"
             data-bus={bus.id}
           >
-            <div className="text-center">
-              <div className="font-semibold text-gray-900 dark:text-gray-100">{bus.label}</div>
-              <div className="text-sm text-gray-600 dark:text-gray-400">{bus.description}</div>
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <div className="font-semibold text-gray-900 dark:text-gray-100">{bus.label}</div>
+                <div className="text-sm text-gray-600 dark:text-gray-400">{bus.description}</div>
+              </div>
+              {busExtras?.[bus.id] || null}
             </div>
 
             <div className="flex flex-col items-center gap-2 w-full">

--- a/src/shared/components/PAQuickMix.jsx
+++ b/src/shared/components/PAQuickMix.jsx
@@ -1,0 +1,103 @@
+/**
+ * PAQuickMix — compact PA mixer for the player drawer (stem×bus mixer #49, §10.1):
+ * PA master fader/mute + one compact strip per stem, so the host can tweak the mix
+ * mid-song without leaving the Player tab. No device pickers here (Audio tab only).
+ *
+ * A second VIEW of the same state, not a second owner: everything renders from the
+ * mixer broadcast (bridge.onMixerChanged) and every change goes out through the
+ * bridge — the Mixer tab, this drawer, and any web admin stay in sync by
+ * construction (§11.13). Collapse state persists with the app's UI settings.
+ */
+
+import { useEffect, useState } from 'react';
+import { StemStrip } from './StemStrip.jsx';
+import { resolveStemEntry, orderStems, CANONICAL_STEMS } from '../utils/stemGain.js';
+import { isMixdownStem } from '../utils/stemClassify.js';
+
+export function PAQuickMix({ bridge }) {
+  const [mixer, setMixer] = useState(null);
+  const [collapsed, setCollapsed] = useState(false);
+
+  useEffect(() => {
+    if (!bridge) return undefined;
+    const unsubscribe = bridge.onMixerChanged?.((m) => setMixer(m));
+    bridge
+      .getMixerState?.()
+      .then((m) => setMixer(m))
+      .catch(() => {});
+    bridge.settingsGet?.('paQuickMixCollapsed').then?.(
+      (v) => setCollapsed(v === '1'),
+      () => {}
+    );
+    return () => unsubscribe && unsubscribe();
+  }, [bridge]);
+
+  const toggleCollapsed = () => {
+    const next = !collapsed;
+    setCollapsed(next);
+    bridge.settingsSet?.('paQuickMixCollapsed', next ? '1' : '0');
+  };
+
+  const pa = mixer?.PA || { gain: 0, muted: false };
+  const songStems = (mixer?.stems || []).map((s) => s.name).filter((n) => n && !isMixdownStem(n));
+  const names = songStems.length ? orderStems(songStems) : CANONICAL_STEMS;
+  const disabled = songStems.length === 0;
+
+  return (
+    <div className="mb-4 border-b border-gray-200 dark:border-gray-700 pb-3">
+      <button
+        className="w-full flex items-center justify-between text-sm font-semibold text-gray-800 dark:text-gray-200 mb-2"
+        onClick={toggleCollapsed}
+      >
+        <span>PA Mix</span>
+        <span className="material-icons text-base">
+          {collapsed ? 'expand_more' : 'expand_less'}
+        </span>
+      </button>
+      {!collapsed && (
+        <>
+          <div className="flex items-center gap-2 mb-2">
+            <span className="text-xs text-gray-600 dark:text-gray-400 w-12">Master</span>
+            <input
+              type="range"
+              className="flex-1 h-1.5 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-600"
+              min="-60"
+              max="12"
+              step="0.5"
+              value={pa.gain ?? 0}
+              onChange={(e) => bridge.setMasterGain?.('PA', parseFloat(e.target.value))}
+              onDoubleClick={() => bridge.setMasterGain?.('PA', 0)}
+            />
+            <button
+              className={`px-2 py-0.5 rounded text-[11px] font-semibold ${
+                pa.muted
+                  ? 'bg-red-600 text-white'
+                  : 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100'
+              }`}
+              onClick={() => bridge.toggleMasterMute?.('PA')}
+            >
+              {pa.muted ? 'MUTED' : 'ON'}
+            </button>
+          </div>
+          <div className="flex gap-1.5 justify-center flex-wrap">
+            {names.map((name) => {
+              const entry = resolveStemEntry(mixer?.stemMix, 'PA', name);
+              return (
+                <StemStrip
+                  key={name}
+                  bus="PA"
+                  name={name}
+                  gain={entry.gain}
+                  muted={entry.muted}
+                  disabled={disabled}
+                  onGain={(bus, stem, gain) => bridge.setStemGain?.(bus, stem, gain)}
+                  onMute={(bus, stem, muted) => bridge.setStemMute?.(bus, stem, muted)}
+                />
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/shared/components/PAQuickMix.jsx
+++ b/src/shared/components/PAQuickMix.jsx
@@ -39,9 +39,10 @@ export function PAQuickMix({ bridge }) {
   };
 
   const pa = mixer?.PA || { gain: 0, muted: false };
+  const isCdg = mixer?.songType === 'cdg';
   const songStems = (mixer?.stems || []).map((s) => s.name).filter((n) => n && !isMixdownStem(n));
-  const names = songStems.length ? orderStems(songStems) : CANONICAL_STEMS;
-  const disabled = songStems.length === 0;
+  const names = isCdg ? ['music'] : songStems.length ? orderStems(songStems) : CANONICAL_STEMS;
+  const disabled = !isCdg && songStems.length === 0;
 
   return (
     <div className="mb-4 border-b border-gray-200 dark:border-gray-700 pb-3">

--- a/src/shared/components/StemStrip.jsx
+++ b/src/shared/components/StemStrip.jsx
@@ -1,0 +1,55 @@
+/**
+ * StemStrip — one per-stem fader+mute for one bus (stem×bus mixer, #49).
+ * Slider is 0-150% (100% = the authored mix, D3); double-click resets to 100%.
+ * Mute is independent of the slider position. Purely presentational: value comes
+ * from the shared mixer state, changes go out through the callbacks (no local
+ * gain state — two mounted views of one fader must never diverge, §11.13).
+ */
+
+export function StemStrip({
+  bus,
+  name,
+  gain = 1,
+  muted = false,
+  disabled = false,
+  onGain,
+  onMute,
+}) {
+  const pct = Math.round(gain * 100);
+  return (
+    <div
+      className={`flex flex-col items-center gap-1 min-w-[64px] ${disabled ? 'opacity-40' : ''}`}
+      data-bus={bus}
+      data-stem={name}
+    >
+      <div className="text-xs font-semibold text-gray-700 dark:text-gray-300 truncate max-w-[72px]">
+        {name}
+      </div>
+      <input
+        type="range"
+        className="w-full h-1.5 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-600"
+        min="0"
+        max="150"
+        step="1"
+        value={pct}
+        disabled={disabled}
+        onChange={(e) => onGain?.(bus, name, parseInt(e.target.value, 10) / 100)}
+        onDoubleClick={() => onGain?.(bus, name, 1)}
+        title={`${name} on ${bus}: ${pct}% (double-click = 100%)`}
+      />
+      <div className="text-[11px] font-mono text-gray-600 dark:text-gray-400">{pct}%</div>
+      <button
+        className={`px-2 py-0.5 rounded text-[11px] font-semibold transition ${
+          muted
+            ? 'bg-red-600 hover:bg-red-700 text-white'
+            : 'bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100'
+        }`}
+        disabled={disabled}
+        onClick={() => onMute?.(bus, name, !muted)}
+        title={muted ? 'Unmute' : 'Mute'}
+      >
+        {muted ? 'MUTED' : 'ON'}
+      </button>
+    </div>
+  );
+}

--- a/src/shared/defaults.js
+++ b/src/shared/defaults.js
@@ -3,10 +3,19 @@
  * Single source of truth - import this everywhere instead of defining defaults inline
  */
 
+import { seedDefaultStemMix } from './utils/stemGain.js';
+
 export const MIXER_DEFAULTS = {
   PA: { gain: 0, muted: false, mono: false },
   IEM: { gain: 0, muted: true, mono: true },
   mic: { gain: 0, muted: true },
+  // Per-bus per-stem user mix (stem×bus mixer, issue #49): linear gain multiplier on
+  // the authored trim (1.0 = authored mix) + independent mute, per D1 defaults:
+  // PA plays the backing mix (vocals muted), IEM is the guide-vocal bus (vocals on,
+  // rest muted; the IEM MASTER above stays muted as the no-second-device guard).
+  stemMix: seedDefaultStemMix(),
+  // Legacy flat per-stem shape used by the dormant main-process mixer stub; superseded
+  // by stemMix (removed along with the stub in the control-plane step).
   stems: {
     vocals: { gain: 0, muted: false },
     instrumental: { gain: 0, muted: false },

--- a/src/shared/hooks/useAudioEngine.js
+++ b/src/shared/hooks/useAudioEngine.js
@@ -71,9 +71,20 @@ export function useAudioEngine() {
       kaiPlayer.setMasterMute(bus, muted);
     };
 
+    // Per-stem events carry the RESOLVED value; apply with report=false so the
+    // renderer does not echo the change back to main (no-echo discipline, §9.3).
+    const handleStemGain = (event, { bus, stem, gain }) => {
+      kaiPlayer.setStemGain(bus, stem, gain, false);
+    };
+    const handleStemMute = (event, { bus, stem, muted }) => {
+      kaiPlayer.setStemMute(bus, stem, muted, false);
+    };
+
     window.kaiAPI.mixer.onSetMasterGain(handleSetMasterGain);
     window.kaiAPI.mixer.onToggleMasterMute(handleToggleMasterMute);
     window.kaiAPI.mixer.onSetMasterMute(handleSetMasterMute);
+    if (window.kaiAPI.mixer.onStemGain) window.kaiAPI.mixer.onStemGain(handleStemGain);
+    if (window.kaiAPI.mixer.onStemMute) window.kaiAPI.mixer.onStemMute(handleStemMute);
 
     console.log('✅ Mixer IPC listeners registered');
 

--- a/src/shared/ipcContracts.js
+++ b/src/shared/ipcContracts.js
@@ -51,10 +51,16 @@ export const AUDIO_CHANNELS = {
 export const MIXER_CHANNELS = {
   SET_MASTER_GAIN: 'mixer:setMasterGain',
   TOGGLE_MASTER_MUTE: 'mixer:toggleMasterMute',
+  // Per-bus per-stem mixer (stem×bus mixer, #49)
+  SET_STEM_GAIN: 'mixer:setStemGain',
+  SET_STEM_MUTE: 'mixer:setStemMute',
+  TOGGLE_STEM_MUTE: 'mixer:toggleStemMute',
 
   // Events (main → renderer)
   STATE_CHANGE: 'mixer:state',
   SET_MASTER_MUTE: 'mixer:setMasterMute',
+  STEM_GAIN: 'mixer:stemGain',
+  STEM_MUTE: 'mixer:stemMute',
 };
 
 // ============================================================================

--- a/src/shared/services/mixerService.js
+++ b/src/shared/services/mixerService.js
@@ -5,6 +5,8 @@
  * to ensure consistent mixer control across all interfaces.
  */
 
+import { clampStemGain, resolveStemEntry } from '../utils/stemGain.js';
+
 /**
  * Get current mixer state
  * @param {Object} appState - Application state instance
@@ -168,5 +170,82 @@ export function setMasterMute(mainApp, bus, muted) {
       success: false,
       error: error.message,
     };
+  }
+}
+
+/**
+ * Set a per-bus per-stem gain (stem×bus mixer, #49).
+ * @param {Object} mainApp - Main application instance
+ * @param {string} bus - 'PA' | 'IEM'
+ * @param {string} stem - stem name (canonical or file-specific)
+ * @param {number} gain - linear multiplier 0..1.5 (1.0 = authored mix); clamped
+ */
+export function setStemGain(mainApp, bus, stem, gain) {
+  try {
+    if ((bus !== 'PA' && bus !== 'IEM') || !stem || typeof gain !== 'number') {
+      return { success: false, error: 'bus (PA/IEM), stem, and numeric gain required' };
+    }
+    const clamped = clampStemGain(gain);
+    const currentMixer = mainApp.appState.state.mixer;
+    const entry = resolveStemEntry(currentMixer.stemMix, bus, stem);
+    const updatedMixer = {
+      ...currentMixer,
+      stemMix: {
+        ...currentMixer.stemMix,
+        [bus]: { ...currentMixer.stemMix?.[bus], [stem]: { ...entry, gain: clamped } },
+      },
+    };
+    mainApp.appState.updateMixerState(updatedMixer);
+    // Renderer applies the audio change (no-echo: it must not re-report this).
+    mainApp.sendToRenderer('mixer:stemGain', { bus, stem, gain: clamped });
+    return { success: true, bus, stem, gain: clamped };
+  } catch (error) {
+    console.error('Error setting stem gain:', error);
+    return { success: false, error: error.message };
+  }
+}
+
+/**
+ * Mute/unmute one stem on one bus (independent of the slider value).
+ */
+export function setStemMute(mainApp, bus, stem, muted) {
+  try {
+    if ((bus !== 'PA' && bus !== 'IEM') || !stem) {
+      return { success: false, error: 'bus (PA/IEM) and stem required' };
+    }
+    const resolved = Boolean(muted);
+    const currentMixer = mainApp.appState.state.mixer;
+    const entry = resolveStemEntry(currentMixer.stemMix, bus, stem);
+    const updatedMixer = {
+      ...currentMixer,
+      stemMix: {
+        ...currentMixer.stemMix,
+        [bus]: { ...currentMixer.stemMix?.[bus], [stem]: { ...entry, muted: resolved } },
+      },
+    };
+    mainApp.appState.updateMixerState(updatedMixer);
+    mainApp.sendToRenderer('mixer:stemMute', { bus, stem, muted: resolved });
+    return { success: true, bus, stem, muted: resolved };
+  } catch (error) {
+    console.error('Error setting stem mute:', error);
+    return { success: false, error: error.message };
+  }
+}
+
+/**
+ * Toggle a stem's mute on one bus; resolves the boolean here and emits the
+ * RESOLVED value (the renderer must never toggle again — same discipline as
+ * toggleMasterMute). Unknown stems resolve from the runtime default entry.
+ */
+export function toggleStemMute(mainApp, bus, stem) {
+  try {
+    if ((bus !== 'PA' && bus !== 'IEM') || !stem) {
+      return { success: false, error: 'bus (PA/IEM) and stem required' };
+    }
+    const current = resolveStemEntry(mainApp.appState.state.mixer.stemMix, bus, stem);
+    return setStemMute(mainApp, bus, stem, !current.muted);
+  } catch (error) {
+    console.error('Error toggling stem mute:', error);
+    return { success: false, error: error.message };
   }
 }

--- a/src/shared/services/mixerService.test.js
+++ b/src/shared/services/mixerService.test.js
@@ -397,3 +397,70 @@ describe('mixerService', () => {
     });
   });
 });
+
+describe('stem×bus mixer (#49)', () => {
+  let mainApp;
+
+  beforeEach(() => {
+    mainApp = new MockMainApp();
+    // The real updateMixerState writes state; these tests assert on the written
+    // shape and toggle off it, so make the mock actually write.
+    mainApp.appState.updateMixerState.mockImplementation((mixer) => {
+      mainApp.appState.state.mixer = mixer;
+    });
+  });
+
+  describe('setStemGain', () => {
+    it('validates bus, stem, and gain', () => {
+      expect(mixerService.setStemGain(mainApp, 'booth', 'drums', 1).success).toBe(false);
+      expect(mixerService.setStemGain(mainApp, 'PA', '', 1).success).toBe(false);
+      expect(mixerService.setStemGain(mainApp, 'PA', 'drums', 'loud').success).toBe(false);
+      expect(mainApp.sendToRenderer).not.toHaveBeenCalled();
+    });
+
+    it('clamps, writes state, and emits the resolved value', () => {
+      const result = mixerService.setStemGain(mainApp, 'PA', 'drums', 9);
+      expect(result).toMatchObject({ success: true, bus: 'PA', stem: 'drums', gain: 1.5 });
+      expect(mainApp.appState.state.mixer.stemMix.PA.drums.gain).toBe(1.5);
+      expect(mainApp.sendToRenderer).toHaveBeenCalledWith('mixer:stemGain', {
+        bus: 'PA',
+        stem: 'drums',
+        gain: 1.5,
+      });
+    });
+
+    it('preserves the mute flag when changing gain', () => {
+      mixerService.setStemMute(mainApp, 'PA', 'vocals', true);
+      mixerService.setStemGain(mainApp, 'PA', 'vocals', 0.7);
+      expect(mainApp.appState.state.mixer.stemMix.PA.vocals).toEqual({ gain: 0.7, muted: true });
+    });
+  });
+
+  describe('setStemMute / toggleStemMute', () => {
+    it('sets and emits the explicit value', () => {
+      const result = mixerService.setStemMute(mainApp, 'IEM', 'drums', false);
+      expect(result).toMatchObject({ success: true, muted: false });
+      expect(mainApp.sendToRenderer).toHaveBeenCalledWith('mixer:stemMute', {
+        bus: 'IEM',
+        stem: 'drums',
+        muted: false,
+      });
+    });
+
+    it('toggle resolves from state and emits the RESOLVED value (never a toggle)', () => {
+      // unknown stem on PA resolves from the runtime default (unmuted for non-vocals)
+      const first = mixerService.toggleStemMute(mainApp, 'PA', 'kazoo');
+      expect(first).toMatchObject({ success: true, muted: true });
+      const second = mixerService.toggleStemMute(mainApp, 'PA', 'kazoo');
+      expect(second).toMatchObject({ success: true, muted: false });
+      // vocal stems' runtime default is muted-on-PA → first toggle unmutes
+      const vox = mixerService.toggleStemMute(mainApp, 'PA', 'vocals');
+      expect(vox).toMatchObject({ success: true, muted: false });
+    });
+
+    it('validates bus and stem', () => {
+      expect(mixerService.setStemMute(mainApp, 'mic', 'drums', true).success).toBe(false);
+      expect(mixerService.toggleStemMute(mainApp, 'PA', '').success).toBe(false);
+    });
+  });
+});

--- a/src/shared/utils/stemClassify.js
+++ b/src/shared/utils/stemClassify.js
@@ -1,0 +1,50 @@
+/**
+ * Stem classification heuristics — pure, name-keyword based.
+ *
+ * Extracted verbatim from KAIPlayer (isVocalStem/isMixdownStem/isMelodicStem) so the
+ * rules are unit-testable and shared by the stem×bus mixer (runtime defaults for
+ * unknown stems, §5.1 of the plan) without touching Web Audio. KAIPlayer switches to
+ * these in the audio-graph step; keep the logic IDENTICAL to what shipped there.
+ */
+
+const VOCAL_KEYWORDS = ['vocals', 'vocal', 'voice', 'lead', 'singing', 'vox'];
+
+export function isVocalStem(stemName) {
+  const lowerName = String(stemName || '').toLowerCase();
+  return VOCAL_KEYWORDS.some((keyword) => lowerName.includes(keyword));
+}
+
+// Mixdown stems contain the full mix and are skipped when individual stems exist.
+const MIXDOWN_KEYWORDS = ['mixdown', 'mix', 'master', 'full mix', 'stereo mix'];
+
+export function isMixdownStem(stemName) {
+  const lowerName = String(stemName || '').toLowerCase();
+  return MIXDOWN_KEYWORDS.some(
+    (keyword) =>
+      lowerName === keyword ||
+      lowerName.includes(`_${keyword}`) ||
+      lowerName.includes(`${keyword}_`)
+  );
+}
+
+// True for stems containing melodic instruments (typically "other") — the best
+// pitch-detection melody reference. Unknown stems default to melodic.
+export function isMelodicStem(stemName) {
+  const lowerName = String(stemName || '').toLowerCase();
+
+  if (
+    lowerName.includes('other') ||
+    lowerName.includes('music') ||
+    lowerName.includes('instrumental') ||
+    lowerName.includes('accompaniment') ||
+    lowerName.includes('melody')
+  ) {
+    return true;
+  }
+
+  if (isVocalStem(stemName)) return false;
+  if (lowerName.includes('drum') || lowerName.includes('percussion')) return false;
+  if (lowerName.includes('bass')) return false;
+
+  return true;
+}

--- a/src/shared/utils/stemGain.js
+++ b/src/shared/utils/stemGain.js
@@ -1,0 +1,129 @@
+/**
+ * Stem×bus mixer — the effective-gain formula and default/merge logic, as PURE
+ * functions (no Web Audio), per the audio enhancement plan §5:
+ *
+ *   stemNodeGain(bus, stem) =
+ *       dbToLinear(stem.fileTrimDb)          // authored mix
+ *     × stemMix[bus][stem].gain              // user slider 0..1.5 (1.0 = authored)
+ *     × (stemMix[bus][stem].muted ? 0 : 1)   // per-stem mute
+ *
+ * Bus master gain/mute stay on the bus masterGain node and must NOT appear here
+ * (double-applying was gotcha #9). The `backup:PA` punchthrough overlays PA-vocals
+ * only (D2): while active, the node targets max(userLevel, authored level) — it can
+ * ADD vocals for the line but never fights the user downward.
+ *
+ * This module is the single init path for every per-stem gain node: the graph is
+ * rebuilt on every play(), so nodes are always initialized from this formula plus
+ * the persisted stemMix state (plan §11.2).
+ */
+
+import { isVocalStem } from './stemClassify.js';
+
+/** Canonical display/UI order; unknown stems append in file order after these. */
+export const CANONICAL_STEMS = ['drums', 'bass', 'other', 'vocals'];
+
+/** Slider range: 0..150% (unity 1.0 = the authored mix; headroom for jam-along). */
+export const STEM_GAIN_MAX = 1.5;
+
+export function dbToLinear(db) {
+  return Math.pow(10, (Number(db) || 0) / 20);
+}
+
+/** Clamp a user slider value into 0..STEM_GAIN_MAX; non-numbers become unity. */
+export function clampStemGain(gain) {
+  const g = Number(gain);
+  if (!Number.isFinite(g)) return 1;
+  return Math.min(STEM_GAIN_MAX, Math.max(0, g));
+}
+
+/**
+ * Runtime default entry for a stem the persisted stemMix doesn't know (§5.1):
+ * audible on PA, muted on IEM — flipped for vocal stems (muted on PA, audible on
+ * IEM), preserving the D1 defaults' spirit for unusual stem names.
+ */
+export function defaultStemEntry(bus, stemName) {
+  const vocal = isVocalStem(stemName);
+  const mutedOnIem = bus === 'IEM';
+  return { gain: 1, muted: vocal ? !mutedOnIem : mutedOnIem };
+}
+
+/** The persisted entry for (bus, stem), or the runtime default. Never mutates. */
+export function resolveStemEntry(stemMix, bus, stemName) {
+  const entry = stemMix?.[bus]?.[stemName];
+  if (entry && typeof entry === 'object') {
+    return { gain: clampStemGain(entry.gain), muted: Boolean(entry.muted) };
+  }
+  return defaultStemEntry(bus, stemName);
+}
+
+/**
+ * The effective gain for one stem's gain node on one bus (§5.2 + §7).
+ *
+ * @param {Object} opts
+ * @param {number} [opts.fileTrimDb=0]  authored per-stem trim from song metadata (dB)
+ * @param {number} [opts.userGain=1]    user slider (linear multiplier, clamped 0..1.5)
+ * @param {boolean} [opts.muted=false]  per-stem-per-bus mute
+ * @param {boolean} [opts.punchthroughActive=false]  backup:PA overlay (PA vocals only)
+ * @returns {number} linear gain for the node
+ */
+export function effectiveStemGain({
+  fileTrimDb = 0,
+  userGain = 1,
+  muted = false,
+  punchthroughActive = false,
+} = {}) {
+  const authored = dbToLinear(fileTrimDb);
+  const userLevel = authored * clampStemGain(userGain) * (muted ? 0 : 1);
+  if (!punchthroughActive) return userLevel;
+  // D2: punchthrough can only ADD vocals — the authored full level wins only when
+  // it's above what the user already set.
+  return Math.max(userLevel, authored);
+}
+
+/**
+ * D1 seed: the defaults table for a fresh profile (canonical 4 stems).
+ * PA plays the backing mix (vocals muted); IEM is the guide-vocal bus (vocals on,
+ * everything else muted; the IEM MASTER stays muted separately as the opt-in guard).
+ */
+export function seedDefaultStemMix() {
+  const seed = { PA: {}, IEM: {} };
+  for (const stem of CANONICAL_STEMS) {
+    seed.PA[stem] = defaultStemEntry('PA', stem);
+    seed.IEM[stem] = defaultStemEntry('IEM', stem);
+  }
+  return seed;
+}
+
+/**
+ * Merge a persisted stemMix over the D1 seed: unknown buses are dropped, unknown
+ * stem keys are kept (files with unusual stems persist the user's choices), gains
+ * are clamped and mutes coerced. Absence of persisted state yields the pure seed
+ * (§5.3 migration: no versioning needed, old shape is a strict subset).
+ */
+export function mergeStemMix(persisted) {
+  const out = seedDefaultStemMix();
+  for (const bus of ['PA', 'IEM']) {
+    const savedBus = persisted?.[bus];
+    if (!savedBus || typeof savedBus !== 'object') continue;
+    for (const [stemName, entry] of Object.entries(savedBus)) {
+      if (!entry || typeof entry !== 'object') continue;
+      out[bus][stemName] = {
+        gain: clampStemGain(entry.gain),
+        muted: Boolean(entry.muted),
+      };
+    }
+  }
+  return out;
+}
+
+/**
+ * Order stem names for display: canonical order first, then the rest in file
+ * order. Mixdown stems are the caller's concern (they are filtered from playback
+ * and from the UI before ordering).
+ */
+export function orderStems(stemNames) {
+  const names = [...(stemNames || [])];
+  const canonical = CANONICAL_STEMS.filter((c) => names.includes(c));
+  const rest = names.filter((n) => !CANONICAL_STEMS.includes(n));
+  return [...canonical, ...rest];
+}

--- a/src/shared/utils/stemGain.test.js
+++ b/src/shared/utils/stemGain.test.js
@@ -1,0 +1,172 @@
+/**
+ * Stem×bus mixer pure logic (plan §12 unit list): effective-gain matrix,
+ * punchthrough max() overlay, unknown-stem runtime defaults, D1 seed, persisted
+ * merge, display ordering, and the classification heuristics they depend on.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  dbToLinear,
+  clampStemGain,
+  effectiveStemGain,
+  defaultStemEntry,
+  resolveStemEntry,
+  seedDefaultStemMix,
+  mergeStemMix,
+  orderStems,
+  CANONICAL_STEMS,
+  STEM_GAIN_MAX,
+} from './stemGain.js';
+import { isVocalStem, isMixdownStem, isMelodicStem } from './stemClassify.js';
+
+describe('dbToLinear / clampStemGain', () => {
+  it('converts dB trims', () => {
+    expect(dbToLinear(0)).toBe(1);
+    expect(dbToLinear(-6)).toBeCloseTo(0.501, 2);
+    expect(dbToLinear(6)).toBeCloseTo(1.995, 2);
+    expect(dbToLinear(undefined)).toBe(1); // missing trim = authored unity
+  });
+
+  it('clamps sliders to 0..1.5 and coerces junk to unity', () => {
+    expect(clampStemGain(0.5)).toBe(0.5);
+    expect(clampStemGain(-1)).toBe(0);
+    expect(clampStemGain(9)).toBe(STEM_GAIN_MAX);
+    expect(clampStemGain('nope')).toBe(1);
+    expect(clampStemGain(undefined)).toBe(1);
+  });
+});
+
+describe('effectiveStemGain (§5.2 formula)', () => {
+  it('multiplies trim × user × mute', () => {
+    // authored -6dB, slider 50% → quarter-ish level
+    expect(effectiveStemGain({ fileTrimDb: -6, userGain: 0.5 })).toBeCloseTo(0.2505, 3);
+    // unity everything
+    expect(effectiveStemGain({})).toBe(1);
+    // mute wins regardless of slider
+    expect(effectiveStemGain({ userGain: 1.5, muted: true })).toBe(0);
+  });
+
+  it('does NOT include bus master terms (gotcha #9: they live on masterGain)', () => {
+    // the formula has no master inputs at all — same value whatever the master does
+    expect(effectiveStemGain({ fileTrimDb: 0, userGain: 1 })).toBe(1);
+  });
+
+  describe('backup:PA punchthrough overlay (D2: only ever ADDS vocals)', () => {
+    it('raises user-muted vocals to the authored level while active', () => {
+      const val = effectiveStemGain({ fileTrimDb: -3, muted: true, punchthroughActive: true });
+      expect(val).toBeCloseTo(dbToLinear(-3), 6); // full authored level
+    });
+
+    it('is a no-op when the user already sits above authored', () => {
+      const val = effectiveStemGain({ fileTrimDb: 0, userGain: 1.2, punchthroughActive: true });
+      expect(val).toBeCloseTo(1.2, 6); // user wins — max(1.2, 1.0)
+    });
+
+    it('restores the user level when inactive (40% case from the plan)', () => {
+      const during = effectiveStemGain({ fileTrimDb: 0, userGain: 0.4, punchthroughActive: true });
+      const after = effectiveStemGain({ fileTrimDb: 0, userGain: 0.4, punchthroughActive: false });
+      expect(during).toBe(1); // line plays at authored 100%
+      expect(after).toBeCloseTo(0.4, 6); // returns to the slider
+    });
+  });
+});
+
+describe('runtime defaults for unknown stems (§5.1)', () => {
+  it('non-vocal: audible on PA, muted on IEM', () => {
+    expect(defaultStemEntry('PA', 'guitar')).toEqual({ gain: 1, muted: false });
+    expect(defaultStemEntry('IEM', 'guitar')).toEqual({ gain: 1, muted: true });
+  });
+
+  it('vocal detection flips the pair', () => {
+    expect(defaultStemEntry('PA', 'Lead Vox')).toEqual({ gain: 1, muted: true });
+    expect(defaultStemEntry('IEM', 'Lead Vox')).toEqual({ gain: 1, muted: false });
+  });
+
+  it('resolveStemEntry falls back to the runtime default and clamps stored values', () => {
+    const stemMix = { PA: { drums: { gain: 99, muted: 0 } } };
+    expect(resolveStemEntry(stemMix, 'PA', 'drums')).toEqual({ gain: STEM_GAIN_MAX, muted: false });
+    expect(resolveStemEntry(stemMix, 'IEM', 'harmonica')).toEqual({ gain: 1, muted: true });
+    expect(resolveStemEntry(undefined, 'PA', 'vocals')).toEqual({ gain: 1, muted: true });
+  });
+});
+
+describe('D1 seed + merge (§5.3)', () => {
+  it('seed matches the D1 defaults table', () => {
+    const seed = seedDefaultStemMix();
+    expect(Object.keys(seed.PA)).toEqual(CANONICAL_STEMS);
+    expect(seed.PA).toMatchObject({
+      drums: { muted: false },
+      bass: { muted: false },
+      other: { muted: false },
+      vocals: { muted: true },
+    });
+    expect(seed.IEM).toMatchObject({
+      drums: { muted: true },
+      bass: { muted: true },
+      other: { muted: true },
+      vocals: { muted: false },
+    });
+    // all sliders default to 100% = authored mix (D3)
+    for (const bus of ['PA', 'IEM'])
+      for (const stem of CANONICAL_STEMS) expect(seed[bus][stem].gain).toBe(1);
+  });
+
+  it('no persisted state → pure seed', () => {
+    expect(mergeStemMix(undefined)).toEqual(seedDefaultStemMix());
+    expect(mergeStemMix(null)).toEqual(seedDefaultStemMix());
+  });
+
+  it('persisted values override the seed; unknown stems survive; junk is sanitized', () => {
+    const merged = mergeStemMix({
+      PA: { vocals: { gain: 0.8, muted: false }, kazoo: { gain: 2.4, muted: 'yes' } },
+      IEM: { drums: 'garbage' },
+      booth: { drums: { gain: 1 } }, // unknown bus dropped
+    });
+    expect(merged.PA.vocals).toEqual({ gain: 0.8, muted: false }); // user's choice
+    expect(merged.PA.kazoo).toEqual({ gain: STEM_GAIN_MAX, muted: true }); // clamped + coerced
+    expect(merged.PA.drums).toEqual({ gain: 1, muted: false }); // seed preserved
+    expect(merged.IEM.drums).toEqual({ gain: 1, muted: true }); // junk entry ignored → seed
+    expect(merged.booth).toBeUndefined();
+  });
+
+  it('round-trips: merge(seed) === seed', () => {
+    expect(mergeStemMix(seedDefaultStemMix())).toEqual(seedDefaultStemMix());
+  });
+});
+
+describe('orderStems', () => {
+  it('canonical order first, then file order', () => {
+    expect(orderStems(['kazoo', 'vocals', 'bass', 'theremin', 'drums'])).toEqual([
+      'drums',
+      'bass',
+      'vocals',
+      'kazoo',
+      'theremin',
+    ]);
+    expect(orderStems([])).toEqual([]);
+    expect(orderStems(undefined)).toEqual([]);
+  });
+});
+
+describe('stemClassify (exact port of the KAIPlayer heuristics)', () => {
+  it('vocal detection', () => {
+    for (const n of ['vocals', 'Lead Vocals', 'VOX', 'backing voice', 'singing'])
+      expect(isVocalStem(n)).toBe(true);
+    for (const n of ['drums', 'bass', 'other']) expect(isVocalStem(n)).toBe(false);
+  });
+
+  it('mixdown detection (exact / underscore-delimited only)', () => {
+    for (const n of ['mixdown', 'mix', 'master', 'stereo mix', 'drums_mix', 'mix_stereo'])
+      expect(isMixdownStem(n)).toBe(true);
+    // 'remix' contains 'mix' but not delimited → NOT a mixdown (matches shipped rules)
+    expect(isMixdownStem('remix')).toBe(false);
+    expect(isMixdownStem('drums')).toBe(false);
+  });
+
+  it('melodic detection', () => {
+    for (const n of ['other', 'instrumental', 'melody', 'accompaniment', 'music'])
+      expect(isMelodicStem(n)).toBe(true);
+    for (const n of ['vocals', 'drums', 'percussion', 'bass']) expect(isMelodicStem(n)).toBe(false);
+    expect(isMelodicStem('theremin')).toBe(true); // unknown defaults to melodic
+  });
+});

--- a/src/web/App.jsx
+++ b/src/web/App.jsx
@@ -530,6 +530,8 @@ export function App() {
             mixer={mixer}
             onGainChange={handleGainChange}
             onMuteToggle={handleMuteToggle}
+            onSetStemGain={(bus, stem, gain) => bridge.setStemGain(bus, stem, gain)}
+            onSetStemMute={(bus, stem, muted) => bridge.setStemMute(bus, stem, muted)}
           />
         </div>
 

--- a/src/web/App.jsx
+++ b/src/web/App.jsx
@@ -532,6 +532,7 @@ export function App() {
             onMuteToggle={handleMuteToggle}
             onSetStemGain={(bus, stem, gain) => bridge.setStemGain(bus, stem, gain)}
             onSetStemMute={(bus, stem, muted) => bridge.setStemMute(bus, stem, muted)}
+            songType={mixer?.songType}
           />
         </div>
 

--- a/src/web/adapters/WebBridge.js
+++ b/src/web/adapters/WebBridge.js
@@ -123,6 +123,20 @@ export class WebBridge extends BridgeInterface {
     });
   }
 
+  async setStemGain(bus, stem, gain) {
+    return await this._fetch('/mixer/stem', {
+      method: 'POST',
+      body: JSON.stringify({ bus, stem, gain }),
+    });
+  }
+
+  async setStemMute(bus, stem, muted) {
+    return await this._fetch('/mixer/stem', {
+      method: 'POST',
+      body: JSON.stringify({ bus, stem, muted }),
+    });
+  }
+
   async setMasterMute(bus, muted) {
     return await this._fetch('/mixer/master-mute', {
       method: 'POST',

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -21,6 +21,8 @@ export default defineConfig({
         'src/shared/services/**/*.js',
         'src/shared/creator/**/*.js',
         'src/shared/formatUtils.js',
+        'src/shared/utils/stemGain.js',
+        'src/shared/utils/stemClassify.js',
         'src/main/creator/creatorJob.js',
         'src/main/creator/hostCreateRelay.js',
         // NOTE: audioInfo.js is intentionally NOT measured — its tests are gated on


### PR DESCRIPTION
Implements #49 per `audio_enhancement_plan.md`: independent per-stem control on each output bus.

- **Dual always-running sources** in kaiPlayer: every stem feeds both the PA and IEM graphs; effective gain = trim × user gain (0..1.5) × mute, punchthrough = max(user, authored)
- **Defaults**: PA has vocals muted (karaoke), IEM has vocals on with master muted, so the singer hears the guide vocal without it leaking to the room
- **Stem strips** in the Audio tab (per-bus rows), compact master cluster, PA quick-mix drawer; CDG songs get the simplified variant (music-only node) driven by `songType` riding the mixer broadcast
- **Control plane**: mixerService stem functions, IPC + preload + contracts, `POST /admin/mixer/stem`, both bridges; no-echo (report=false) on the engine side
- **Persistence**: `stemMix` persisted via statePersistence with the rest of the mixer state
- Utils `stemGain.js` / `stemClassify.js` with tests (+18), mixerService tests

Rebased onto current main (post v0.7.2-prep, post .kai sweep): clean, zero conflicts, 369/369 tests, both bundles build.

UI was polished against the live web admin during development. Remaining gate before merge: the §12 listening matrix (human ears on PA/IEM routing).