### PR TITLE
v0.9.0

### DIFF
--- a/com.loukai.app.metainfo.xml
+++ b/com.loukai.app.metainfo.xml
@@ -48,6 +48,17 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="0.9.0" date="2026-07-18">
+      <description>
+        <p>Key shift</p>
+        <ul>
+          <li>NEW: transpose the loaded song up or down 6 semitones live from the player or the web admin - the band and guide vocal shift together, the singer's mic never does</li>
+          <li>Shows the transposed key while shifted (Am to Bm at +2) when the song's key is known</li>
+          <li>Per-song by design: resets to 0 on every load and is never saved to settings</li>
+          <li>Zero cost when unshifted - the pitch processor is fully bypassed at 0</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.8.1" date="2026-07-18">
       <description>
         <p>Editor save no longer freezes the app</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loukai-app",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loukai-app",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loukai-app",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "type": "module",
   "description": "Loukai Karaoke - Free and open source karaoke system for playing and creating stem-based karaoke files",
   "main": "src/main/main.js",


### PR DESCRIPTION
Feature release: key shift for the loaded song (#90 / #91). Version bump + metainfo release notes. After merge: tag `v0.9.0` on main to fire the Build and Release workflow.