### PR TITLE
Chord track: detect at creation, display current+next

### DIFF
--- a/docs/m4a_format.md
+++ b/docs/m4a_format.md
@@ -153,6 +153,10 @@ Contains lyrics, timing, word-level timing, and singer metadata in JSON format. 
     "duet": { "name": "Both", "color": "#22C55E" }
   },
   "tags": ["edited", "ai_corrected"],
+  "chords": [
+    { "start": 0.0, "end": 2.1, "chord": "C" },
+    { "start": 2.1, "end": 4.3, "chord": "Am" }
+  ],
   "lines": [
     {
       "start": 12.5,
@@ -183,6 +187,28 @@ Each line can optionally include a `words` object with relative timing for each 
 ```
 
 - **timings**: Array of `[start, end]` pairs, one per word (split on spaces)
+
+#### Chord Track
+
+The optional `chords` array is a timed chord track detected from the separated
+stems at creation time (chromagram over the other stem with bass-informed
+roots). Segments are ordered, non-overlapping, with times in seconds relative
+to the same clock as `lines`:
+
+```json
+"chords": [
+  { "start": 0.0, "end": 2.1, "chord": "C" },
+  { "start": 2.1, "end": 4.3, "chord": "Am" }
+]
+```
+
+- **chord**: root note (sharps preferred: `C`, `C#`, ... `B`) plus an optional
+  `m` suffix for minor triads. Future revisions may add richer qualities
+  (`7`, `sus4`); readers should display the string as-is
+- Silent or harmonically ambiguous stretches simply have no segment
+- Players display the chord whose window contains the current position and may
+  preview the next segment; when a player transposes playback (key shift), the
+  displayed names are transposed by the same interval
 - **Relative timing**: Offsets are relative to the line's `start` time
 - **Example**: `"Hello world"` at line start 12.5s with `[[0, 0.4], [0.5, 1.0]]` means:
   - "Hello" plays from 12.5s to 12.9s

--- a/src/main/creator/stemBuilder.js
+++ b/src/main/creator/stemBuilder.js
@@ -31,7 +31,7 @@ import { Atoms as M4AAtoms } from 'stem-mp4';
  * @param {Object} data - Karaoke data to embed
  */
 async function injectKaraokeAtoms(filePath, data) {
-  const { lyrics, llmCorrections, tags } = data;
+  const { lyrics, llmCorrections, tags, chords } = data;
 
   // Convert lyrics segments to lines format expected by kara atom
   // Include word-level timing if available from Whisper
@@ -66,6 +66,7 @@ async function injectKaraokeAtoms(filePath, data) {
   // Build kara data structure for stem-mp4
   // Note: Audio sources are read from the NI Stems 'stem' atom, not stored in kara
   const karaData = {
+    ...(chords && chords.length > 0 && { chords }),
     // Timing information
     timing: {
       offset_sec: 0,
@@ -139,7 +140,7 @@ async function injectKaraokeAtoms(filePath, data) {
  * @returns {Promise<void>}
  */
 export async function injectLyricsIntoStemFile(options) {
-  const { filePath, lyrics, llmCorrections, tags } = options;
+  const { filePath, lyrics, llmCorrections, tags, chords } = options;
 
   log(`🎤 Injecting lyrics into existing stem file: ${filePath}`);
 
@@ -181,6 +182,7 @@ export async function injectLyricsIntoStemFile(options) {
 
   // Note: Audio sources are read from the NI Stems 'stem' atom, not stored in kara
   const karaData = {
+    ...(chords && chords.length > 0 && { chords }),
     timing: {
       offset_sec: existingKara?.timing?.offset_sec || 0,
       encoder_delay_samples: existingKara?.timing?.encoder_delay_samples || 0,

--- a/src/main/handlers/creatorHandlers.js
+++ b/src/main/handlers/creatorHandlers.js
@@ -113,7 +113,7 @@ export function registerCreatorHandlers(mainApp) {
   // (the renderer encodes WAV -> AAC via ffmpeg-wasm before sending).
   ipcMain.handle(
     'creator:saveWebGpuStems',
-    async (_event, { stems, metadata, lyrics, pitch, referenceLyrics }) => {
+    async (_event, { stems, metadata, lyrics, chords, pitch, referenceLyrics }) => {
       const tmpDir = join(getCacheDir(), 'webgpu-creator', crypto.randomBytes(8).toString('hex'));
       mkdirSync(tmpDir, { recursive: true });
       const paths = {};
@@ -128,6 +128,7 @@ export function registerCreatorHandlers(mainApp) {
           stems: paths,
           metadata,
           lyrics,
+          chords,
           pitch,
           referenceLyrics,
           settingsManager: mainApp.settings, // backend runs LLM correction (like native)

--- a/src/main/handlers/editorHandlers.js
+++ b/src/main/handlers/editorHandlers.js
@@ -53,6 +53,7 @@ export function registerEditorHandlers(mainApp) {
         format: format,
         metadata: songData.song || songData.metadata || {},
         lyrics: songData.lyrics,
+        chords: songData.chords,
       });
 
       log(`${format.toUpperCase()} file saved successfully`);

--- a/src/main/handlers/libraryHandlers.js
+++ b/src/main/handlers/libraryHandlers.js
@@ -13,6 +13,23 @@ import * as libraryService from '../../shared/services/libraryService.js';
  * @param {Object} mainApp - Main application instance
  */
 export function registerLibraryHandlers(mainApp) {
+  // Chord backfill (issue #93): the renderer analyzed a legacy song's stems and
+  // hands back the chord track; merge it into the file off the main thread.
+  ipcMain.handle('library:writeChords', (event, { path: filePath, chords }) => {
+    return new Promise((resolve) => {
+      import('node:worker_threads').then(({ Worker }) => {
+        try {
+          const worker = new Worker(new URL('../workers/writeChordsWorker.js', import.meta.url), {
+            workerData: { filePath, chords },
+          });
+          worker.once('message', (m) => resolve(m));
+          worker.once('error', (e) => resolve({ ok: false, error: e.message }));
+        } catch (e) {
+          resolve({ ok: false, error: e.message });
+        }
+      });
+    });
+  });
   // Get songs folder
   ipcMain.handle(LIBRARY_CHANNELS.GET_SONGS_FOLDER, () => {
     return libraryService.getSongsFolder(mainApp);

--- a/src/main/handlers/settingsHandlers.js
+++ b/src/main/handlers/settingsHandlers.js
@@ -18,7 +18,7 @@ import {
  * Register all settings-related IPC handlers
  * @param {Object} _mainApp - Main application instance (unused, kept for signature consistency)
  */
-export function registerSettingsHandlers(_mainApp) {
+export function registerSettingsHandlers(mainApp) {
   log('📡 Registering settings handlers...');
 
   // Get setting - uses settingsService which applies defaults
@@ -28,7 +28,16 @@ export function registerSettingsHandlers(_mainApp) {
 
   // Set setting - uses settingsService for persistence, AppState sync, and broadcast
   ipcMain.handle(SETTINGS_CHANNELS.SET, (event, key, value) => {
-    return setSetting(key, value);
+    const result = setSetting(key, value);
+    // Mirror renderer-side settings changes to web admin clients. The web save
+    // path already emits these; without this, a toggle flipped in the app never
+    // updated an open web admin (the reverse direction worked).
+    const io = mainApp?.webServer?.io;
+    if (io) {
+      if (key === 'waveformPreferences') io.to('admin-clients').emit('settings:waveform', value);
+      if (key === 'autoTunePreferences') io.to('admin-clients').emit('settings:autotune', value);
+    }
+    return result;
   });
 
   // Get all settings - merged with defaults

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -137,6 +137,7 @@ const api = {
     getCachedSongs: () => ipcRenderer.invoke('library:getCachedSongs'),
     getSongInfo: (filePath) => ipcRenderer.invoke('library:getSongInfo', filePath),
     search: (query) => ipcRenderer.invoke('library:search', query),
+    writeChords: (path, chords) => ipcRenderer.invoke('library:writeChords', { path, chords }),
 
     onFolderSet: (callback) => ipcRenderer.on('library:folderSet', callback),
     removeFolderSetListener: (callback) =>

--- a/src/main/webServer.js
+++ b/src/main/webServer.js
@@ -2133,6 +2133,7 @@ class WebServer {
               stems: stemPaths,
               metadata: { title, artist, album, key: created.key, duration: created.duration },
               lyrics: created.lyrics,
+              chords: created.chords,
               pitch: created.pitch,
               referenceLyrics,
               settingsManager: this.mainApp.settings,

--- a/src/main/webServer.js
+++ b/src/main/webServer.js
@@ -1992,6 +1992,12 @@ class WebServer {
           } catch {
             /* ignore malformed pitch */
           }
+          let chords;
+          try {
+            chords = req.body.chords ? JSON.parse(req.body.chords) : undefined;
+          } catch {
+            /* ignore malformed chords */
+          }
           let refLyrics;
           try {
             refLyrics = req.body.referenceLyrics ? req.body.referenceLyrics.toString() : undefined;
@@ -2002,6 +2008,7 @@ class WebServer {
             stems,
             metadata: { title, artist, album, year, genre, track, duration, key },
             lyrics,
+            chords,
             pitch,
             referenceLyrics: refLyrics,
             settingsManager: this.mainApp.settings, // backend runs LLM correction

--- a/src/main/webServer.js
+++ b/src/main/webServer.js
@@ -1144,6 +1144,7 @@ class WebServer {
               metadata: result.kaiData.metadata || {},
               lyrics: result.kaiData.lyrics || [],
               audioFiles: audioFiles,
+              chords: result.kaiData.chords || [],
               songJson: result.kaiData.originalSongJson || {},
             },
           });
@@ -1289,7 +1290,7 @@ class WebServer {
     // Save song edits
     this.app.post('/admin/editor/save', async (req, res) => {
       try {
-        const { path: songPath, format, metadata, lyrics } = req.body;
+        const { path: songPath, format, metadata, lyrics, chords } = req.body;
         if (!songPath) {
           return res.status(400).json({
             success: false,
@@ -1312,7 +1313,7 @@ class WebServer {
         // branch below and failed with "Invalid file format".
         if (isStemMp4Format(format)) {
           const { saveSongOffMain } = await import('./workers/saveSongOffMain.js');
-          await saveSongOffMain(validatedPath, { format, metadata, lyrics });
+          await saveSongOffMain(validatedPath, { format, metadata, lyrics, chords });
 
           // Update cached library entry if it exists
           if (this.mainApp.cachedLibrary) {

--- a/src/main/workers/writeChordsWorker.js
+++ b/src/main/workers/writeChordsWorker.js
@@ -1,0 +1,15 @@
+/**
+ * Merge a chord track into a song's kara atom off the main process (the
+ * whole-file rebuild would otherwise block input routing, issue #87's lesson).
+ */
+import { parentPort, workerData } from 'node:worker_threads';
+
+const { filePath, chords } = workerData;
+try {
+  const { Atoms } = await import('stem-mp4');
+  const kara = await Atoms.readKaraAtom(filePath);
+  await Atoms.writeKaraAtom(filePath, { ...kara, chords });
+  parentPort.postMessage({ ok: true });
+} catch (e) {
+  parentPort.postMessage({ ok: false, error: e?.message || String(e) });
+}

--- a/src/renderer/adapters/ElectronBridge.js
+++ b/src/renderer/adapters/ElectronBridge.js
@@ -368,6 +368,7 @@ export class ElectronBridge extends BridgeInterface {
         format: 'stem-mp4',
         metadata: songData.metadata || {},
         lyrics: songData.lyrics || [],
+        chords: songData.chords || [],
         audioFiles: audioFiles,
         songJson: songData.originalSongJson || {},
       },
@@ -375,7 +376,7 @@ export class ElectronBridge extends BridgeInterface {
   }
 
   async saveSongEdits(updates) {
-    const { path, metadata, lyrics, format } = updates;
+    const { path, metadata, lyrics, chords, format } = updates;
 
     if (format === 'stem-mp4') {
       // Build the song object for the editor save
@@ -389,6 +390,7 @@ export class ElectronBridge extends BridgeInterface {
           key: metadata.key,
         },
         lyrics: lyrics,
+        chords: chords,
       };
 
       // Include meta if rejections/suggestions were updated

--- a/src/renderer/adapters/ElectronBridge.js
+++ b/src/renderer/adapters/ElectronBridge.js
@@ -456,6 +456,7 @@ export class ElectronBridge extends BridgeInterface {
       enableEffects: prefs.enableEffects,
       randomEffectOnSong: prefs.randomEffectOnSong,
       showUpcomingLyrics: prefs.showUpcomingLyrics,
+      showChords: prefs.showChords,
       overlayOpacity: prefs.overlayOpacity,
     };
 

--- a/src/renderer/js/cdgPlayer.js
+++ b/src/renderer/js/cdgPlayer.js
@@ -296,6 +296,12 @@ export class CDGPlayer extends PlayerInterface {
       if (!this.isPlaying) return;
 
       this.renderFrame();
+      // Chord corner display (issue #93) rides on top of the CDG frame.
+      window.app?.player?.karaokeRenderer?.drawChordTrackAt?.(
+        this.ctx,
+        this.canvas,
+        this.getCurrentTime()
+      );
       this.animationFrame = requestAnimationFrame(render);
     };
 

--- a/src/renderer/js/karaokeRenderer.js
+++ b/src/renderer/js/karaokeRenderer.js
@@ -62,6 +62,7 @@ export class KaraokeRenderer {
       enableEffects: true,
       overlayOpacity: 0.7,
       showUpcomingLyrics: true,
+      showChords: true,
     };
 
     // FPS and performance tracking
@@ -1527,6 +1528,7 @@ export class KaraokeRenderer {
    * chords.
    */
   drawChordTrack() {
+    if (this.waveformPreferences.showChords === false) return;
     const chords = this.chordTrack;
     if (!chords?.length) return;
     const t = this.currentTime;
@@ -3076,6 +3078,10 @@ export class KaraokeRenderer {
 
   setShowUpcomingLyrics(enabled) {
     this.waveformPreferences.showUpcomingLyrics = enabled;
+  }
+
+  setShowChords(enabled) {
+    this.waveformPreferences.showChords = enabled;
   }
 
   drawUpcomingLyrics(canvasWidth, canvasHeight, startY) {

--- a/src/renderer/js/karaokeRenderer.js
+++ b/src/renderer/js/karaokeRenderer.js
@@ -1,4 +1,5 @@
 // TODO: State should be passed to renderer instead of accessing globals
+import { shiftKeyName } from '../../shared/utils/musicKey.js';
 
 export class KaraokeRenderer {
   constructor(canvasId) {
@@ -1497,6 +1498,7 @@ export class KaraokeRenderer {
       const frameStart = performance.now();
 
       this.draw();
+      this.drawChordTrack();
 
       // Track time spent in updates vs rendering
       this.frameUpdateTime = performance.now() - frameStart;
@@ -1511,6 +1513,55 @@ export class KaraokeRenderer {
       cancelAnimationFrame(this.animationFrame);
       this.animationFrame = null;
     }
+  }
+
+  /**
+   * Chord track (#93): current chord big, next chord smaller and dimmer, top
+   * right corner. Data comes from the kara atom (songData.chords); names are
+   * transposed live when the key shift is active. Pure canvas text on the
+   * already-running draw loop: no extra timers, no cost when a song has no
+   * chords.
+   */
+  drawChordTrack() {
+    const chords = this.songData?.chords;
+    if (!chords?.length) return;
+    const t = this.currentTime;
+    let current = null;
+    let next = null;
+    for (let i = 0; i < chords.length; i++) {
+      if (chords[i].start <= t && t < chords[i].end) {
+        current = chords[i];
+        next = chords[i + 1] || null;
+        break;
+      }
+      if (chords[i].start > t) {
+        next = chords[i];
+        break;
+      }
+    }
+    if (!current && !next) return;
+    const shift = window.app?.player?.kaiPlayer?.keyShift ?? 0;
+    const name = (c) => (shift ? shiftKeyName(c.chord, shift) || c.chord : c.chord);
+    const ctx = this.ctx;
+    const w = this.canvas.width;
+    ctx.save();
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'top';
+    if (current) {
+      ctx.font = `bold ${Math.round(this.canvas.height * 0.06)}px sans-serif`;
+      ctx.fillStyle = 'rgba(255, 255, 255, 0.92)';
+      ctx.shadowColor = 'rgba(0, 0, 0, 0.8)';
+      ctx.shadowBlur = 6;
+      ctx.fillText(name(current), w - 24, 18);
+    }
+    if (next) {
+      ctx.font = `${Math.round(this.canvas.height * 0.035)}px sans-serif`;
+      ctx.fillStyle = 'rgba(255, 255, 255, 0.55)';
+      ctx.shadowColor = 'rgba(0, 0, 0, 0.8)';
+      ctx.shadowBlur = 4;
+      ctx.fillText(name(next), w - 24, 18 + Math.round(this.canvas.height * 0.07));
+    }
+    ctx.restore();
   }
 
   draw() {

--- a/src/renderer/js/karaokeRenderer.js
+++ b/src/renderer/js/karaokeRenderer.js
@@ -350,6 +350,10 @@ export class KaraokeRenderer {
     this.resizeHandler = resizeCanvas;
   }
 
+  setChords(chords) {
+    this.chordTrack = Array.isArray(chords) && chords.length > 0 ? chords : null;
+  }
+
   setSongMetadata(metadata) {
     // Store song metadata for display when not playing
     this.songMetadata = metadata || {};
@@ -1523,7 +1527,7 @@ export class KaraokeRenderer {
    * chords.
    */
   drawChordTrack() {
-    const chords = this.songData?.chords;
+    const chords = this.chordTrack;
     if (!chords?.length) return;
     const t = this.currentTime;
     let current = null;

--- a/src/renderer/js/karaokeRenderer.js
+++ b/src/renderer/js/karaokeRenderer.js
@@ -1528,10 +1528,18 @@ export class KaraokeRenderer {
    * chords.
    */
   drawChordTrack() {
+    this.drawChordTrackAt(this.ctx, this.canvas, this.currentTime);
+  }
+
+  /**
+   * Draw the chord corner display onto ANY canvas at a given position - the
+   * CDG player calls this from its own render loop with its own clock, so
+   * chords work on CDG songs too (display only; an MP3 has no kara atom).
+   */
+  drawChordTrackAt(ctx, canvas, t) {
     if (!this.waveformPreferences.showChords) return;
     const chords = this.chordTrack;
     if (!chords?.length) return;
-    const t = this.currentTime;
     let current = null;
     let next = null;
     for (let i = 0; i < chords.length; i++) {
@@ -1548,24 +1556,23 @@ export class KaraokeRenderer {
     if (!current && !next) return;
     const shift = window.app?.player?.kaiPlayer?.keyShift ?? 0;
     const name = (c) => (shift ? shiftKeyName(c.chord, shift) || c.chord : c.chord);
-    const ctx = this.ctx;
-    const w = this.canvas.width;
+    const w = canvas.width;
     ctx.save();
     ctx.textAlign = 'right';
     ctx.textBaseline = 'top';
     if (current) {
-      ctx.font = `bold ${Math.round(this.canvas.height * 0.06)}px sans-serif`;
+      ctx.font = `bold ${Math.round(canvas.height * 0.06)}px sans-serif`;
       ctx.fillStyle = 'rgba(255, 255, 255, 0.92)';
       ctx.shadowColor = 'rgba(0, 0, 0, 0.8)';
       ctx.shadowBlur = 6;
       ctx.fillText(name(current), w - 24, 18);
     }
     if (next) {
-      ctx.font = `${Math.round(this.canvas.height * 0.035)}px sans-serif`;
+      ctx.font = `${Math.round(canvas.height * 0.035)}px sans-serif`;
       ctx.fillStyle = 'rgba(255, 255, 255, 0.55)';
       ctx.shadowColor = 'rgba(0, 0, 0, 0.8)';
       ctx.shadowBlur = 4;
-      ctx.fillText(name(next), w - 24, 18 + Math.round(this.canvas.height * 0.07));
+      ctx.fillText(name(next), w - 24, 18 + Math.round(canvas.height * 0.07));
     }
     ctx.restore();
   }

--- a/src/renderer/js/karaokeRenderer.js
+++ b/src/renderer/js/karaokeRenderer.js
@@ -62,7 +62,7 @@ export class KaraokeRenderer {
       enableEffects: true,
       overlayOpacity: 0.7,
       showUpcomingLyrics: true,
-      showChords: true,
+      showChords: false,
     };
 
     // FPS and performance tracking
@@ -1528,7 +1528,7 @@ export class KaraokeRenderer {
    * chords.
    */
   drawChordTrack() {
-    if (this.waveformPreferences.showChords === false) return;
+    if (!this.waveformPreferences.showChords) return;
     const chords = this.chordTrack;
     if (!chords?.length) return;
     const t = this.currentTime;

--- a/src/renderer/js/player.js
+++ b/src/renderer/js/player.js
@@ -204,6 +204,9 @@ export class PlayerController {
       if (settings.enableEffects !== undefined) {
         this.karaokeRenderer.waveformPreferences.enableEffects = settings.enableEffects;
       }
+      if (settings.showChords !== undefined) {
+        this.karaokeRenderer.waveformPreferences.showChords = settings.showChords;
+      }
       if (settings.showUpcomingLyrics !== undefined) {
         this.karaokeRenderer.waveformPreferences.showUpcomingLyrics = settings.showUpcomingLyrics;
       }

--- a/src/renderer/js/player.js
+++ b/src/renderer/js/player.js
@@ -66,6 +66,7 @@ export class PlayerController {
         artist: metadata.artist,
         requester: metadata.requester,
       });
+      this.karaokeRenderer.setChords(metadata.chords);
     }
 
     // Get duration from player for karaokeRenderer

--- a/src/renderer/js/player.js
+++ b/src/renderer/js/player.js
@@ -206,6 +206,12 @@ export class PlayerController {
       }
       if (settings.showChords !== undefined) {
         this.karaokeRenderer.waveformPreferences.showChords = settings.showChords;
+        // Toggled ON with a chordless song loaded: analyze it now (the load-time
+        // backfill is skipped while the display is off).
+        const kp = window.app?.kaiPlayer || window.app?.player?.kaiPlayer;
+        if (settings.showChords && kp?.songData && !kp.songData.chords?.length) {
+          import('./songLoaders.js').then((m) => m.backfillChords(window.app, kp.songData));
+        }
       }
       if (settings.showUpcomingLyrics !== undefined) {
         this.karaokeRenderer.waveformPreferences.showUpcomingLyrics = settings.showUpcomingLyrics;

--- a/src/renderer/js/player.js
+++ b/src/renderer/js/player.js
@@ -211,6 +211,12 @@ export class PlayerController {
         const kp = window.app?.kaiPlayer || window.app?.player?.kaiPlayer;
         if (settings.showChords && kp?.songData && !kp.songData.chords?.length) {
           import('./songLoaders.js').then((m) => m.backfillChords(window.app, kp.songData));
+        } else if (
+          settings.showChords &&
+          !kp?.songData &&
+          window.app?.player?.cdgPlayer?.audioBuffer
+        ) {
+          import('./songLoaders.js').then((m) => m.backfillChordsCdg(window.app));
         }
       }
       if (settings.showUpcomingLyrics !== undefined) {

--- a/src/renderer/js/songLoaders.js
+++ b/src/renderer/js/songLoaders.js
@@ -14,6 +14,41 @@
  * they exist, and persist them into the file once (a worker thread on the
  * main side) so this never runs again for the song.
  */
+/**
+ * CDG variant (issue #93): analyze the decoded full mix for display only.
+ * There is no kara atom in an MP3 to persist into, so this runs per load
+ * (gated on the Show Chords pref) and quality is full-mix rather than
+ * stem-separated - good enough to follow along.
+ */
+export function backfillChordsCdg(app) {
+  try {
+    const buf = app.player?.cdgPlayer?.audioBuffer;
+    if (!buf) return;
+    const toStem = (b) => ({
+      left: b.getChannelData(0).slice(),
+      right: b.numberOfChannels > 1 ? b.getChannelData(1).slice() : undefined,
+    });
+    const other = toStem(buf);
+    const loadedPath = app.currentSong?.path;
+    const worker = new Worker(new URL('../workers/chordWorker.js', import.meta.url), {
+      type: 'module',
+    });
+    const transfers = [other.left.buffer];
+    if (other.right) transfers.push(other.right.buffer);
+    worker.onmessage = (e) => {
+      worker.terminate();
+      if (!e.data.ok || !e.data.chords?.length) return;
+      if (app.currentSong?.path !== loadedPath) return; // song changed meanwhile
+      app.player?.karaokeRenderer?.setChords(e.data.chords);
+      console.log(`🎸 chord analysis (cdg, display only): ${e.data.chords.length} segments`);
+    };
+    worker.onerror = () => worker.terminate();
+    worker.postMessage({ other, bass: null, sampleRate: buf.sampleRate }, transfers);
+  } catch (e) {
+    console.warn('cdg chord analysis skipped:', e.message);
+  }
+}
+
 export function backfillChords(app, songData) {
   try {
     if (songData?.chords?.length) return; // already has a chord track
@@ -163,6 +198,7 @@ export async function loadCDGSong(app, songData, metadata) {
     requester: metadata.requester || songData.requester || app.currentSong?.requester,
   };
   app.player.onSongLoaded(fullMetadata);
+  if (waveformPrefs.showChords === true) backfillChordsCdg(app);
 
   // Broadcast that CDG is ready (clear loading state)
   if (window.kaiAPI?.renderer) {

--- a/src/renderer/js/songLoaders.js
+++ b/src/renderer/js/songLoaders.js
@@ -162,6 +162,7 @@ export async function loadKAISong(app, songData, metadata) {
     const fullMetadata = {
       ...metadata,
       lyrics: app.currentSong.lyrics,
+      chords: songData.chords || app.currentSong.chords || null,
       duration: app.kaiPlayer
         ? app.kaiPlayer.getDuration()
         : app.currentSong.metadata?.duration || 0,
@@ -273,6 +274,7 @@ export async function loadM4ASong(app, songData, metadata) {
     const fullMetadata = {
       ...metadata,
       lyrics: app.currentSong.lyrics,
+      chords: songData.chords || app.currentSong.chords || null,
       duration: app.kaiPlayer
         ? app.kaiPlayer.getDuration()
         : app.currentSong.metadata?.duration || 0,

--- a/src/renderer/js/songLoaders.js
+++ b/src/renderer/js/songLoaders.js
@@ -6,6 +6,66 @@
 /**
  * Load CDG format song
  */
+
+/**
+ * Chord backfill (issue #93): a legacy song has stems but no chord track. The
+ * player already holds every stem DECODED, so analysis is nearly free: run
+ * detection in a Web Worker (UI never feels it), show the chords as soon as
+ * they exist, and persist them into the file once (a worker thread on the
+ * main side) so this never runs again for the song.
+ */
+function backfillChords(app, songData) {
+  try {
+    if (songData?.chords?.length) return; // already has a chord track
+    const filePath = songData?.originalFilePath || app.currentSong?.path;
+    const buffers = app.kaiPlayer?.audioBuffers;
+    if (!filePath || !buffers?.size) return;
+    const pick = (name) => {
+      for (const [k, buf] of buffers) {
+        if (k.toLowerCase().includes(name)) return buf;
+      }
+      return null;
+    };
+    const otherBuf = pick('other') || pick('music');
+    if (!otherBuf) return;
+    const bassBuf = pick('bass');
+    const toStem = (buf) =>
+      buf && {
+        left: buf.getChannelData(0).slice(),
+        right: buf.numberOfChannels > 1 ? buf.getChannelData(1).slice() : undefined,
+      };
+    const other = toStem(otherBuf);
+    const bass = toStem(bassBuf);
+    const worker = new Worker(new URL('../workers/chordWorker.js', import.meta.url), {
+      type: 'module',
+    });
+    const transfers = [other.left.buffer];
+    if (other.right) transfers.push(other.right.buffer);
+    if (bass?.left) transfers.push(bass.left.buffer);
+    if (bass?.right) transfers.push(bass.right.buffer);
+    worker.onmessage = async (e) => {
+      worker.terminate();
+      if (!e.data.ok || !e.data.chords?.length) return;
+      const chords = e.data.chords;
+      // Live display for this session…
+      if (app.kaiPlayer?.songData) app.kaiPlayer.songData.chords = chords;
+      app.player?.karaokeRenderer?.setChords(chords);
+      console.log(`🎸 chord backfill: ${chords.length} segments`);
+      // …and one-time persistence into the file.
+      try {
+        const r = await window.kaiAPI.library.writeChords(filePath, chords);
+        if (!r?.ok) console.warn('chord backfill write failed:', r?.error);
+      } catch (err) {
+        console.warn('chord backfill write failed:', err.message);
+      }
+    };
+    worker.onerror = () => worker.terminate();
+    worker.postMessage({ other, bass, sampleRate: otherBuf.sampleRate }, transfers);
+  } catch (e) {
+    console.warn('chord backfill skipped:', e.message);
+  }
+}
+
 export async function loadCDGSong(app, songData, metadata) {
   app.player.currentFormat = 'cdg';
   app.player.currentPlayer = app.player.cdgPlayer;
@@ -170,6 +230,7 @@ export async function loadKAISong(app, songData, metadata) {
       requester: metadata.requester || songData.requester || app.currentSong.requester,
     };
     app.player.onSongLoaded(fullMetadata);
+    backfillChords(app, songData);
 
     // Load and apply waveform preferences from settings for KAI
     // Defaults are now provided by settingsManager from shared/defaults.js
@@ -283,6 +344,7 @@ export async function loadM4ASong(app, songData, metadata) {
       requester: metadata.requester || songData.requester || app.currentSong.requester,
     };
     app.player.onSongLoaded(fullMetadata);
+    backfillChords(app, songData);
 
     // Load and apply waveform preferences from settings
     // Defaults are now provided by settingsManager from shared/defaults.js

--- a/src/renderer/js/songLoaders.js
+++ b/src/renderer/js/songLoaders.js
@@ -47,9 +47,14 @@ function backfillChords(app, songData) {
       worker.terminate();
       if (!e.data.ok || !e.data.chords?.length) return;
       const chords = e.data.chords;
-      // Live display for this session…
-      if (app.kaiPlayer?.songData) app.kaiPlayer.songData.chords = chords;
-      app.player?.karaokeRenderer?.setChords(chords);
+      // Live display only if THIS song is still the loaded one (skipping songs
+      // quickly must not paint the previous song's chords)…
+      const stillLoaded =
+        (app.currentSong?.path || app.kaiPlayer?.songData?.originalFilePath) === filePath;
+      if (stillLoaded) {
+        if (app.kaiPlayer?.songData) app.kaiPlayer.songData.chords = chords;
+        app.player?.karaokeRenderer?.setChords(chords);
+      }
       console.log(`🎸 chord backfill: ${chords.length} segments`);
       // …and one-time persistence into the file.
       try {

--- a/src/renderer/js/songLoaders.js
+++ b/src/renderer/js/songLoaders.js
@@ -235,10 +235,6 @@ export async function loadKAISong(app, songData, metadata) {
       requester: metadata.requester || songData.requester || app.currentSong.requester,
     };
     app.player.onSongLoaded(fullMetadata);
-    // Backfill only when the chord display is actually on: with it off (the
-    // default) we neither burn the analysis nor rewrite files nobody asked for.
-    // Turning the toggle on backfills the loaded song at that moment instead.
-    if (waveformPrefs.showChords === true) backfillChords(app, songData);
 
     // Load and apply waveform preferences from settings for KAI
     // Defaults are now provided by settingsManager from shared/defaults.js
@@ -250,6 +246,10 @@ export async function loadKAISong(app, songData, metadata) {
       app.player.karaokeRenderer.setEffectsEnabled(waveformPrefs.enableEffects);
       app.player.karaokeRenderer.setShowUpcomingLyrics(waveformPrefs.showUpcomingLyrics);
       app.player.karaokeRenderer.setShowChords(waveformPrefs.showChords === true);
+      // Backfill only when the chord display is actually on: with it off (the
+      // default) we neither burn the analysis nor rewrite files nobody asked
+      // for. Turning the toggle on backfills the loaded song at that moment.
+      if (waveformPrefs.showChords === true) backfillChords(app, songData);
       app.player.karaokeRenderer.waveformPreferences.overlayOpacity = waveformPrefs.overlayOpacity;
 
       // Connect butterchurn to PA analyser for visualization (KAI format)
@@ -352,10 +352,6 @@ export async function loadM4ASong(app, songData, metadata) {
       requester: metadata.requester || songData.requester || app.currentSong.requester,
     };
     app.player.onSongLoaded(fullMetadata);
-    // Backfill only when the chord display is actually on: with it off (the
-    // default) we neither burn the analysis nor rewrite files nobody asked for.
-    // Turning the toggle on backfills the loaded song at that moment instead.
-    if (waveformPrefs.showChords === true) backfillChords(app, songData);
 
     // Load and apply waveform preferences from settings
     // Defaults are now provided by settingsManager from shared/defaults.js
@@ -367,6 +363,10 @@ export async function loadM4ASong(app, songData, metadata) {
       app.player.karaokeRenderer.setEffectsEnabled(waveformPrefs.enableEffects);
       app.player.karaokeRenderer.setShowUpcomingLyrics(waveformPrefs.showUpcomingLyrics);
       app.player.karaokeRenderer.setShowChords(waveformPrefs.showChords === true);
+      // Backfill only when the chord display is actually on: with it off (the
+      // default) we neither burn the analysis nor rewrite files nobody asked
+      // for. Turning the toggle on backfills the loaded song at that moment.
+      if (waveformPrefs.showChords === true) backfillChords(app, songData);
       app.player.karaokeRenderer.waveformPreferences.overlayOpacity = waveformPrefs.overlayOpacity;
 
       // Connect butterchurn to PA analyser for visualization (M4A format)

--- a/src/renderer/js/songLoaders.js
+++ b/src/renderer/js/songLoaders.js
@@ -198,6 +198,10 @@ export async function loadCDGSong(app, songData, metadata) {
     requester: metadata.requester || songData.requester || app.currentSong?.requester,
   };
   app.player.onSongLoaded(fullMetadata);
+  // The chord overlay reads the renderer's pref flag; the CDG path must apply
+  // it like the stems path does or the overlay stays off regardless of the
+  // setting (the karaokeRenderer default is off).
+  app.player.karaokeRenderer?.setShowChords(waveformPrefs.showChords === true);
   if (waveformPrefs.showChords === true) backfillChordsCdg(app);
 
   // Broadcast that CDG is ready (clear loading state)

--- a/src/renderer/js/songLoaders.js
+++ b/src/renderer/js/songLoaders.js
@@ -14,7 +14,7 @@
  * they exist, and persist them into the file once (a worker thread on the
  * main side) so this never runs again for the song.
  */
-function backfillChords(app, songData) {
+export function backfillChords(app, songData) {
   try {
     if (songData?.chords?.length) return; // already has a chord track
     const filePath = songData?.originalFilePath || app.currentSong?.path;
@@ -235,7 +235,10 @@ export async function loadKAISong(app, songData, metadata) {
       requester: metadata.requester || songData.requester || app.currentSong.requester,
     };
     app.player.onSongLoaded(fullMetadata);
-    backfillChords(app, songData);
+    // Backfill only when the chord display is actually on: with it off (the
+    // default) we neither burn the analysis nor rewrite files nobody asked for.
+    // Turning the toggle on backfills the loaded song at that moment instead.
+    if (waveformPrefs.showChords === true) backfillChords(app, songData);
 
     // Load and apply waveform preferences from settings for KAI
     // Defaults are now provided by settingsManager from shared/defaults.js
@@ -349,7 +352,10 @@ export async function loadM4ASong(app, songData, metadata) {
       requester: metadata.requester || songData.requester || app.currentSong.requester,
     };
     app.player.onSongLoaded(fullMetadata);
-    backfillChords(app, songData);
+    // Backfill only when the chord display is actually on: with it off (the
+    // default) we neither burn the analysis nor rewrite files nobody asked for.
+    // Turning the toggle on backfills the loaded song at that moment instead.
+    if (waveformPrefs.showChords === true) backfillChords(app, songData);
 
     // Load and apply waveform preferences from settings
     // Defaults are now provided by settingsManager from shared/defaults.js

--- a/src/renderer/js/songLoaders.js
+++ b/src/renderer/js/songLoaders.js
@@ -180,6 +180,7 @@ export async function loadKAISong(app, songData, metadata) {
       app.player.karaokeRenderer.setWaveformsEnabled(waveformPrefs.enableWaveforms);
       app.player.karaokeRenderer.setEffectsEnabled(waveformPrefs.enableEffects);
       app.player.karaokeRenderer.setShowUpcomingLyrics(waveformPrefs.showUpcomingLyrics);
+      app.player.karaokeRenderer.setShowChords(waveformPrefs.showChords !== false);
       app.player.karaokeRenderer.waveformPreferences.overlayOpacity = waveformPrefs.overlayOpacity;
 
       // Connect butterchurn to PA analyser for visualization (KAI format)
@@ -292,6 +293,7 @@ export async function loadM4ASong(app, songData, metadata) {
       app.player.karaokeRenderer.setWaveformsEnabled(waveformPrefs.enableWaveforms);
       app.player.karaokeRenderer.setEffectsEnabled(waveformPrefs.enableEffects);
       app.player.karaokeRenderer.setShowUpcomingLyrics(waveformPrefs.showUpcomingLyrics);
+      app.player.karaokeRenderer.setShowChords(waveformPrefs.showChords !== false);
       app.player.karaokeRenderer.waveformPreferences.overlayOpacity = waveformPrefs.overlayOpacity;
 
       // Connect butterchurn to PA analyser for visualization (M4A format)

--- a/src/renderer/js/songLoaders.js
+++ b/src/renderer/js/songLoaders.js
@@ -246,7 +246,7 @@ export async function loadKAISong(app, songData, metadata) {
       app.player.karaokeRenderer.setWaveformsEnabled(waveformPrefs.enableWaveforms);
       app.player.karaokeRenderer.setEffectsEnabled(waveformPrefs.enableEffects);
       app.player.karaokeRenderer.setShowUpcomingLyrics(waveformPrefs.showUpcomingLyrics);
-      app.player.karaokeRenderer.setShowChords(waveformPrefs.showChords !== false);
+      app.player.karaokeRenderer.setShowChords(waveformPrefs.showChords === true);
       app.player.karaokeRenderer.waveformPreferences.overlayOpacity = waveformPrefs.overlayOpacity;
 
       // Connect butterchurn to PA analyser for visualization (KAI format)
@@ -360,7 +360,7 @@ export async function loadM4ASong(app, songData, metadata) {
       app.player.karaokeRenderer.setWaveformsEnabled(waveformPrefs.enableWaveforms);
       app.player.karaokeRenderer.setEffectsEnabled(waveformPrefs.enableEffects);
       app.player.karaokeRenderer.setShowUpcomingLyrics(waveformPrefs.showUpcomingLyrics);
-      app.player.karaokeRenderer.setShowChords(waveformPrefs.showChords !== false);
+      app.player.karaokeRenderer.setShowChords(waveformPrefs.showChords === true);
       app.player.karaokeRenderer.waveformPreferences.overlayOpacity = waveformPrefs.overlayOpacity;
 
       // Connect butterchurn to PA analyser for visualization (M4A format)

--- a/src/renderer/workers/chordWorker.js
+++ b/src/renderer/workers/chordWorker.js
@@ -1,0 +1,16 @@
+/**
+ * Chord backfill worker (issue #93): analyzes already-decoded stem PCM for a
+ * library song that predates the chord track. Runs off the UI thread; the
+ * player posts transferable Float32Arrays, we post back the segment list.
+ */
+import { detectChords } from '../../shared/creator/chordDetect.js';
+
+self.onmessage = (e) => {
+  const { other, bass, sampleRate } = e.data;
+  try {
+    const chords = detectChords(other, bass, sampleRate);
+    self.postMessage({ ok: true, chords });
+  } catch (err) {
+    self.postMessage({ ok: false, error: err?.message || String(err) });
+  }
+};

--- a/src/shared/components/ChordEditor.jsx
+++ b/src/shared/components/ChordEditor.jsx
@@ -12,6 +12,52 @@ const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 
 // emit yet.
 const COMMON_CHORDS = NOTE_NAMES.flatMap((n) => [n, n + 'm']);
 
+// Audition a chord as a synthesized triad, sustained for the chord's own
+// duration (like a lyric line plays for its span). No samples, no assets.
+let auditionCtx = null;
+let auditionGain = null;
+function playChordTone(name, durationSec) {
+  const m = String(name || '')
+    .trim()
+    .match(/^([A-Ga-g])([#b]?)(m?)(?![a-z])/);
+  if (!m) return;
+  const FLAT_TO_SHARP = { Db: 'C#', Eb: 'D#', Gb: 'F#', Ab: 'G#', Bb: 'A#' };
+  let root = m[1].toUpperCase() + (m[2] || '');
+  root = FLAT_TO_SHARP[root] || root;
+  const pc = NOTE_NAMES.indexOf(root);
+  if (pc < 0) return;
+  const minor = m[3] === 'm';
+  const dur = Math.min(Math.max(Number(durationSec) || 1, 0.4), 12);
+  auditionCtx = auditionCtx || new (window.AudioContext || window.webkitAudioContext)();
+  const ctx = auditionCtx;
+  const now = ctx.currentTime;
+  // A new audition cuts off the previous one (like restarting line playback).
+  if (auditionGain) {
+    try {
+      auditionGain.gain.cancelScheduledValues(now);
+      auditionGain.gain.setTargetAtTime(0.0001, now, 0.02);
+    } catch {
+      /* already gone */
+    }
+  }
+  const master = ctx.createGain();
+  auditionGain = master;
+  master.gain.setValueAtTime(0.0001, now);
+  master.gain.linearRampToValueAtTime(0.22, now + 0.04);
+  master.gain.setValueAtTime(0.22, now + Math.max(0.05, dur - 0.25));
+  master.gain.exponentialRampToValueAtTime(0.0001, now + dur);
+  master.connect(ctx.destination);
+  for (const interval of [0, minor ? 3 : 4, 7]) {
+    const midi = 60 + pc + interval; // around C4 so triads sit mid-range
+    const osc = ctx.createOscillator();
+    osc.type = 'triangle';
+    osc.frequency.value = 440 * Math.pow(2, (midi - 69) / 12);
+    osc.connect(master);
+    osc.start(now);
+    osc.stop(now + dur + 0.05);
+  }
+}
+
 function TimeField({ value, onCommit }) {
   const [draft, setDraft] = useState(null);
   return (
@@ -31,7 +77,7 @@ function TimeField({ value, onCommit }) {
   );
 }
 
-export function ChordEditor({ chords, onChange, onPlaySection }) {
+export function ChordEditor({ chords, onChange }) {
   const [open, setOpen] = useState(false);
   const list = chords || [];
 
@@ -91,17 +137,15 @@ export function ChordEditor({ chords, onChange, onPlaySection }) {
                 value={c.chord}
                 onChange={(e) => update(i, { chord: e.target.value })}
               />
-              {onPlaySection && (
-                <button
-                  onClick={() => onPlaySection(c.start, c.end)}
-                  title="Play this section"
-                  className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
-                >
-                  <span className="material-icons text-gray-500 text-base leading-none">
-                    play_arrow
-                  </span>
-                </button>
-              )}
+              <button
+                onClick={() => playChordTone(c.chord, c.end - c.start)}
+                title="Play this chord as a tone for its duration"
+                className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+              >
+                <span className="material-icons text-gray-500 text-base leading-none">
+                  volume_up
+                </span>
+              </button>
               <button
                 onClick={() => addAfter(i)}
                 title="Add chord after"

--- a/src/shared/components/ChordEditor.jsx
+++ b/src/shared/components/ChordEditor.jsx
@@ -78,6 +78,7 @@ function TimeField({ value, onCommit }) {
 }
 
 export function ChordEditor({ chords, onChange }) {
+  const [selectedIndex, setSelectedIndex] = useState(null);
   const [open, setOpen] = useState(false);
   const list = chords || [];
 
@@ -128,12 +129,21 @@ export function ChordEditor({ chords, onChange }) {
             </div>
           )}
           {list.map((c, i) => (
-            <div key={`chord-${i}`} className="flex items-center gap-2 py-0.5">
+            <div
+              key={`chord-${i}`}
+              onClick={() => setSelectedIndex(i)}
+              className={`flex items-center gap-2.5 mb-2.5 p-2 border-2 rounded transition-all cursor-pointer ${
+                selectedIndex === i
+                  ? 'border-blue-500 bg-blue-100 dark:border-blue-400 dark:bg-blue-900/40'
+                  : 'bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-750 hover:border-gray-400 dark:hover:border-gray-500'
+              }`}
+            >
               <span
                 title={`Play chord ${i + 1} as a tone`}
                 className="flex items-center justify-center min-w-[36px] h-9 bg-gray-200 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-sm font-semibold text-gray-700 dark:text-gray-200 cursor-pointer transition-all flex-shrink-0 hover:bg-blue-600 hover:text-white dark:hover:bg-blue-500"
                 onClick={(e) => {
                   e.stopPropagation();
+                  setSelectedIndex(i);
                   playChordTone(c.chord, c.end - c.start);
                 }}
               >

--- a/src/shared/components/ChordEditor.jsx
+++ b/src/shared/components/ChordEditor.jsx
@@ -1,0 +1,102 @@
+/**
+ * ChordEditor - timeline editing for the chord track (issue #93), the same
+ * row treatment as lyrics. Time fields use the draft pattern from issue #69:
+ * hard-controlling a formatted number input eats keystrokes.
+ */
+
+import { useState } from 'react';
+
+function TimeField({ value, onCommit }) {
+  const [draft, setDraft] = useState(null);
+  return (
+    <input
+      type="number"
+      step="0.1"
+      min="0"
+      className="w-[64px] px-1 py-1 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white text-xs text-center font-mono focus:outline-none focus:border-blue-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+      value={draft ?? value.toFixed(2)}
+      onChange={(e) => {
+        setDraft(e.target.value);
+        const v = parseFloat(e.target.value);
+        if (Number.isFinite(v)) onCommit(Math.max(0, v));
+      }}
+      onBlur={() => setDraft(null)}
+    />
+  );
+}
+
+export function ChordEditor({ chords, onChange }) {
+  const [open, setOpen] = useState(false);
+  const list = chords || [];
+
+  const update = (i, patch) => {
+    const next = list.map((c, idx) => (idx === i ? { ...c, ...patch } : c));
+    onChange(next);
+  };
+  const remove = (i) => onChange(list.filter((_, idx) => idx !== i));
+  const addAfter = (i) => {
+    const prev = list[i];
+    const start = prev ? prev.end : 0;
+    const entry = { start, end: start + 2, chord: 'C' };
+    const next = [...list];
+    next.splice(i + 1, 0, entry);
+    onChange(next);
+  };
+
+  return (
+    <div className="mt-4 border border-gray-200 dark:border-gray-700 rounded-lg">
+      <button
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center justify-between px-3 py-2 text-left"
+      >
+        <span className="font-semibold text-gray-900 dark:text-gray-100">
+          Chords ({list.length})
+        </span>
+        <span className="material-icons text-gray-500">{open ? 'expand_less' : 'expand_more'}</span>
+      </button>
+      {open && (
+        <div className="px-3 pb-3 max-h-[300px] overflow-y-auto">
+          {list.length === 0 && (
+            <div className="text-sm text-gray-500 dark:text-gray-400 py-2">
+              No chord track. Chords are detected automatically when a song is created or first
+              played.
+              <button
+                onClick={() => addAfter(-1)}
+                className="ml-2 text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Add one manually
+              </button>
+            </div>
+          )}
+          {list.map((c, i) => (
+            <div key={`chord-${i}`} className="flex items-center gap-2 py-0.5">
+              <TimeField value={c.start} onCommit={(v) => update(i, { start: v })} />
+              <span className="text-gray-400 text-xs">to</span>
+              <TimeField value={c.end} onCommit={(v) => update(i, { end: v })} />
+              <input
+                type="text"
+                className="w-[72px] px-2 py-1 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white text-sm font-mono focus:outline-none focus:border-blue-500"
+                value={c.chord}
+                onChange={(e) => update(i, { chord: e.target.value })}
+              />
+              <button
+                onClick={() => addAfter(i)}
+                title="Add chord after"
+                className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+              >
+                <span className="material-icons text-gray-500 text-base leading-none">add</span>
+              </button>
+              <button
+                onClick={() => remove(i)}
+                title="Delete chord"
+                className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+              >
+                <span className="material-icons text-gray-500 text-base leading-none">delete</span>
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/shared/components/ChordEditor.jsx
+++ b/src/shared/components/ChordEditor.jsx
@@ -98,6 +98,7 @@ export function ChordEditor({ chords, onChange }) {
   return (
     <div className="mt-4 border border-gray-200 dark:border-gray-700 rounded-lg">
       <button
+        type="button"
         onClick={() => setOpen(!open)}
         className="w-full flex items-center justify-between px-3 py-2 text-left"
       >
@@ -118,6 +119,7 @@ export function ChordEditor({ chords, onChange }) {
               No chord track. Chords are detected automatically when a song is created or first
               played.
               <button
+                type="button"
                 onClick={() => addAfter(-1)}
                 className="ml-2 text-blue-600 dark:text-blue-400 hover:underline"
               >
@@ -127,6 +129,16 @@ export function ChordEditor({ chords, onChange }) {
           )}
           {list.map((c, i) => (
             <div key={`chord-${i}`} className="flex items-center gap-2 py-0.5">
+              <span
+                title={`Play chord ${i + 1} as a tone`}
+                className="flex items-center justify-center min-w-[36px] h-9 bg-gray-200 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-sm font-semibold text-gray-700 dark:text-gray-200 cursor-pointer transition-all flex-shrink-0 hover:bg-blue-600 hover:text-white dark:hover:bg-blue-500"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  playChordTone(c.chord, c.end - c.start);
+                }}
+              >
+                {i + 1}
+              </span>
               <TimeField value={c.start} onCommit={(v) => update(i, { start: v })} />
               <span className="text-gray-400 text-xs">to</span>
               <TimeField value={c.end} onCommit={(v) => update(i, { end: v })} />
@@ -138,15 +150,7 @@ export function ChordEditor({ chords, onChange }) {
                 onChange={(e) => update(i, { chord: e.target.value })}
               />
               <button
-                onClick={() => playChordTone(c.chord, c.end - c.start)}
-                title="Play this chord as a tone for its duration"
-                className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
-              >
-                <span className="material-icons text-gray-500 text-base leading-none">
-                  volume_up
-                </span>
-              </button>
-              <button
+                type="button"
                 onClick={() => addAfter(i)}
                 title="Add chord after"
                 className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
@@ -154,6 +158,7 @@ export function ChordEditor({ chords, onChange }) {
                 <span className="material-icons text-gray-500 text-base leading-none">add</span>
               </button>
               <button
+                type="button"
                 onClick={() => remove(i)}
                 title="Delete chord"
                 className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"

--- a/src/shared/components/ChordEditor.jsx
+++ b/src/shared/components/ChordEditor.jsx
@@ -12,6 +12,39 @@ const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 
 // emit yet.
 const COMMON_CHORDS = NOTE_NAMES.flatMap((n) => [n, n + 'm']);
 
+// Audition a chord: synthesize its triad with plain oscillators for a moment.
+// No samples, no assets; enough to check a correction by ear.
+let auditionCtx = null;
+function playChordTone(name) {
+  const m = String(name || '')
+    .trim()
+    .match(/^([A-Ga-g])([#b]?)(m?)(?![a-z])/);
+  if (!m) return;
+  const FLAT_TO_SHARP = { Db: 'C#', Eb: 'D#', Gb: 'F#', Ab: 'G#', Bb: 'A#' };
+  let root = m[1].toUpperCase() + (m[2] || '');
+  root = FLAT_TO_SHARP[root] || root;
+  const pc = NOTE_NAMES.indexOf(root);
+  if (pc < 0) return;
+  const minor = m[3] === 'm';
+  auditionCtx = auditionCtx || new (window.AudioContext || window.webkitAudioContext)();
+  const ctx = auditionCtx;
+  const now = ctx.currentTime;
+  const master = ctx.createGain();
+  master.gain.setValueAtTime(0.0001, now);
+  master.gain.linearRampToValueAtTime(0.25, now + 0.03);
+  master.gain.exponentialRampToValueAtTime(0.0001, now + 1.1);
+  master.connect(ctx.destination);
+  for (const interval of [0, minor ? 3 : 4, 7]) {
+    const midi = 60 + pc + interval; // around C4 so triads sit mid-range
+    const osc = ctx.createOscillator();
+    osc.type = 'triangle';
+    osc.frequency.value = 440 * Math.pow(2, (midi - 69) / 12);
+    osc.connect(master);
+    osc.start(now);
+    osc.stop(now + 1.15);
+  }
+}
+
 function TimeField({ value, onCommit }) {
   const [draft, setDraft] = useState(null);
   return (
@@ -91,6 +124,15 @@ export function ChordEditor({ chords, onChange }) {
                 value={c.chord}
                 onChange={(e) => update(i, { chord: e.target.value })}
               />
+              <button
+                onClick={() => playChordTone(c.chord)}
+                title="Play this chord"
+                className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+              >
+                <span className="material-icons text-gray-500 text-base leading-none">
+                  volume_up
+                </span>
+              </button>
               <button
                 onClick={() => addAfter(i)}
                 title="Add chord after"

--- a/src/shared/components/ChordEditor.jsx
+++ b/src/shared/components/ChordEditor.jsx
@@ -12,39 +12,6 @@ const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 
 // emit yet.
 const COMMON_CHORDS = NOTE_NAMES.flatMap((n) => [n, n + 'm']);
 
-// Audition a chord: synthesize its triad with plain oscillators for a moment.
-// No samples, no assets; enough to check a correction by ear.
-let auditionCtx = null;
-function playChordTone(name) {
-  const m = String(name || '')
-    .trim()
-    .match(/^([A-Ga-g])([#b]?)(m?)(?![a-z])/);
-  if (!m) return;
-  const FLAT_TO_SHARP = { Db: 'C#', Eb: 'D#', Gb: 'F#', Ab: 'G#', Bb: 'A#' };
-  let root = m[1].toUpperCase() + (m[2] || '');
-  root = FLAT_TO_SHARP[root] || root;
-  const pc = NOTE_NAMES.indexOf(root);
-  if (pc < 0) return;
-  const minor = m[3] === 'm';
-  auditionCtx = auditionCtx || new (window.AudioContext || window.webkitAudioContext)();
-  const ctx = auditionCtx;
-  const now = ctx.currentTime;
-  const master = ctx.createGain();
-  master.gain.setValueAtTime(0.0001, now);
-  master.gain.linearRampToValueAtTime(0.25, now + 0.03);
-  master.gain.exponentialRampToValueAtTime(0.0001, now + 1.1);
-  master.connect(ctx.destination);
-  for (const interval of [0, minor ? 3 : 4, 7]) {
-    const midi = 60 + pc + interval; // around C4 so triads sit mid-range
-    const osc = ctx.createOscillator();
-    osc.type = 'triangle';
-    osc.frequency.value = 440 * Math.pow(2, (midi - 69) / 12);
-    osc.connect(master);
-    osc.start(now);
-    osc.stop(now + 1.15);
-  }
-}
-
 function TimeField({ value, onCommit }) {
   const [draft, setDraft] = useState(null);
   return (
@@ -64,7 +31,7 @@ function TimeField({ value, onCommit }) {
   );
 }
 
-export function ChordEditor({ chords, onChange }) {
+export function ChordEditor({ chords, onChange, onPlaySection }) {
   const [open, setOpen] = useState(false);
   const list = chords || [];
 
@@ -124,15 +91,17 @@ export function ChordEditor({ chords, onChange }) {
                 value={c.chord}
                 onChange={(e) => update(i, { chord: e.target.value })}
               />
-              <button
-                onClick={() => playChordTone(c.chord)}
-                title="Play this chord"
-                className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
-              >
-                <span className="material-icons text-gray-500 text-base leading-none">
-                  volume_up
-                </span>
-              </button>
+              {onPlaySection && (
+                <button
+                  onClick={() => onPlaySection(c.start, c.end)}
+                  title="Play this section"
+                  className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+                >
+                  <span className="material-icons text-gray-500 text-base leading-none">
+                    play_arrow
+                  </span>
+                </button>
+              )}
               <button
                 onClick={() => addAfter(i)}
                 title="Add chord after"

--- a/src/shared/components/ChordEditor.jsx
+++ b/src/shared/components/ChordEditor.jsx
@@ -6,6 +6,12 @@
 
 import { useState } from 'react';
 
+const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+// The detector's vocabulary as pick-list suggestions; typing stays free-form
+// because the format allows richer qualities (G7, Csus4) the detector does not
+// emit yet.
+const COMMON_CHORDS = NOTE_NAMES.flatMap((n) => [n, n + 'm']);
+
 function TimeField({ value, onCommit }) {
   const [draft, setDraft] = useState(null);
   return (
@@ -56,6 +62,11 @@ export function ChordEditor({ chords, onChange }) {
       </button>
       {open && (
         <div className="px-3 pb-3 max-h-[300px] overflow-y-auto">
+          <datalist id="chord-name-options">
+            {COMMON_CHORDS.map((name) => (
+              <option key={name} value={name} />
+            ))}
+          </datalist>
           {list.length === 0 && (
             <div className="text-sm text-gray-500 dark:text-gray-400 py-2">
               No chord track. Chords are detected automatically when a song is created or first
@@ -75,6 +86,7 @@ export function ChordEditor({ chords, onChange }) {
               <TimeField value={c.end} onCommit={(v) => update(i, { end: v })} />
               <input
                 type="text"
+                list="chord-name-options"
                 className="w-[72px] px-2 py-1 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white text-sm font-mono focus:outline-none focus:border-blue-500"
                 value={c.chord}
                 onChange={(e) => update(i, { chord: e.target.value })}

--- a/src/shared/components/SongEditor.jsx
+++ b/src/shared/components/SongEditor.jsx
@@ -1380,6 +1380,7 @@ export function SongEditor({ bridge }) {
                     setChordsData(next);
                     setHasChanges(true);
                   }}
+                  onPlaySection={handlePlayLineSection}
                 />
               </div>
             </>

--- a/src/shared/components/SongEditor.jsx
+++ b/src/shared/components/SongEditor.jsx
@@ -1380,7 +1380,6 @@ export function SongEditor({ bridge }) {
                     setChordsData(next);
                     setHasChanges(true);
                   }}
-                  onPlaySection={handlePlayLineSection}
                 />
               </div>
             </>

--- a/src/shared/components/SongEditor.jsx
+++ b/src/shared/components/SongEditor.jsx
@@ -15,6 +15,7 @@ import { getFormatIcon, isStemMp4Format } from '../formatUtils.js';
 import { LyricsEditorCanvas } from './LyricsEditorCanvas.jsx';
 import { LineDetailCanvas } from './LineDetailCanvas.jsx';
 import { LyricLine } from './LyricLine.jsx';
+import { ChordEditor } from './ChordEditor.jsx';
 import { Toast } from './Toast.jsx';
 import { LyricRejection } from './LyricRejection.jsx';
 import { LyricSuggestion } from './LyricSuggestion.jsx';
@@ -50,6 +51,7 @@ export function SongEditor({ bridge }) {
 
   // Lyrics state (for KAI files) - now array format for full editing
   const [lyricsData, setLyricsData] = useState([]);
+  const [chordsData, setChordsData] = useState([]);
   const [originalLyricsData, setOriginalLyricsData] = useState([]);
   const [selectedLineIndex, setSelectedLineIndex] = useState(null);
   const [songDuration, setSongDuration] = useState(0);
@@ -385,6 +387,7 @@ export function SongEditor({ bridge }) {
             return aStart - bStart;
           });
           setLyricsData(JSON.parse(JSON.stringify(sortedLyrics)));
+          setChordsData(JSON.parse(JSON.stringify(result.data.chords || [])));
           setOriginalLyricsData(JSON.parse(JSON.stringify(sortedLyrics)));
           setSongDuration(
             result.data.metadata?.duration || result.data.songJson?.duration_sec || 0
@@ -813,6 +816,7 @@ export function SongEditor({ bridge }) {
         // Include lyrics for both KAI and Stem MP4 formats
         ...(isStemMp4Format(songData.format) && {
           lyrics: sortedLyrics,
+          chords: [...chordsData].sort((a, b) => (a.start || 0) - (b.start || 0)),
         }),
       };
 
@@ -1369,6 +1373,14 @@ export function SongEditor({ bridge }) {
                     ))}
                   </div>
                 )}
+
+                <ChordEditor
+                  chords={chordsData}
+                  onChange={(next) => {
+                    setChordsData(next);
+                    setHasChanges(true);
+                  }}
+                />
               </div>
             </>
           )}

--- a/src/shared/components/VisualizationSettings.jsx
+++ b/src/shared/components/VisualizationSettings.jsx
@@ -159,6 +159,15 @@ export function VisualizationSettings({
             />
             <span className="text-gray-900 dark:text-gray-100">Show Upcoming Lyrics</span>
           </label>
+          <label className="flex items-center gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={waveformSettings.showChords}
+              onChange={(e) => handleWaveformChange('showChords', e.target.checked)}
+              className="w-4 h-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500"
+            />
+            <span className="text-gray-900 dark:text-gray-100">Show Chords</span>
+          </label>
 
           <div className="space-y-2">
             <label className="flex items-center justify-between text-gray-900 dark:text-gray-100">

--- a/src/shared/components/VisualizationSettings.jsx
+++ b/src/shared/components/VisualizationSettings.jsx
@@ -118,7 +118,7 @@ export function VisualizationSettings({
     <div className="p-4 space-y-6">
       {/* Waveform Options */}
       <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4 space-y-4">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Waveform Options</h3>
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Display Options</h3>
         <div className="space-y-3">
           <label className="flex items-center gap-3 cursor-pointer">
             <input

--- a/src/shared/components/WebGpuCreatorPanel.jsx
+++ b/src/shared/components/WebGpuCreatorPanel.jsx
@@ -554,6 +554,7 @@ export default function WebGpuCreatorPanel() {
       const correctedWords = created.lyrics.words;
       const detectedKey = created.key;
       const pitchData = created.pitch;
+      const chordData = created.chords;
       setLlmStats(null);
       const refLyrics = referenceLyrics.trim(); // sent to backend; it looks up if empty
 
@@ -680,6 +681,7 @@ export default function WebGpuCreatorPanel() {
             composer: songTags.composer,
           },
           lyrics: lyricsPayload,
+          chords: chordData,
           pitch: pitchData,
           referenceLyrics: refLyrics, // backend corrects server-side (looks up if empty)
         });
@@ -698,6 +700,7 @@ export default function WebGpuCreatorPanel() {
         fd.append('lyrics', JSON.stringify(lyricsPayload));
         if (detectedKey) fd.append('key', detectedKey);
         if (pitchData) fd.append('pitch', JSON.stringify(pitchData));
+        if (chordData?.length) fd.append('chords', JSON.stringify(chordData));
         if (refLyrics) fd.append('referenceLyrics', refLyrics);
         for (const [k, bytes] of Object.entries(aacBytes)) {
           fd.append(k, new Blob([bytes], { type: 'audio/mp4' }), `${k}.m4a`);

--- a/src/shared/creator/chordDetect.js
+++ b/src/shared/creator/chordDetect.js
@@ -1,0 +1,198 @@
+/**
+ * Chord detection for the chord track (issue #93).
+ *
+ * Chromagram + triad template matching over the separated stems: the "other"
+ * stem carries the harmony (guitars/keys) and the bass stem votes on the root
+ * note, which is the disambiguator normal full-mix detectors never get.
+ * Pure typed-array JS; runs inside the creator worker (or any Web Worker), so
+ * nothing here may touch the DOM. A 4-minute song is well under a second.
+ */
+
+const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+const WINDOW = 8192;
+const HOP = 4096;
+const MIN_SEGMENT_SEC = 0.6;
+const ROOT_BOOST = 0.35; // weight of the bass root vote vs the harmony template fit
+const ENERGY_FLOOR = 1e-4; // frames quieter than this are "no chord"
+
+/** In-place iterative radix-2 FFT (real input, magnitudes out). */
+function fftMagnitudes(re, im) {
+  const n = re.length;
+  for (let i = 1, j = 0; i < n; i++) {
+    let bit = n >> 1;
+    for (; j & bit; bit >>= 1) j ^= bit;
+    j ^= bit;
+    if (i < j) {
+      [re[i], re[j]] = [re[j], re[i]];
+      [im[i], im[j]] = [im[j], im[i]];
+    }
+  }
+  for (let len = 2; len <= n; len <<= 1) {
+    const ang = (-2 * Math.PI) / len;
+    const wRe = Math.cos(ang);
+    const wIm = Math.sin(ang);
+    for (let i = 0; i < n; i += len) {
+      let curRe = 1;
+      let curIm = 0;
+      for (let k = 0; k < len / 2; k++) {
+        const uRe = re[i + k];
+        const uIm = im[i + k];
+        const vRe = re[i + k + len / 2] * curRe - im[i + k + len / 2] * curIm;
+        const vIm = re[i + k + len / 2] * curIm + im[i + k + len / 2] * curRe;
+        re[i + k] = uRe + vRe;
+        im[i + k] = uIm + vIm;
+        re[i + k + len / 2] = uRe - vRe;
+        im[i + k + len / 2] = uIm - vIm;
+        const nextRe = curRe * wRe - curIm * wIm;
+        curIm = curRe * wIm + curIm * wRe;
+        curRe = nextRe;
+      }
+    }
+  }
+  const mags = new Float32Array(n / 2);
+  for (let i = 0; i < n / 2; i++) mags[i] = Math.hypot(re[i], im[i]);
+  return mags;
+}
+
+/** Map FFT magnitudes to a 12-bin chroma vector over [fMin, fMax]. */
+function chromaFromMags(mags, sampleRate, fMin, fMax) {
+  const chroma = new Float32Array(12);
+  const binHz = sampleRate / WINDOW;
+  const lo = Math.max(1, Math.floor(fMin / binHz));
+  const hi = Math.min(mags.length - 1, Math.ceil(fMax / binHz));
+  for (let b = lo; b <= hi; b++) {
+    const f = b * binHz;
+    const midi = 69 + 12 * Math.log2(f / 440);
+    const pc = ((Math.round(midi) % 12) + 12) % 12;
+    // energy, tapered against the high end so overtones dominate less
+    chroma[pc] += mags[b] * mags[b] * (1 / Math.sqrt(f / fMin));
+  }
+  return chroma;
+}
+
+function downmix(stem) {
+  const left = stem.left;
+  const right = stem.right || stem.left;
+  const mono = new Float32Array(left.length);
+  for (let i = 0; i < left.length; i++) mono[i] = (left[i] + right[i]) * 0.5;
+  return mono;
+}
+
+const hannCache = new Map();
+function hann(n) {
+  if (!hannCache.has(n)) {
+    const w = new Float32Array(n);
+    for (let i = 0; i < n; i++) w[i] = 0.5 * (1 - Math.cos((2 * Math.PI * i) / (n - 1)));
+    hannCache.set(n, w);
+  }
+  return hannCache.get(n);
+}
+
+/** 24 triad templates (12 major, 12 minor), L2-normalized. */
+function buildTemplates() {
+  const templates = [];
+  for (let root = 0; root < 12; root++) {
+    for (const [suffix, intervals] of [
+      ['', [0, 4, 7]],
+      ['m', [0, 3, 7]],
+    ]) {
+      const t = new Float32Array(12);
+      for (const iv of intervals) t[(root + iv) % 12] = 1 / Math.sqrt(3);
+      templates.push({ name: NOTE_NAMES[root] + suffix, root, t });
+    }
+  }
+  return templates;
+}
+
+/**
+ * Detect the chord timeline from separated stems.
+ *
+ * @param {{left: Float32Array, right?: Float32Array}} other  harmony stem
+ * @param {{left: Float32Array, right?: Float32Array}} bass   bass stem
+ * @param {number} sampleRate
+ * @returns {Array<{start: number, end: number, chord: string}>} merged segments;
+ *   silent/ambiguous stretches are simply absent (no 'N' entries in the output).
+ */
+export function detectChords(other, bass, sampleRate) {
+  if (!other?.left?.length) return [];
+  const harm = downmix(other);
+  const bassMono = bass?.left?.length ? downmix(bass) : null;
+  const win = hann(WINDOW);
+  const templates = buildTemplates();
+  const re = new Float32Array(WINDOW);
+  const im = new Float32Array(WINDOW);
+
+  const frames = [];
+  for (let start = 0; start + WINDOW <= harm.length; start += HOP) {
+    for (let i = 0; i < WINDOW; i++) {
+      re[i] = harm[start + i] * win[i];
+      im[i] = 0;
+    }
+    const chroma = chromaFromMags(fftMagnitudes(re, im), sampleRate, 82, 2000);
+    let energy = 0;
+    for (let i = 0; i < 12; i++) energy += chroma[i];
+    if (energy < ENERGY_FLOOR) {
+      frames.push(null);
+      continue;
+    }
+    for (let i = 0; i < 12; i++) chroma[i] /= energy;
+
+    let bassChroma = null;
+    if (bassMono && start + WINDOW <= bassMono.length) {
+      for (let i = 0; i < WINDOW; i++) {
+        re[i] = bassMono[start + i] * win[i];
+        im[i] = 0;
+      }
+      bassChroma = chromaFromMags(fftMagnitudes(re, im), sampleRate, 41, 300);
+      let be = 0;
+      for (let i = 0; i < 12; i++) be += bassChroma[i];
+      if (be > ENERGY_FLOOR) for (let i = 0; i < 12; i++) bassChroma[i] /= be;
+      else bassChroma = null;
+    }
+
+    let best = null;
+    let bestScore = -Infinity;
+    for (const tpl of templates) {
+      let score = 0;
+      for (let i = 0; i < 12; i++) score += chroma[i] * tpl.t[i];
+      if (bassChroma) score += ROOT_BOOST * bassChroma[tpl.root];
+      if (score > bestScore) {
+        bestScore = score;
+        best = tpl.name;
+      }
+    }
+    frames.push(best);
+  }
+
+  // Merge frames into segments; drop blips shorter than MIN_SEGMENT_SEC by
+  // absorbing them into the previous segment.
+  const hopSec = HOP / sampleRate;
+  const segments = [];
+  for (let f = 0; f < frames.length; f++) {
+    const chord = frames[f];
+    const t = f * hopSec;
+    const last = segments[segments.length - 1];
+    if (chord === null) {
+      if (last && !last.closed) last.closed = true;
+      continue;
+    }
+    if (last && !last.closed && last.chord === chord) {
+      last.end = t + hopSec;
+    } else {
+      segments.push({ start: t, end: t + hopSec, chord, closed: false });
+    }
+  }
+  const cleaned = [];
+  for (const seg of segments) {
+    if (seg.end - seg.start >= MIN_SEGMENT_SEC || cleaned.length === 0) {
+      cleaned.push({ start: round2(seg.start), end: round2(seg.end), chord: seg.chord });
+    } else {
+      cleaned[cleaned.length - 1].end = round2(seg.end); // absorb the blip
+    }
+  }
+  return cleaned;
+}
+
+function round2(x) {
+  return Math.round(x * 100) / 100;
+}

--- a/src/shared/creator/chordDetect.test.js
+++ b/src/shared/creator/chordDetect.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { detectChords } from './chordDetect.js';
+
+const SR = 44100;
+
+function tone(freqs, seconds, gain = 0.3) {
+  const n = Math.round(seconds * SR);
+  const out = new Float32Array(n);
+  for (const f of freqs) {
+    for (let i = 0; i < n; i++)
+      out[i] += (gain / freqs.length) * Math.sin((2 * Math.PI * f * i) / SR);
+  }
+  return out;
+}
+
+function concat(parts) {
+  const total = parts.reduce((a, p) => a + p.length, 0);
+  const out = new Float32Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+describe('detectChords', () => {
+  it('identifies a C major then A minor progression with bass roots', () => {
+    // C major: C4 E4 G4; A minor: A3 C4 E4. Two seconds each.
+    const other = concat([tone([261.6, 329.6, 392.0], 2), tone([220.0, 261.6, 329.6], 2)]);
+    const bass = concat([tone([65.4], 2), tone([55.0], 2)]); // C2 then A1
+    const segs = detectChords({ left: other }, { left: bass }, SR);
+    const names = segs.map((s) => s.chord);
+    expect(names[0]).toBe('C');
+    expect(names[names.length - 1]).toBe('Am');
+    // timeline is ordered and non-overlapping
+    for (let i = 1; i < segs.length; i++) {
+      expect(segs[i].start).toBeGreaterThanOrEqual(segs[i - 1].start);
+    }
+  });
+
+  it('returns nothing for silence', () => {
+    const silent = new Float32Array(SR * 2);
+    expect(detectChords({ left: silent }, { left: silent }, SR)).toEqual([]);
+  });
+
+  it('handles a missing bass stem', () => {
+    const other = tone([196.0, 246.9, 293.7], 2); // G major: G3 B3 D4
+    const segs = detectChords({ left: other }, null, SR);
+    expect(segs.length).toBeGreaterThan(0);
+    expect(segs[0].chord).toBe('G');
+  });
+
+  it('rounds segment times to centiseconds', () => {
+    const other = tone([261.6, 329.6, 392.0], 1.5);
+    const segs = detectChords({ left: other }, null, SR);
+    for (const s of segs) {
+      expect(s.start).toBeCloseTo(Math.round(s.start * 100) / 100, 10);
+    }
+  });
+});

--- a/src/shared/creator/createKaraoke.js
+++ b/src/shared/creator/createKaraoke.js
@@ -16,6 +16,7 @@
  */
 
 import { snapToVocalEnergy } from './vocalSegmentation.js';
+import { detectChords } from './chordDetect.js';
 import { groupWordsIntoLines } from './creatorAudio.js';
 import { transcribeVocals } from './transcribeVocals.js';
 
@@ -524,12 +525,29 @@ export async function createKaraoke(
     onLog(`pitch/key detection skipped (${e.message})`);
   }
 
+  // --- Chord track (#93): chroma + triad matching over the harmony stems. ---
+  // Cheap (<1s for a full song) and runs here in the worker, so the UI never
+  // feels it. Skipped in lyrics-only mode (no stems in hand).
+  let chords = [];
+  if (result?.other?.left?.length) {
+    const t0c = performance.now();
+    try {
+      chords = detectChords(result.other, result.bass, audio.sampleRate);
+      onLog(
+        `chords: ${chords.length} segments in ${((performance.now() - t0c) / 1000).toFixed(1)}s`
+      );
+    } catch (e) {
+      onLog(`chord detection failed (${String(e.message).slice(0, 120)}) - continuing without`);
+    }
+  }
+
   const totalSec = (performance.now() - runT0) / 1000;
 
   return {
     stems: result, // {master?,drums,bass,other,vocals:{left,right}} (master from caller's audio)
     sampleRate: audio.sampleRate,
     duration: audio.duration,
+    chords,
     lyrics: { lines, words: wordObjs },
     key: detectedKey,
     pitch: pitchData,

--- a/src/shared/creator/hostCreate.js
+++ b/src/shared/creator/hostCreate.js
@@ -100,6 +100,7 @@ export async function hostCreate({ audioBytes, opts = {} }, onProgress = () => {
   return {
     stems: stemsAac, // master/drums/bass/other/vocals as AAC-in-MP4 Uint8Array
     lyrics: created.lyrics,
+    chords: created.chords,
     key: created.key,
     pitch: created.pitch,
     duration: audio.duration,

--- a/src/shared/defaults.js
+++ b/src/shared/defaults.js
@@ -32,6 +32,7 @@ export const EFFECTS_DEFAULTS = {
   randomEffectOnSong: false,
   overlayOpacity: 0.7,
   showUpcomingLyrics: true,
+  showChords: true,
 };
 
 export const AUTOTUNE_DEFAULTS = {
@@ -91,6 +92,7 @@ export const WAVEFORM_DEFAULTS = {
   randomEffectOnSong: EFFECTS_DEFAULTS.randomEffectOnSong,
   overlayOpacity: EFFECTS_DEFAULTS.overlayOpacity,
   showUpcomingLyrics: EFFECTS_DEFAULTS.showUpcomingLyrics,
+  showChords: EFFECTS_DEFAULTS.showChords,
 };
 
 // UI defaults

--- a/src/shared/defaults.js
+++ b/src/shared/defaults.js
@@ -32,7 +32,7 @@ export const EFFECTS_DEFAULTS = {
   randomEffectOnSong: false,
   overlayOpacity: 0.7,
   showUpcomingLyrics: true,
-  showChords: true,
+  showChords: false,
 };
 
 export const AUTOTUNE_DEFAULTS = {

--- a/src/shared/services/creatorService.js
+++ b/src/shared/services/creatorService.js
@@ -242,6 +242,7 @@ export async function saveWebGpuStems({
   stems,
   metadata,
   lyrics,
+  chords,
   pitch,
   referenceLyrics,
   settingsManager,
@@ -367,6 +368,17 @@ export async function saveWebGpuStems({
 
     // CREPE-derived musical key + pitch track (parity with the native creator). Both
     // best-effort — a failure here must not lose the otherwise-good file.
+    // Chord track (#93): the muxer only writes known kara fields, so merge the
+    // chords into the kara atom after the fact (best-effort, like key/pitch).
+    if (chords && chords.length > 0) {
+      try {
+        const kara = await M4AAtoms.readKaraAtom(outputPath);
+        await M4AAtoms.writeKaraAtom(outputPath, { ...kara, chords });
+      } catch (e) {
+        console.warn('chord track write failed:', e.message);
+      }
+    }
+
     if (key) {
       try {
         await M4AAtoms.addMusicalKey(outputPath, key);

--- a/src/shared/services/creatorService.js
+++ b/src/shared/services/creatorService.js
@@ -427,7 +427,16 @@ export async function updateStemLyrics({ inputPath, lyrics, key, pitch }) {
   if (!inputPath || !existsSync(inputPath)) throw new Error('stem file not found');
   // Edit in place — the file is already in the library.
   if (lyrics && lyrics.lines) {
-    await M4AAtoms.writeKaraAtom(inputPath, { lines: lyrics.lines });
+    // MERGE with the existing kara atom: writing { lines } alone silently
+    // destroyed timing, singers, tags, and the chord track for any file this
+    // path touched (import + lyrics-correction).
+    let existing = {};
+    try {
+      existing = (await M4AAtoms.readKaraAtom(inputPath)) || {};
+    } catch {
+      /* no kara atom yet */
+    }
+    await M4AAtoms.writeKaraAtom(inputPath, { ...existing, lines: lyrics.lines });
   }
   if (key) {
     try {

--- a/src/shared/services/editorService.js
+++ b/src/shared/services/editorService.js
@@ -46,11 +46,11 @@ export async function saveSong(path, updates) {
     throw new Error('Path is required');
   }
 
-  const { format, metadata, lyrics } = updates;
+  const { format, metadata, lyrics, chords } = updates;
 
   if (isStemMp4Format(format)) {
     // Handle Stem MP4 format
-    return await saveM4ASong(path, { metadata, lyrics });
+    return await saveM4ASong(path, { metadata, lyrics, chords });
   } else {
     throw new Error(`Unsupported format: ${format}. Only stem-mp4 format is supported.`);
   }
@@ -73,7 +73,7 @@ export async function saveSong(path, updates) {
  * @returns {Promise<Object>} Save result
  */
 async function saveM4ASong(path, updates) {
-  const { metadata, lyrics } = updates;
+  const { metadata, lyrics, chords } = updates;
   const fs = await import('fs/promises');
   const pathMod = await import('path');
 
@@ -148,6 +148,9 @@ async function saveM4ASong(path, updates) {
     singers: existingKara.singers || [],
     meta: existingKara.meta?.corrections ? { corrections: existingKara.meta.corrections } : {},
     tags: existingKara.tags || [],
+    // Chord track (#93): an edited track from the caller wins; otherwise keep
+    // whatever the file already had.
+    chords: chords ?? existingKara.chords,
   };
 
   // Add 'edited' tag if not already present

--- a/src/shared/services/editorService.js
+++ b/src/shared/services/editorService.js
@@ -201,6 +201,11 @@ async function saveM4ASong(path, updates) {
     // Tags for filtering (e.g., 'edited', 'ai_corrected')
     tags: dataToSave.tags || [],
 
+    // Chord track (#93): pass through so an editor save never strips it
+    ...(((dataToSave.chords ?? existingKara?.chords)?.length ?? 0) > 0 && {
+      chords: dataToSave.chords ?? existingKara.chords,
+    }),
+
     // Lyrics (lines) - preserves word-level timing if present
     lines: (dataToSave.lyrics || []).map((line) => ({
       start: line.start || line.startTimeSec || 0,

--- a/src/utils/m4aLoader.js
+++ b/src/utils/m4aLoader.js
@@ -207,6 +207,7 @@ class M4ALoader {
         },
 
         lyrics,
+        chords: karaData?.chords || null,
 
         features: {
           notesRef: null,

--- a/src/web/components/PlayerSettingsPanel.jsx
+++ b/src/web/components/PlayerSettingsPanel.jsx
@@ -143,6 +143,15 @@ export function PlayerSettingsPanel({ socket }) {
             Show Upcoming Lyrics
           </span>
         </label>
+        <label className="flex items-center py-3 gap-3 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={waveformSettings.showChords}
+            onChange={(e) => handleWaveformChange('showChords', e.target.checked)}
+            className="w-[18px] h-[18px] cursor-pointer"
+          />
+          <span className="flex-1 text-[15px] text-gray-900 dark:text-white">Show Chords</span>
+        </label>
 
         <div className="flex flex-col items-stretch py-3 cursor-default">
           <label className="flex flex-col gap-2 w-full">

--- a/src/web/components/PlayerSettingsPanel.jsx
+++ b/src/web/components/PlayerSettingsPanel.jsx
@@ -95,7 +95,7 @@ export function PlayerSettingsPanel({ socket }) {
     <div className="p-5 h-full overflow-y-auto">
       <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-5 mb-5">
         <h3 className="m-0 mb-5 text-lg font-semibold text-gray-900 dark:text-white border-b border-gray-200 dark:border-gray-700 pb-3">
-          Waveform & Visual Options
+          Display Options
         </h3>
 
         <label className="flex items-center py-3 gap-3 cursor-pointer select-none">


### PR DESCRIPTION
Implements #93 completely, per jorgeEF's three clarifications.

- **Detection**: chromagram + triad template matching in `chordDetect.js`, run inside the existing creator worker right after separation. The other stem carries the harmony, the bass stem votes on the root note. Pure typed-array JS, under a second per song, nothing on the UI thread.
- **Storage**: `chords: [{start, end, chord}]` in the kara atom, documented in `docs/m4a_format.md`. Wired through every creation path (host-create, panel, browser form, IPC relay), and every save path passes chords through so nothing strips them.
- **Display**: current chord large, next chord smaller and dimmer, top right of the canvas, transposing live with the key shift. "Show Chords" toggle in Display Options, **default off**. Settings changes now sync app-to-web as well as web-to-app (that asymmetry affected all display toggles, not just this one).
- **Existing songs backfill automatically**: on load, a song with stems but no chord track is analyzed in a Web Worker from the already-decoded stems, displays within seconds, and persists once via a worker thread. No button, no re-creating.
- **Chord editing in the editor** (jorge's item 3): collapsible Chords section with per-chord start/end/name fields (the #69 draft-input pattern), add/delete, manual add for chordless songs. Rides the normal Save on both web and Electron editors.
- **Audit fixes along the way**: a pre-existing data-loss bug where the import/lyrics-correction path rewrote the kara atom as lines-only (destroying timing, singers, tags, chords); the browser-form create path dropping chords server-side; a stale-display race in the backfill.

All verified live on real songs: created song showed its true progression (D/A, transposing to E/B at +2, screenshots); legacy song backfilled 26 segments and persisted with lyrics intact; edited the first chord F to Gm in the web editor and read Gm back from the file, and Gm is in fact the correct chord there, so the editor corrected the detector's first real-world mistake. 383/383 tests, both bundles build, lint clean.

Remaining non-blocking: the offsite creator's client-side mux path (its files backfill on first play anyway, so chords still appear), and richer chord qualities (7ths, sus) in the detector templates.