### PR TITLE
Editor: key lyric rows by stable identity

### DIFF
--- a/src/shared/components/SongEditor.jsx
+++ b/src/shared/components/SongEditor.jsx
@@ -386,9 +386,13 @@ export function SongEditor({ bridge }) {
             const bStart = b.start || b.startTimeSec || 0;
             return aStart - bStart;
           });
-          setLyricsData(JSON.parse(JSON.stringify(sortedLyrics)));
+          // Stable per-line identity for React keys: rows hold internal state
+          // (time-field drafts), so index keys re-marry that state to the WRONG
+          // line after a delete/insert (#96's stuck-display class of bug).
+          const withIds = sortedLyrics.map((l) => ({ ...l, _id: crypto.randomUUID() }));
+          setLyricsData(JSON.parse(JSON.stringify(withIds)));
           setChordsData(JSON.parse(JSON.stringify(result.data.chords || [])));
-          setOriginalLyricsData(JSON.parse(JSON.stringify(sortedLyrics)));
+          setOriginalLyricsData(JSON.parse(JSON.stringify(withIds)));
           setSongDuration(
             result.data.metadata?.duration || result.data.songJson?.duration_sec || 0
           );
@@ -684,6 +688,7 @@ export function SongEditor({ bridge }) {
     const margin = gap * 0.1;
 
     const newLine = {
+      _id: crypto.randomUUID(),
       start: currentEndTime + margin,
       startTimeSec: currentEndTime + margin,
       end: currentEndTime + margin + usableGap,
@@ -728,6 +733,7 @@ export function SongEditor({ bridge }) {
     if (!firstLine) {
       // No lines exist, create a default one
       const newLine = {
+        _id: crypto.randomUUID(),
         start: 0,
         startTimeSec: 0,
         end: 3,
@@ -746,6 +752,7 @@ export function SongEditor({ bridge }) {
     const usableGap = gap * 0.8;
 
     const newLine = {
+      _id: crypto.randomUUID(),
       start: 0,
       startTimeSec: 0,
       end: usableGap,
@@ -974,6 +981,7 @@ export function SongEditor({ bridge }) {
 
     // Create new lyric line from suggestion
     const newLine = {
+      _id: crypto.randomUUID(),
       start: suggestion.start_time,
       startTimeSec: suggestion.start_time,
       end: suggestion.end_time,
@@ -1303,7 +1311,7 @@ export function SongEditor({ bridge }) {
                   {lyricsData && lyricsData.length > 0 ? (
                     lyricsData.map((line, index) => (
                       <LyricLine
-                        key={`lyric-${index}`}
+                        key={line._id || `lyric-${index}`}
                         line={line}
                         index={index}
                         isSelected={selectedLineIndex === index}


### PR DESCRIPTION
Hardening for #96. Lyric rows hold internal state (the #69 time-field drafts), and index keys re-marry that state to the wrong line after any delete or insert - the reported stuck-display class of bug. Rows now key on a per-line `_id` assigned at load and at every line-creation site; the id lives only in editor state (the kara atom mapper never writes it). The reported hard freeze itself did not reproduce on current main in three attempts on both editors (plain delete, delete of a mid-edit row, rapid deletes; zero page errors), so #96 stays open for the reporter's platform and console details. 383/383 tests, both bundles build, editor smoke-tested live after the change.