### PR TITLE
v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ npm run build:mac
 npm start
 ```
 
+Notes:
+
+- On Linux, `npm start` / `npm run dev` launch through `scripts/start-electron.mjs`, which repairs stale display env vars (`WAYLAND_DISPLAY`, `DISPLAY`, `XAUTHORITY`) before Electron spawns — so launching from long-lived tmux/screen shells just works.
+- Only one instance runs at a time; a second launch focuses the existing window and exits.
+- Song creation (stem separation) requires a working WebGPU adapter (a real GPU). There is no CPU fallback.
+
 ---
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npx loukai-app
   - Compatible with DJ software (Traktor, Mixxx) via standard NI Stems metadata
   - Smaller file sizes than legacy formats
   - Embedded lyrics with word-level timing in custom atoms
-- **Real-Time Stem Control**: Individual volume, mute, and solo controls for vocals, drums, bass, and other stems
+- **Real-Time Stem Control**: Per-stem volume and mute on each output bus (PA and IEM monitors) — run a vocals-on monitor mix for the singer while the room hears the karaoke mix
 - **Legacy Format Support**: CDG/MP3 pairs
 - **Dual Output Routing**: Independent PA and IEM (in-ear monitor) outputs with per-stem routing
 - **High-Quality Audio**: Web Audio API with real-time processing and pitch correction

--- a/com.loukai.app.metainfo.xml
+++ b/com.loukai.app.metainfo.xml
@@ -48,16 +48,18 @@
   <content_rating type="oars-1.1" />
 
   <releases>
-    <release version="0.7.2" date="2026-07-18">
+    <release version="0.8.0" date="2026-07-18">
       <description>
-        <p>Rock-solid Linux launch and a smarter creator</p>
+        <p>Stem mixer on every output, and a rock-solid Linux launch</p>
         <ul>
-          <li>Linux: the app now runs on native Wayland with GPU creation AND casting to phones/browser viewers working at the same time</li>
-          <li>Launching from a terminal always brings up the window; a second launch focuses the running app instead of failing</li>
+          <li>NEW: per-stem volume and mute on each output bus - give the singer a vocals-on monitor mix while the room hears the karaoke mix, live from the web admin</li>
+          <li>Monitors (IEM) start fully muted so nothing leaks on single-sound-card setups; enable exactly the stems you want</li>
+          <li>Linux: native Wayland with GPU song creation AND casting to phones/browser viewers working at the same time; terminal launches always bring up the window</li>
+          <li>A second launch focuses the running app instead of failing</li>
           <li>Better default lyrics model (Whisper large-v3-turbo, multilingual with language auto-detect)</li>
           <li>Stem separation runs on the GPU or fails fast with a clear message - no more silent hour-long CPU runs</li>
           <li>Newly created songs appear in the app library instantly - no manual sync</li>
-          <li>Queue Load works for .stem.mp4 files; editor timestamp fields no longer eat keystrokes</li>
+          <li>Queue Load works for .stem.mp4 files; editor timestamp fields no longer eat keystrokes; legacy .kai code paths removed</li>
         </ul>
       </description>
     </release>

--- a/com.loukai.app.metainfo.xml
+++ b/com.loukai.app.metainfo.xml
@@ -48,6 +48,19 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="0.7.2" date="2026-07-18">
+      <description>
+        <p>Rock-solid Linux launch and a smarter creator</p>
+        <ul>
+          <li>Linux: the app now runs on native Wayland with GPU creation AND casting to phones/browser viewers working at the same time</li>
+          <li>Launching from a terminal always brings up the window; a second launch focuses the running app instead of failing</li>
+          <li>Better default lyrics model (Whisper large-v3-turbo, multilingual with language auto-detect)</li>
+          <li>Stem separation runs on the GPU or fails fast with a clear message - no more silent hour-long CPU runs</li>
+          <li>Newly created songs appear in the app library instantly - no manual sync</li>
+          <li>Queue Load works for .stem.mp4 files; editor timestamp fields no longer eat keystrokes</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.7.0" date="2026-07-17">
       <description>
         <p>WebGPU creator everywhere, AIFF support, and a fully pure-JS runtime</p>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -343,36 +343,39 @@ worklets).
 ```
 PA context (sinkId: PA device)                 IEM context (sinkId: IEM device)
 ──────────────────────────────                 ────────────────────────────────
-non-vocal stem sources ─► per-stem gain ─┐     vocal stem sources ─► per-stem gain
-vocal "backup" source ─► vocalsPAGain(0) ─┤        └─(iemMonoVocals?)─► ChannelMerger(1)
-mic ─► micGain ─► [auto-tune chain] ──────┤                              │
-                                          ▼                              ▼
-                                    PA.masterGain                  IEM.masterGain
-                                     ├─► destination (PA device)    └─► destination (IEM device)
-                                     └─► streamDestination (MediaStream → WebRTC viewers)
+EVERY stem ─► per-stem gain (PA) ─────────┐    EVERY stem ─► per-stem gain (IEM)
+mic ─► micGain ─► [auto-tune chain] ──────┤        └─(iemMonoVocals?)─► ChannelMerger(1)
+                                          ▼                              │
+                                    PA.masterGain                        ▼
+                                     ├─► destination (PA device)   IEM.masterGain
+                                     └─► streamDestination           └─► destination (IEM device)
+                                          (MediaStream → WebRTC viewers)
        (per-source pre-gain tap ─► AnalyserNode ─► Butterchurn)
 ```
 
-### Routing rules
+### Routing rules (stem×bus mixer, #49)
 
-- Stems are classified **by name keywords** at source-start time
-  (`isVocalStem`: vocals/vocal/voice/lead/singing/vox). Vocals get sources in the
-  IEM context; everything else gets sources in the PA context. `AudioBuffer`s are
-  decoded once (PA context) and shared — buffers are context-agnostic.
-- **IEM carries the recorded guide-vocal stem, never the live mic.** It defaults
-  to muted (user opts in) and mono-sums vocals through a `ChannelMerger(1)` by
-  default ("single earpiece" mode).
-- **The live mic goes to PA only** and lives in the PA context. Mic → IEM would
-  require bridging contexts (nodes cannot span `AudioContext`s).
-- **`backup:PA` punchthrough**: the vocal stem is *always also playing* into the
-  PA context through `vocalsPAGain` at gain 0; lyric lines tagged
-  `singer: "backup:PA"` ramp it up/down over 50 ms (`linearRampToValueAtTime`).
-  This always-running-muted-source + gain-ramp pattern is the template for any
-  glitch-free rerouting; other topology changes (e.g. IEM mono toggle) do a full
-  stop-and-rebuild of sources.
-- Mixer model: three master faders (PA / IEM / mic) mapped to `masterGain` nodes
-  and `microphoneGain`. Per-stem gains are static dB trims from song metadata;
-  there is no runtime per-stem fader/mute/solo in the audio path.
+- **Every stem plays into BOTH contexts, always** (dual always-running sources).
+  Audibility is decided per `(bus, stem)` by a gain formula, not by topology:
+  `effective = trim(dB from song metadata) × userGain(0..1.5) × mute`. Mixer
+  changes are glitch-free gain ramps; no source rebuilds.
+- **Defaults**: PA plays music with vocals muted (karaoke); **IEM starts fully
+  muted** — a second sound card can't be assumed, so monitors are an explicit
+  opt-in per stem. Stems are classified by name keywords (`isVocalStem`:
+  vocals/vocal/voice/lead/singing/vox) for the defaults and for punchthrough.
+- **`backup:PA` punchthrough**: lyric lines tagged `singer: "backup:PA"` ramp
+  the PA vocal stem over 50 ms to `max(userGain, authored)` — an authored
+  punchthrough can't be silenced by a user mute, and a user boost survives it.
+- **The live mic goes to PA only** and lives in the PA context (nodes cannot
+  span `AudioContext`s). IEM mono ("single earpiece" mode) sums through a
+  `ChannelMerger(1)`; toggling it rebuilds sources.
+- `AudioBuffer`s are decoded once (PA context) and shared — buffers are
+  context-agnostic.
+- Mixer model: three master faders (PA / IEM / mic) plus per-stem gain/mute on
+  each bus, persisted wholesale as `appState.mixer.stemMix` and controlled from
+  the Audio tab, the PA quick-mix drawer, and `POST /admin/mixer/stem`.
+- CDG songs collapse to a single "music" node per bus (`songType` rides the
+  mixer broadcast so remote UIs render the simplified variant).
 
 ### Clocks and scheduling
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,7 +162,7 @@ Two distinct React SPAs served by the Express server:
 
 ### 4. Creator Pipeline
 
-Song creation runs **entirely in-browser** (renderer or web page) on WebGPU via onnxruntime-web, with WASM fallback — no Python, native modules, or system ffmpeg. Main-process code only proxies/caches assets, tracks job status, and muxes/saves output. A web-admin "host-create" path lets a phone upload audio to `POST /admin/creator/host-create`; the desktop player's renderer then runs the GPU creation (see `hostCreateRelay.js`).
+Song creation runs **entirely in-browser** (renderer or web page) on WebGPU via onnxruntime-web — no Python, native modules, or system ffmpeg. Stem separation REQUIRES a real WebGPU adapter (no WASM fallback: a broken GPU environment fails fast with a clear error instead of grinding the CPU for an hour). Whisper may still use the wasm EP for lyrics-only and stem-reuse runs. Main-process code only proxies/caches assets, tracks job status, and muxes/saves output. A web-admin "host-create" path lets a phone upload audio to `POST /admin/creator/host-create`; the desktop player's renderer then runs the GPU creation (see `hostCreateRelay.js`).
 
 ```mermaid
 graph LR
@@ -507,13 +507,23 @@ Channels organized by domain:
 - **Butterchurn 2** - Visualizations
 - **Canvas API** - Graphics rendering
 
-### AI/ML (Creator) — 100% in-browser, WebGPU with WASM fallback
-- **Demucs** - Stem separation (htdemucs ONNX via onnxruntime-web; optional htdemucs_ft ensemble)
-- **Whisper** - Speech-to-text (@huggingface/transformers, timestamped ONNX models)
+### AI/ML (Creator) — 100% in-browser on WebGPU
+- **Demucs** - Stem separation (htdemucs ONNX via onnxruntime-web; optional htdemucs_ft ensemble). WebGPU-only: no CPU/WASM fallback
+- **Whisper** - Speech-to-text (@huggingface/transformers, timestamped ONNX models; default `whisper-large-v3-turbo_timestamped`, multilingual with auto-detect)
 - **CREPE** - Pitch/key detection (crepe_tiny.onnx bundled in static/webgpu)
 - **AAC encode** - ffmpeg-wasm (@ffmpeg/core single-thread, in a web worker)
 - **aubiojs** - Realtime pitch tracking
 - **OpenAI/Anthropic/Google** - LLM lyrics correction
+
+### Linux graphics configuration
+
+Chromium flags on Linux (`src/main/main.js`) are the product of a measured matrix on Wayland/RDNA3 and each one is load-bearing:
+
+- **Native ozone platform** (Wayland on a Wayland desktop). Forcing `ozone-platform=x11` creates NO toplevel window at all while the renderer and web server keep running — the app looks dead but serves the admin.
+- **`enable-features=Vulkan`** gives Dawn the real hardware WebGPU adapter (`shader-f16` for the fp16 demucs chain). Without it the adapter is SwiftShader and separation refuses to run.
+- **`disable-gpu-compositing`** because Vulkan compositing breaks `canvas.captureStream()` per-frame (kSkia backing errors → green/empty WebRTC viewers). WebGPU compute and WebGL still run on the GPU; only final surface composition is CPU.
+
+`npm start` / `npm run dev` go through `scripts/start-electron.mjs`, which repairs `WAYLAND_DISPLAY` / `DISPLAY` / `XAUTHORITY` before Electron spawns (Chromium zygotes fork before app JS runs, so main.js cannot fix a stale tmux environment). The app holds a single-instance lock: a second launch focuses the running window and exits.
 
 ### Build & Distribution
 - **electron-builder 26** - Packaging

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loukai-app",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loukai-app",
-      "version": "0.7.0",
+      "version": "0.7.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loukai-app",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loukai-app",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loukai-app",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "type": "module",
   "description": "Loukai Karaoke - Free and open source karaoke system for playing and creating stem-based karaoke files",
   "main": "src/main/main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loukai-app",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "type": "module",
   "description": "Loukai Karaoke - Free and open source karaoke system for playing and creating stem-based karaoke files",
   "main": "src/main/main.js",

--- a/src/shared/components/MixerPanel.jsx
+++ b/src/shared/components/MixerPanel.jsx
@@ -28,7 +28,11 @@ export function MixerPanel({
   const handleMuteToggle = onToggleMasterMute || onMuteToggle;
   const buses = [
     { id: 'PA', label: 'PA (Main)', description: 'Music + Mic to audience' },
-    { id: 'IEM', label: 'IEM (Monitors)', description: 'Vocals only (mono)' },
+    {
+      id: 'IEM',
+      label: 'IEM (Monitors)',
+      description: 'Monitor mix (mono) - stems muted until enabled',
+    },
     { id: 'mic', label: 'Mic Input', description: 'Microphone gain' },
   ];
 

--- a/src/shared/utils/stemGain.js
+++ b/src/shared/utils/stemGain.js
@@ -42,9 +42,12 @@ export function clampStemGain(gain) {
  * IEM), preserving the D1 defaults' spirit for unusual stem names.
  */
 export function defaultStemEntry(bus, stemName) {
-  const vocal = isVocalStem(stemName);
-  const mutedOnIem = bus === 'IEM';
-  return { gain: 1, muted: vocal ? !mutedOnIem : mutedOnIem };
+  // PA: karaoke defaults - vocals muted, music on. IEM: EVERYTHING muted -
+  // most hosts have a single sound card, so monitors are an explicit opt-in
+  // (an unmuted IEM vocal on a shared output would leak guide vocals to the
+  // room by default).
+  if (bus === 'IEM') return { gain: 1, muted: true };
+  return { gain: 1, muted: isVocalStem(stemName) };
 }
 
 /** The persisted entry for (bus, stem), or the runtime default. Never mutates. */

--- a/src/shared/utils/stemGain.test.js
+++ b/src/shared/utils/stemGain.test.js
@@ -77,9 +77,9 @@ describe('runtime defaults for unknown stems (§5.1)', () => {
     expect(defaultStemEntry('IEM', 'guitar')).toEqual({ gain: 1, muted: true });
   });
 
-  it('vocal detection flips the pair', () => {
+  it('vocals muted on PA; everything muted on IEM (single-sound-card default)', () => {
     expect(defaultStemEntry('PA', 'Lead Vox')).toEqual({ gain: 1, muted: true });
-    expect(defaultStemEntry('IEM', 'Lead Vox')).toEqual({ gain: 1, muted: false });
+    expect(defaultStemEntry('IEM', 'Lead Vox')).toEqual({ gain: 1, muted: true });
   });
 
   it('resolveStemEntry falls back to the runtime default and clamps stored values', () => {
@@ -100,11 +100,13 @@ describe('D1 seed + merge (§5.3)', () => {
       other: { muted: false },
       vocals: { muted: true },
     });
+    // IEM defaults fully muted: we can't assume a second sound card exists,
+    // and an unmuted IEM vocal on a shared output leaks guide vocals.
     expect(seed.IEM).toMatchObject({
       drums: { muted: true },
       bass: { muted: true },
       other: { muted: true },
-      vocals: { muted: false },
+      vocals: { muted: true },
     });
     // all sliders default to 100% = authored mix (D3)
     for (const bus of ['PA', 'IEM'])


### PR DESCRIPTION
Release prep for **v0.8.0** — supersedes #82 (the unshipped v0.7.2 prep is folded in here; the stem×bus mixer merging made this a feature release).

Content on top of merged main:

- **IEM stems now default fully muted.** A second sound card can't be assumed, and an unmuted IEM vocal on a shared output would leak guide vocals to the room. Monitors are an explicit per-stem opt-in; Audio tab copy updated; stemGain tests updated. PA defaults unchanged (music on, vocals muted).
- **architecture.md**: Audio Engine & Routing section rewritten for the shipped stem×bus graph (dual always-running sources, gain-formula audibility, `max(user, authored)` punchthrough) — the old split-context topology description was stale. Plus everything from #82: the Linux graphics configuration section, launcher/single-instance notes, WebGPU-only separation.
- **README**: stem-control bullet reflects per-bus mixing; production notes from #82.
- **metainfo**: 0.8.0 release notes (mixer headline + the Linux/creator fixes).
- **version**: 0.7.0 → 0.8.0.

Full retest performed on merged main before this prep, all passing live: launch health (zero X errors, rdna-3 + f16), single-instance lock, queue load + playback + browser viewer streaming (pixel-verified, zero kSkia), Electron canvas-window popout receiving frames, editor IPC round trip (post-.kai-sweep), editor time-input typing, mixer strips + `POST /admin/mixer/stem` live, host-create end to end with instant search in both the web admin and the Electron Library tab. 369/369 tests, both bundles build.

One finding filed as #85: OOM kill at a 6.5G peak under deliberately stacked load (playback + two WebRTC streams + host-create), with memory staying high after the create finished — warmed creator sessions are the suspect. Not a blocker; tracked separately.

After merge: tag `v0.8.0` on main to fire the Build and Release workflow, publish when the artifacts look good.