### PR TITLE
v0.10.1

### DIFF
--- a/com.loukai.app.metainfo.xml
+++ b/com.loukai.app.metainfo.xml
@@ -48,6 +48,14 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="0.10.1" date="2026-07-21">
+      <description>
+        <p>Security dependency updates</p>
+        <ul>
+          <li>Updates bundled dependencies for newly published advisories (node-tar, body-parser); no feature changes from 0.10.0</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.10.0" date="2026-07-21">
       <description>
         <p>Chords on screen - play along with any song</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loukai-app",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loukai-app",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loukai-app",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "type": "module",
   "description": "Loukai Karaoke - Free and open source karaoke system for playing and creating stem-based karaoke files",
   "main": "src/main/main.js",


### PR DESCRIPTION
Security patch release: rebuilds the binaries with the audited dependency tree from #99 (node-tar critical, body-parser). No feature changes from 0.10.0. The npm package self-heals at install time; the frozen GitHub artifacts need this rebuild. Tag `v0.10.1` after merge AND green CI.