### PR TITLE
v0.8.1

### DIFF
--- a/com.loukai.app.metainfo.xml
+++ b/com.loukai.app.metainfo.xml
@@ -48,6 +48,14 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="0.8.1" date="2026-07-18">
+      <description>
+        <p>Editor save no longer freezes the app</p>
+        <ul>
+          <li>Saving a song in the editor ran the whole file rebuild on the process that routes keyboard input, freezing typing app-wide for seconds on larger files - the save now runs in a worker thread and input stays live throughout</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.8.0" date="2026-07-18">
       <description>
         <p>Stem mixer on every output, and a rock-solid Linux launch</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loukai-app",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loukai-app",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loukai-app",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "description": "Loukai Karaoke - Free and open source karaoke system for playing and creating stem-based karaoke files",
   "main": "src/main/main.js",


### PR DESCRIPTION
Patch release: the editor-save freeze fix (#88 / #87). Version bump + metainfo release notes. After merge: tag `v0.8.1` on main to fire the Build and Release workflow.