### PR TITLE
Key shift for the loaded song

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -376,6 +376,11 @@ mic ─► micGain ─► [auto-tune chain] ──────┤        └─(
   the Audio tab, the PA quick-mix drawer, and `POST /admin/mixer/stem`.
 - CDG songs collapse to a single "music" node per bus (`songType` rides the
   mixer broadcast so remote UIs render the simplified variant).
+- **Key shift (#90)**: every recorded source sums into a per-bus `songBus`;
+  at 0 semitones it feeds `masterGain` directly (hard bypass, zero cost), else
+  through a SoundTouch AudioWorklet (`pitchSemitones`). The mic joins after and
+  is never shifted. Per-loaded-song: resets to 0 on load, syncs across surfaces
+  via the mixer broadcast, and statePersistence strips it so it never persists.
 
 ### Clocks and scheduling
 

--- a/src/main/handlers/mixerHandlers.js
+++ b/src/main/handlers/mixerHandlers.js
@@ -29,6 +29,10 @@ export function registerMixerHandlers(mainApp) {
     return mixerService.setStemGain(mainApp, bus, stem, gain);
   });
 
+  ipcMain.handle('mixer:setKeyShift', (event, semitones) => {
+    return mixerService.setKeyShift(mainApp, semitones);
+  });
+
   ipcMain.handle(MIXER_CHANNELS.SET_STEM_MUTE, (event, bus, stem, muted) => {
     return mixerService.setStemMute(mainApp, bus, stem, muted);
   });

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -31,6 +31,9 @@ const api = {
     setStemGain: (bus, stem, gain) => ipcRenderer.invoke('mixer:setStemGain', bus, stem, gain),
     setStemMute: (bus, stem, muted) => ipcRenderer.invoke('mixer:setStemMute', bus, stem, muted),
     toggleStemMute: (bus, stem) => ipcRenderer.invoke('mixer:toggleStemMute', bus, stem),
+    // Key shift for the loaded song (issue #90) - ephemeral, never persisted
+    setKeyShift: (semitones) => ipcRenderer.invoke('mixer:setKeyShift', semitones),
+    onKeyShift: (callback) => ipcRenderer.on('mixer:keyShift', callback),
 
     onStateChange: (callback) => ipcRenderer.on('mixer:state', callback),
     removeStateListener: (callback) => ipcRenderer.removeListener('mixer:state', callback),

--- a/src/main/statePersistence.js
+++ b/src/main/statePersistence.js
@@ -39,6 +39,7 @@ class StatePersistence {
       // Restore mixer state if available
       if (savedState.mixer) {
         this.appState.state.mixer = savedState.mixer;
+        delete this.appState.state.mixer.keyShift;
         log('📂 Loaded mixer state');
       }
 
@@ -75,6 +76,7 @@ class StatePersistence {
         // Restore from backup
         if (savedState.mixer) {
           this.appState.state.mixer = savedState.mixer;
+          delete this.appState.state.mixer.keyShift;
           log('📂 Loaded mixer state from backup');
         }
 
@@ -118,7 +120,8 @@ class StatePersistence {
 
       // Don't save playback state (position, isPlaying) or queue - those are ephemeral
       const stateToSave = {
-        mixer: snapshot.mixer,
+        // keyShift is per-loaded-song (issue #90): synced live, never saved
+        mixer: (({ keyShift: _keyShift, ...rest }) => rest)(snapshot.mixer || {}),
         effects: snapshot.effects,
         preferences: snapshot.preferences,
         savedAt: new Date().toISOString(),

--- a/src/main/webServer.js
+++ b/src/main/webServer.js
@@ -1508,6 +1508,15 @@ class WebServer {
     // ===== NEW: Master Mixer Control Endpoints =====
     // Per-bus per-stem mixer (stem×bus mixer, #49): {bus, stem, gain?} or
     // {bus, stem, muted?} — gain and mute are independent controls.
+    this.app.post('/admin/mixer/keyshift', (req, res) => {
+      try {
+        const { semitones } = req.body || {};
+        res.json(mixerService.setKeyShift(this.mainApp, semitones));
+      } catch (error) {
+        res.status(500).json({ success: false, error: error.message });
+      }
+    });
+
     this.app.post('/admin/mixer/stem', (req, res) => {
       try {
         const { bus, stem, gain, muted } = req.body;

--- a/src/renderer/adapters/ElectronBridge.js
+++ b/src/renderer/adapters/ElectronBridge.js
@@ -112,6 +112,15 @@ export class ElectronBridge extends BridgeInterface {
     return { success: false, error: 'Audio engine not initialized' };
   }
 
+  setKeyShift(semitones) {
+    // Apply locally - kaiPlayer reports back to main via reportMixerState()
+    const kaiPlayer = window.app?.player?.kaiPlayer;
+    if (kaiPlayer) {
+      return { success: true, semitones: kaiPlayer.setKeyShift(semitones) };
+    }
+    return { success: false, error: 'Audio engine not initialized' };
+  }
+
   setMasterMute(bus, muted) {
     // Apply locally - kaiPlayer will report back to main process via reportMixerState()
     const kaiPlayer = window.app?.player?.kaiPlayer;

--- a/src/renderer/components/TransportControlsWrapper.jsx
+++ b/src/renderer/components/TransportControlsWrapper.jsx
@@ -12,6 +12,26 @@ export function TransportControlsWrapper({ bridge: _bridge }) {
   const { currentSong, isPlaying, currentPosition, duration } = usePlayerState();
   const { play, pause, restart, next, seek } = usePlayer();
   const [currentEffect, setCurrentEffect] = useState('');
+  const [keyShift, setKeyShift] = useState(0);
+
+  // Track the loaded song's key shift: main relays every change (from the web
+  // admin or from here) via mixer:keyShift; song loads reset it through the
+  // engine's mixer report, which also flows back through main.
+  useEffect(() => {
+    const kaiPlayer = window.app?.player?.kaiPlayer;
+    if (kaiPlayer) setKeyShift(kaiPlayer.keyShift ?? 0);
+    if (!window.kaiAPI?.mixer?.onKeyShift) return;
+    const handle = (event, { semitones }) => setKeyShift(semitones ?? 0);
+    window.kaiAPI.mixer.onKeyShift(handle);
+    return () => {};
+  }, []);
+
+  const handleKeyShift = (n) => {
+    const kaiPlayer = window.app?.player?.kaiPlayer;
+    if (kaiPlayer) {
+      setKeyShift(kaiPlayer.setKeyShift(n));
+    }
+  };
 
   // Subscribe to effects state (TODO: move to EffectsContext in future)
   useEffect(() => {
@@ -64,6 +84,9 @@ export function TransportControlsWrapper({ bridge: _bridge }) {
       onPreviousEffect={handlePreviousEffect}
       onNextEffect={handleNextEffect}
       onOpenCanvasWindow={handleOpenCanvasWindow}
+      keyShift={keyShift}
+      songKey={currentSong?.key}
+      onKeyShift={handleKeyShift}
     />
   );
 }

--- a/src/renderer/js/kaiPlayer.js
+++ b/src/renderer/js/kaiPlayer.js
@@ -1,4 +1,5 @@
 import { PlayerInterface } from './PlayerInterface.js';
+import { clampKeyShift } from '../../shared/utils/musicKey.js';
 import { MicrophoneEngine } from './microphoneEngine.js';
 import {
   effectiveStemGain,
@@ -106,6 +107,7 @@ export class KAIPlayer extends PlayerInterface {
       // Apply saved PA gain (considering mute state)
       const paGain = this.mixerState.PA.muted ? 0 : this.dbToLinear(this.mixerState.PA.gain);
       this.outputNodes.PA.masterGain.gain.value = paGain;
+      this.setupSongBus('PA');
 
       // Create analyser for butterchurn visualization (before gain affects signal)
       this.outputNodes.PA.analyser = this.audioContexts.PA.createAnalyser();
@@ -134,6 +136,7 @@ export class KAIPlayer extends PlayerInterface {
       // Apply saved IEM gain (considering mute state)
       const iemGain = this.mixerState.IEM.muted ? 0 : this.dbToLinear(this.mixerState.IEM.gain);
       this.outputNodes.IEM.masterGain.gain.value = iemGain;
+      this.setupSongBus('IEM');
 
       // Initialize microphone engine
       this.micEngine = new MicrophoneEngine(this.audioContexts.PA, this.outputNodes.PA.masterGain, {
@@ -340,6 +343,7 @@ export class KAIPlayer extends PlayerInterface {
         ? 0
         : this.dbToLinear(this.mixerState[busType].gain);
       this.outputNodes[busType].masterGain.gain.value = savedGain;
+      this.setupSongBus(busType);
 
       // Create analyser for PA (for butterchurn visualization)
       if (busType === 'PA') {
@@ -399,6 +403,7 @@ export class KAIPlayer extends PlayerInterface {
   async loadSong(songData) {
     this.cdgMusicNode = null; // stems song replaces any CDG music-node registration
     this.mixerState.songType = 'kai';
+    this.setKeyShift(0, false); // per-song: a new load always starts unshifted
 
     this.songData = songData;
 
@@ -670,7 +675,7 @@ export class KAIPlayer extends PlayerInterface {
     this.mixerState.stems.forEach((stem) => {
       // Create gain node for PA output
       const paGainNode = this.audioContexts.PA.createGain();
-      paGainNode.connect(this.outputNodes.PA.masterGain);
+      paGainNode.connect(this.outputNodes.PA.songBus);
       this.outputNodes.PA.gainNodes.set(stem.name, paGainNode);
 
       // Create gain node for IEM output
@@ -681,9 +686,9 @@ export class KAIPlayer extends PlayerInterface {
         // Create channel merger to convert stereo to mono
         const channelMerger = this.audioContexts.IEM.createChannelMerger(1);
         iemGainNode.connect(channelMerger);
-        channelMerger.connect(this.outputNodes.IEM.masterGain);
+        channelMerger.connect(this.outputNodes.IEM.songBus);
       } else {
-        iemGainNode.connect(this.outputNodes.IEM.masterGain);
+        iemGainNode.connect(this.outputNodes.IEM.songBus);
       }
 
       this.outputNodes.IEM.gainNodes.set(stem.name, iemGainNode);
@@ -753,12 +758,105 @@ export class KAIPlayer extends PlayerInterface {
   }
 
   /**
+   * Key shift (issue #90): every recorded source (all stems, or the CDG music
+   * node) sums into a per-bus songBus; that sum either feeds masterGain
+   * directly (0 semitones: hard bypass, zero cost) or runs through a
+   * SoundTouch AudioWorklet pitched by pitchSemitones. The live mic connects
+   * to masterGain directly and is never shifted. Per-loaded-song by design:
+   * reset to 0 on every load, synced across surfaces via the mixer broadcast,
+   * never persisted (statePersistence strips it).
+   */
+  setupSongBus(bus) {
+    const ctx = this.audioContexts[bus];
+    const out = this.outputNodes[bus];
+    if (!ctx || !out?.masterGain) return;
+    out.songBus = ctx.createGain();
+    // A fresh context has no worklet module or node yet.
+    out.keyShiftNode = null;
+    out.soundtouchModuleLoaded = false;
+    this.applyKeyShiftRouting(bus);
+  }
+
+  async ensureKeyShiftNode(bus) {
+    const ctx = this.audioContexts[bus];
+    const out = this.outputNodes[bus];
+    if (!ctx || !out) return null;
+    if (out.keyShiftNode) return out.keyShiftNode;
+    try {
+      if (!out.soundtouchModuleLoaded) {
+        await ctx.audioWorklet.addModule('js/soundtouch-worklet.js');
+        out.soundtouchModuleLoaded = true;
+      }
+      const node = new AudioWorkletNode(ctx, 'soundtouch-processor', {
+        numberOfInputs: 1,
+        numberOfOutputs: 1,
+        outputChannelCount: [2],
+      });
+      node.connect(out.masterGain);
+      out.keyShiftNode = node;
+      return node;
+    } catch (e) {
+      console.error(`key shift worklet unavailable on ${bus}:`, e);
+      return null;
+    }
+  }
+
+  async applyKeyShiftRouting(bus) {
+    const out = this.outputNodes[bus];
+    if (!out?.songBus || !out.masterGain) return;
+    const target = this.keyShift ?? 0;
+    let node = null;
+    if (target !== 0) {
+      // Keep the current path audible while the worklet loads (first engage
+      // costs one module fetch; after that the node is reused).
+      node = await this.ensureKeyShiftNode(bus);
+      if ((this.keyShift ?? 0) !== target) return; // superseded while loading
+    }
+    try {
+      out.songBus.disconnect();
+    } catch {
+      /* fresh node, nothing connected */
+    }
+    if (target !== 0 && node) {
+      node.parameters.get('pitchSemitones').value = target;
+      out.songBus.connect(node);
+    } else {
+      out.songBus.connect(out.masterGain);
+    }
+  }
+
+  /**
+   * Set the loaded song's key shift in semitones (clamped to -6..6).
+   * report=false is the no-echo path for commands that came FROM main.
+   */
+  setKeyShift(semitones, report = true) {
+    const n = clampKeyShift(semitones);
+    if (n === (this.keyShift ?? 0)) return n;
+    this.keyShift = n;
+    this.mixerState.keyShift = n;
+    this.applyKeyShiftRouting('PA');
+    this.applyKeyShiftRouting('IEM');
+    if (report) this.reportMixerState();
+    return n;
+  }
+
+  /**
    * CDG mode (§8): the loaded CDG song's single music gain node, driven by the PA
    * "music" strip through the same stemMix state (persists like any stem key).
    * Registered by the CDG loader; cleared when a stems song loads.
    */
   attachCdgMusicNode(gainNode) {
     this.cdgMusicNode = gainNode;
+    // Route the CDG music through the PA song bus so key shift (#90) covers it.
+    if (this.outputNodes.PA?.songBus) {
+      try {
+        gainNode.disconnect();
+      } catch {
+        /* not connected yet */
+      }
+      gainNode.connect(this.outputNodes.PA.songBus);
+    }
+    this.setKeyShift(0, false); // per-song: a new load always starts unshifted
     // The mixer UIs render the single-music-fader variant off this flag (it rides
     // the same mixer broadcast every surface already subscribes to).
     this.mixerState.songType = 'cdg';
@@ -1002,6 +1100,7 @@ export class KAIPlayer extends PlayerInterface {
       IEM: this.mixerState.IEM,
       mic: this.mixerState.mic,
       stems: this.mixerState.stems, // For reference only
+      keyShift: this.keyShift,
       isPlaying: this.isPlaying,
       position: this.getCurrentPosition(),
       duration: this.getDuration(),

--- a/src/shared/components/PlayerControls.jsx
+++ b/src/shared/components/PlayerControls.jsx
@@ -165,22 +165,21 @@ export function PlayerControls({
         {/* Key shift (issue #90): per-loaded-song, resets on load, never saved */}
         {onKeyShift && (
           <>
-            <div className="w-px h-8 bg-gray-200 dark:bg-gray-700 mx-2" />
             <div
-              className="flex items-center gap-1 flex-shrink-0"
+              className="flex items-center flex-shrink-0"
               title="Key shift (music and guide vocal, never the mic)"
             >
               <button
                 onClick={() => onKeyShift(keyShift - 1)}
                 disabled={loading || keyShift <= KEY_SHIFT_MIN}
-                className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition disabled:opacity-40 flex items-center justify-center"
+                className="p-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition disabled:opacity-40 flex items-center justify-center"
               >
                 <span className="material-icons text-gray-700 dark:text-gray-300 text-lg leading-none">
                   remove
                 </span>
               </button>
               <span
-                className={`text-sm font-mono min-w-[52px] text-center ${
+                className={`text-sm font-mono text-center px-0.5 ${
                   keyShift !== 0
                     ? 'text-blue-600 dark:text-blue-400 font-semibold'
                     : 'text-gray-500 dark:text-gray-400'
@@ -197,7 +196,7 @@ export function PlayerControls({
               <button
                 onClick={() => onKeyShift(keyShift + 1)}
                 disabled={loading || keyShift >= KEY_SHIFT_MAX}
-                className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition disabled:opacity-40 flex items-center justify-center"
+                className="p-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition disabled:opacity-40 flex items-center justify-center"
               >
                 <span className="material-icons text-gray-700 dark:text-gray-300 text-lg leading-none">
                   add

--- a/src/shared/components/PlayerControls.jsx
+++ b/src/shared/components/PlayerControls.jsx
@@ -7,6 +7,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { formatDuration } from '../formatUtils.js';
+import { shiftKeyName, KEY_SHIFT_MIN, KEY_SHIFT_MAX } from '../utils/musicKey.js';
 
 export function PlayerControls({
   playback,
@@ -22,6 +23,9 @@ export function PlayerControls({
   onNextEffect,
   onOpenCanvasWindow,
   onOpenViewer,
+  keyShift = 0,
+  songKey,
+  onKeyShift,
   className = '',
 }) {
   const { isPlaying, position = 0, duration = 0 } = playback || {};
@@ -157,6 +161,51 @@ export function PlayerControls({
           <span>/</span>
           <span>{formatDuration(duration)}</span>
         </div>
+
+        {/* Key shift (issue #90): per-loaded-song, resets on load, never saved */}
+        {onKeyShift && (
+          <>
+            <div className="w-px h-8 bg-gray-200 dark:bg-gray-700 mx-2" />
+            <div
+              className="flex items-center gap-1 flex-shrink-0"
+              title="Key shift (music and guide vocal, never the mic)"
+            >
+              <button
+                onClick={() => onKeyShift(keyShift - 1)}
+                disabled={loading || keyShift <= KEY_SHIFT_MIN}
+                className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition disabled:opacity-40 flex items-center justify-center"
+              >
+                <span className="material-icons text-gray-700 dark:text-gray-300 text-lg leading-none">
+                  remove
+                </span>
+              </button>
+              <span
+                className={`text-sm font-mono min-w-[52px] text-center ${
+                  keyShift !== 0
+                    ? 'text-blue-600 dark:text-blue-400 font-semibold'
+                    : 'text-gray-500 dark:text-gray-400'
+                }`}
+              >
+                {keyShift === 0
+                  ? songKey || 'Key'
+                  : `${keyShift > 0 ? '+' : ''}${keyShift}${
+                      songKey && shiftKeyName(songKey, keyShift)
+                        ? ` ${shiftKeyName(songKey, keyShift)}`
+                        : ''
+                    }`}
+              </span>
+              <button
+                onClick={() => onKeyShift(keyShift + 1)}
+                disabled={loading || keyShift >= KEY_SHIFT_MAX}
+                className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition disabled:opacity-40 flex items-center justify-center"
+              >
+                <span className="material-icons text-gray-700 dark:text-gray-300 text-lg leading-none">
+                  add
+                </span>
+              </button>
+            </div>
+          </>
+        )}
 
         {/* Divider */}
         <div className="w-px h-8 bg-gray-200 dark:bg-gray-700 mx-2" />

--- a/src/shared/hooks/useAudioEngine.js
+++ b/src/shared/hooks/useAudioEngine.js
@@ -79,12 +79,16 @@ export function useAudioEngine() {
     const handleStemMute = (event, { bus, stem, muted }) => {
       kaiPlayer.setStemMute(bus, stem, muted, false);
     };
+    const handleKeyShift = (event, { semitones }) => {
+      kaiPlayer.setKeyShift(semitones, false);
+    };
 
     window.kaiAPI.mixer.onSetMasterGain(handleSetMasterGain);
     window.kaiAPI.mixer.onToggleMasterMute(handleToggleMasterMute);
     window.kaiAPI.mixer.onSetMasterMute(handleSetMasterMute);
     if (window.kaiAPI.mixer.onStemGain) window.kaiAPI.mixer.onStemGain(handleStemGain);
     if (window.kaiAPI.mixer.onStemMute) window.kaiAPI.mixer.onStemMute(handleStemMute);
+    if (window.kaiAPI.mixer.onKeyShift) window.kaiAPI.mixer.onKeyShift(handleKeyShift);
 
     console.log('✅ Mixer IPC listeners registered');
 

--- a/src/shared/services/mixerService.js
+++ b/src/shared/services/mixerService.js
@@ -6,6 +6,7 @@
  */
 
 import { clampStemGain, resolveStemEntry } from '../utils/stemGain.js';
+import { clampKeyShift } from '../utils/musicKey.js';
 
 /**
  * Get current mixer state
@@ -180,6 +181,29 @@ export function setMasterMute(mainApp, bus, muted) {
  * @param {string} stem - stem name (canonical or file-specific)
  * @param {number} gain - linear multiplier 0..1.5 (1.0 = authored mix); clamped
  */
+/**
+ * Set the key shift for the loaded song (issue #90). Ephemeral by design:
+ * lives in the mixer broadcast so every surface syncs, but statePersistence
+ * strips it before writing to disk and the engine resets it on song load.
+ */
+export function setKeyShift(mainApp, semitones) {
+  try {
+    const n = Number(semitones);
+    if (!Number.isFinite(n)) {
+      return { success: false, error: 'numeric semitones required' };
+    }
+    const clamped = clampKeyShift(n);
+    const currentMixer = mainApp.appState.state.mixer;
+    mainApp.appState.updateMixerState({ ...currentMixer, keyShift: clamped });
+    // Renderer applies the audio change (no-echo: it must not re-report this).
+    mainApp.sendToRenderer('mixer:keyShift', { semitones: clamped });
+    return { success: true, semitones: clamped };
+  } catch (error) {
+    console.error('Error setting key shift:', error);
+    return { success: false, error: error.message };
+  }
+}
+
 export function setStemGain(mainApp, bus, stem, gain) {
   try {
     if ((bus !== 'PA' && bus !== 'IEM') || !stem || typeof gain !== 'number') {

--- a/src/shared/services/mixerService.test.js
+++ b/src/shared/services/mixerService.test.js
@@ -129,7 +129,7 @@ describe('mixerService', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('bus (PA/IEM/mic) and gainDb required');
-      expect(appState.updateMixerState).not.toHaveBeenCalled();
+      expect(mainApp.appState.updateMixerState).not.toHaveBeenCalled();
       expect(mainApp.sendToRenderer).not.toHaveBeenCalled();
     });
 
@@ -253,7 +253,7 @@ describe('mixerService', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('bus (PA/IEM/mic) required');
-      expect(appState.updateMixerState).not.toHaveBeenCalled();
+      expect(mainApp.appState.updateMixerState).not.toHaveBeenCalled();
       expect(mainApp.sendToRenderer).not.toHaveBeenCalled();
     });
 
@@ -359,7 +359,7 @@ describe('mixerService', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('bus (PA/IEM/mic) and muted status required');
-      expect(appState.updateMixerState).not.toHaveBeenCalled();
+      expect(mainApp.appState.updateMixerState).not.toHaveBeenCalled();
       expect(mainApp.sendToRenderer).not.toHaveBeenCalled();
     });
 
@@ -407,6 +407,29 @@ describe('stem×bus mixer (#49)', () => {
     // shape and toggle off it, so make the mock actually write.
     mainApp.appState.updateMixerState.mockImplementation((mixer) => {
       mainApp.appState.state.mixer = mixer;
+    });
+  });
+
+  describe('setKeyShift', () => {
+    it('clamps, updates mixer state, and relays to the renderer', () => {
+      const result = mixerService.setKeyShift(mainApp, 9);
+      expect(result).toEqual({ success: true, semitones: 6 });
+      expect(mainApp.appState.updateMixerState).toHaveBeenCalledWith(
+        expect.objectContaining({ keyShift: 6 })
+      );
+      expect(mainApp.sendToRenderer).toHaveBeenCalledWith('mixer:keyShift', { semitones: 6 });
+    });
+
+    it('rounds fractional semitones', () => {
+      const result = mixerService.setKeyShift(mainApp, -2.6);
+      expect(result).toEqual({ success: true, semitones: -3 });
+    });
+
+    it('rejects non-numeric input without touching state', () => {
+      const result = mixerService.setKeyShift(mainApp, 'up a bit');
+      expect(result.success).toBe(false);
+      expect(mainApp.appState.updateMixerState).not.toHaveBeenCalled();
+      expect(mainApp.sendToRenderer).not.toHaveBeenCalled();
     });
   });
 

--- a/src/shared/utils/musicKey.js
+++ b/src/shared/utils/musicKey.js
@@ -1,0 +1,57 @@
+/**
+ * Musical key name arithmetic for the key shift control (issue #90).
+ * Pure string math: no audio here.
+ */
+
+const SHARP_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+
+const PITCH_CLASS = {
+  C: 0,
+  'B#': 0,
+  'C#': 1,
+  Db: 1,
+  D: 2,
+  'D#': 3,
+  Eb: 3,
+  E: 4,
+  Fb: 4,
+  'E#': 5,
+  F: 5,
+  'F#': 6,
+  Gb: 6,
+  G: 7,
+  'G#': 8,
+  Ab: 8,
+  A: 9,
+  'A#': 10,
+  Bb: 10,
+  B: 11,
+  Cb: 11,
+};
+
+/**
+ * Transpose a key name by N semitones, preserving the mode suffix.
+ * 'Am' +2 -> 'Bm', 'F#' -1 -> 'F', 'Bb minor' +1 -> 'B minor'.
+ * Returns null when the key string is unparseable (display falls back to
+ * bare semitones).
+ */
+export function shiftKeyName(key, semitones) {
+  if (!key || typeof key !== 'string') return null;
+  const m = key.trim().match(/^([A-Ga-g])([#b♯♭]?)(.*)$/);
+  if (!m) return null;
+  const accidental = m[2] === '♯' ? '#' : m[2] === '♭' ? 'b' : m[2];
+  const root = m[1].toUpperCase() + accidental;
+  const pc = PITCH_CLASS[root];
+  if (pc === undefined) return null;
+  const n = Math.round(Number(semitones) || 0);
+  const shifted = (((pc + n) % 12) + 12) % 12;
+  return SHARP_NAMES[shifted] + m[3];
+}
+
+/** Clamp + round a requested key shift to the supported range. */
+export const KEY_SHIFT_MIN = -6;
+export const KEY_SHIFT_MAX = 6;
+export function clampKeyShift(semitones) {
+  const n = Math.round(Number(semitones) || 0);
+  return Math.max(KEY_SHIFT_MIN, Math.min(KEY_SHIFT_MAX, n));
+}

--- a/src/shared/utils/musicKey.test.js
+++ b/src/shared/utils/musicKey.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { shiftKeyName, clampKeyShift } from './musicKey.js';
+
+describe('shiftKeyName', () => {
+  it('shifts natural keys', () => {
+    expect(shiftKeyName('C', 2)).toBe('D');
+    expect(shiftKeyName('A', 3)).toBe('C');
+  });
+
+  it('preserves the mode suffix', () => {
+    expect(shiftKeyName('Am', 2)).toBe('Bm');
+    expect(shiftKeyName('Bb minor', 1)).toBe('B minor');
+    expect(shiftKeyName('F#m', -2)).toBe('Em');
+  });
+
+  it('handles flats and unicode accidentals, normalizing to sharps', () => {
+    expect(shiftKeyName('Bb', 1)).toBe('B');
+    expect(shiftKeyName('Eb', 2)).toBe('F');
+    expect(shiftKeyName('D♭', 0)).toBe('C#');
+    expect(shiftKeyName('F♯', 1)).toBe('G');
+  });
+
+  it('wraps around the octave in both directions', () => {
+    expect(shiftKeyName('B', 1)).toBe('C');
+    expect(shiftKeyName('C', -1)).toBe('B');
+    expect(shiftKeyName('C', -13)).toBe('B');
+  });
+
+  it('is identity at 0', () => {
+    expect(shiftKeyName('G', 0)).toBe('G');
+    expect(shiftKeyName('Am', 0)).toBe('Am');
+  });
+
+  it('returns null for garbage', () => {
+    expect(shiftKeyName('', 2)).toBeNull();
+    expect(shiftKeyName(null, 2)).toBeNull();
+    expect(shiftKeyName('H', 2)).toBeNull();
+    expect(shiftKeyName(42, 2)).toBeNull();
+  });
+});
+
+describe('clampKeyShift', () => {
+  it('clamps to -6..6 and rounds', () => {
+    expect(clampKeyShift(9)).toBe(6);
+    expect(clampKeyShift(-9)).toBe(-6);
+    expect(clampKeyShift(2.6)).toBe(3);
+    expect(clampKeyShift('nope')).toBe(0);
+  });
+});

--- a/src/web/App.jsx
+++ b/src/web/App.jsx
@@ -489,6 +489,9 @@ export function App() {
                 onPreviousEffect={handleEffectPrevious}
                 onNextEffect={handleEffectNext}
                 onOpenViewer={() => window.open('/viewer', '_blank', 'noopener')}
+                keyShift={mixer?.keyShift ?? 0}
+                songKey={currentSong?.key}
+                onKeyShift={(n) => bridge.setKeyShift(n)}
               />
             </div>
             <div className="flex gap-4 flex-1 min-h-0 overflow-hidden">

--- a/src/web/adapters/WebBridge.js
+++ b/src/web/adapters/WebBridge.js
@@ -130,6 +130,13 @@ export class WebBridge extends BridgeInterface {
     });
   }
 
+  async setKeyShift(semitones) {
+    return await this._fetch('/mixer/keyshift', {
+      method: 'POST',
+      body: JSON.stringify({ semitones }),
+    });
+  }
+
   async setStemMute(bus, stem, muted) {
     return await this._fetch('/mixer/stem', {
       method: 'POST',


### PR DESCRIPTION
Implements #90: real-time transpose (-6..+6 semitones) for the loaded song. Everything recorded shifts together (band, and the guide vocal wherever it is audible, so punchthrough and IEM monitors arrive in the new key); the live mic is never shifted.

**Engine**: all stem gain nodes (and the CDG music node) sum into a per-bus `songBus`. At 0 semitones that feeds `masterGain` directly: hard bypass, zero cost. Shifted, it runs through a SoundTouch AudioWorklet (the vendored `soundtouch-worklet.js`, used at last) with `pitchSemitones` set: one stereo instance per bus, lazily created, reused, all DSP on the audio rendering thread. Device changes rebuild routing; song loads reset to 0.

**Control plane**: `mixerService.setKeyShift` + `mixer:setKeyShift` IPC + `POST /admin/mixer/keyshift` + both bridges. The value rides the existing mixer broadcast, so the web admin and the Electron app sync in both directions, and `statePersistence` strips it from disk writes (per-song, never saved).

**UI**: compact minus/display/plus cluster in the shared `PlayerControls` transport bar, so it appears in both the Electron player and the web admin queue tab. Unshifted it shows the song's key (when known); shifted it shows the offset and the transposed key name (`+2 Bm`), via a new `musicKey` utility. Placed in the transport rather than a drawer so it is one tap mid-set; easy to move if it feels wrong in use.

Verified live: `+2` from the web endpoint engages the worklet on both buses (`pitchSemitones=2`) with playback running and zero worklet errors; both UIs show `+2`; resetting from the Electron side clears the web display; `loadSong` resets `3 -> 0` through the real load pipeline (instrumented). 379/379 tests, both bundles build.

Needs an ears check before merge: pitch quality of SoundTouch on full mixes, and the IEM/PA blend while shifted.