### PR TITLE
Run the editor save in a worker thread

### DIFF
--- a/src/main/handlers/editorHandlers.js
+++ b/src/main/handlers/editorHandlers.js
@@ -48,8 +48,8 @@ export function registerEditorHandlers(mainApp) {
       }
       const format = STEM_MP4_FORMAT;
 
-      const editorService = await import('../../shared/services/editorService.js');
-      const _result = await editorService.saveSong(originalPath, {
+      const { saveSongOffMain } = await import('../workers/saveSongOffMain.js');
+      const _result = await saveSongOffMain(originalPath, {
         format: format,
         metadata: songData.song || songData.metadata || {},
         lyrics: songData.lyrics,

--- a/src/main/webServer.js
+++ b/src/main/webServer.js
@@ -1311,8 +1311,8 @@ class WebServer {
         // every web-admin lyric save for a .stem.mp4 fell through to the CDG/ID3
         // branch below and failed with "Invalid file format".
         if (isStemMp4Format(format)) {
-          const editorService = await import('../shared/services/editorService.js');
-          await editorService.saveSong(validatedPath, { format, metadata, lyrics });
+          const { saveSongOffMain } = await import('./workers/saveSongOffMain.js');
+          await saveSongOffMain(validatedPath, { format, metadata, lyrics });
 
           // Update cached library entry if it exists
           if (this.mainApp.cachedLibrary) {

--- a/src/main/workers/editorSaveWorker.js
+++ b/src/main/workers/editorSaveWorker.js
@@ -1,0 +1,18 @@
+/**
+ * Worker-thread entry for the editor save. The save pipeline (read the whole
+ * .stem.mp4, rebuild the kara atom, re-parse metadata, rebuild metadata atoms,
+ * write) is CPU work proportional to file size. In Electron the MAIN process
+ * routes input events to every window, so running that pipeline on the main
+ * thread freezes the keyboard app-wide for the duration (seconds on big files
+ * or slow machines). Here it runs off-main; the event loop stays free.
+ */
+import { parentPort, workerData } from 'node:worker_threads';
+
+const { filePath, updates } = workerData;
+try {
+  const editorService = await import('../../shared/services/editorService.js');
+  const result = await editorService.saveSong(filePath, updates);
+  parentPort.postMessage({ ok: true, result });
+} catch (e) {
+  parentPort.postMessage({ ok: false, error: e?.message || String(e) });
+}

--- a/src/main/workers/saveSongOffMain.js
+++ b/src/main/workers/saveSongOffMain.js
@@ -1,0 +1,49 @@
+import { Worker } from 'node:worker_threads';
+
+/**
+ * Run editorService.saveSong in a worker thread so the main process event loop
+ * (which routes input to every window) never blocks on the file rebuild.
+ *
+ * Save FAILURES inside the worker propagate as rejections. Only a worker that
+ * dies before reporting anything (boot failure, e.g. an exotic packaging
+ * setup) falls back to the in-process save - slower UI, but the save works.
+ */
+export function saveSongOffMain(filePath, updates) {
+  return new Promise((resolve, reject) => {
+    let reported = false;
+    const fallback = async () => {
+      try {
+        const editorService = await import('../../shared/services/editorService.js');
+        resolve(await editorService.saveSong(filePath, updates));
+      } catch (e) {
+        reject(e);
+      }
+    };
+    let worker;
+    try {
+      worker = new Worker(new URL('./editorSaveWorker.js', import.meta.url), {
+        workerData: { filePath, updates },
+      });
+    } catch {
+      fallback();
+      return;
+    }
+    worker.once('message', (m) => {
+      reported = true;
+      if (m.ok) resolve(m.result);
+      else reject(new Error(m.error));
+    });
+    worker.once('error', () => {
+      if (!reported) {
+        reported = true;
+        fallback();
+      }
+    });
+    worker.once('exit', (code) => {
+      if (!reported && code !== 0) {
+        reported = true;
+        fallback();
+      }
+    });
+  });
+}


### PR DESCRIPTION
Fixes #87 (the freeze @jorgeEF reported on #85).

The save pipeline rebuilds the whole .stem.mp4 in memory (read, kara atom rebuild, metadata re-parse via music-metadata, metadata/key atom rebuilds, write) as synchronous CPU work on the **main process** — and Electron's main process is what routes input events to every window. Blocked main = dead keyboard in every text field, vanished caret, app-wide, for exactly the duration of the save. Measured: ~150ms save on a 34MB file produced a matching ~150ms input stall; a CPU profile showed the renderer idle during it, confirming the input pipeline (not React) was the victim. Bigger file + slower machine = the reported multi-second freeze.

Fix: `saveSongOffMain()` runs `editorService.saveSong` inside a `worker_threads` Worker. Both save entry points (Electron IPC `editor:save`, web admin `/admin/editor/save`) go through it. Real save errors propagate as rejections; only a worker that dies before reporting anything (packaging edge cases) falls back to the in-process save, trading UI smoothness for a save that still completes. `editorService` is unchanged, so its 16 unit tests still cover the pipeline.

Verified live before/after on the same file: stalls `[143]` → `[]` across repeated runs (save 230-280ms including ~60ms worker boot).