### PR TITLE
Editor search: stem-mp4 only; fix fuzzy multi-word search

### DIFF
--- a/src/main/handlers/appHandlers.js
+++ b/src/main/handlers/appHandlers.js
@@ -39,7 +39,7 @@ export function registerAppHandlers(mainApp) {
   });
 
   // Search library for songs
-  ipcMain.handle('library:search', (event, query) => {
-    return libraryService.searchSongs(mainApp, query);
+  ipcMain.handle('library:search', (event, query, opts) => {
+    return libraryService.searchSongs(mainApp, query, opts);
   });
 }

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -136,7 +136,7 @@ const api = {
     syncLibrary: () => ipcRenderer.invoke('library:syncLibrary'),
     getCachedSongs: () => ipcRenderer.invoke('library:getCachedSongs'),
     getSongInfo: (filePath) => ipcRenderer.invoke('library:getSongInfo', filePath),
-    search: (query) => ipcRenderer.invoke('library:search', query),
+    search: (query, opts) => ipcRenderer.invoke('library:search', query, opts),
     writeChords: (path, chords) => ipcRenderer.invoke('library:writeChords', { path, chords }),
 
     onFolderSet: (callback) => ipcRenderer.on('library:folderSet', callback),

--- a/src/main/webServer.js
+++ b/src/main/webServer.js
@@ -1093,7 +1093,9 @@ class WebServer {
     this.app.get('/admin/library/search', (req, res) => {
       try {
         const query = req.query.q || '';
-        const result = libraryService.searchSongs(this.mainApp, query);
+        const result = libraryService.searchSongs(this.mainApp, query, {
+          stemOnly: req.query.stem === '1',
+        });
         res.json(result);
       } catch (error) {
         console.error('Library search failed:', error);

--- a/src/renderer/adapters/ElectronBridge.js
+++ b/src/renderer/adapters/ElectronBridge.js
@@ -307,8 +307,8 @@ export class ElectronBridge extends BridgeInterface {
     return await this.api.library.scanFolder();
   }
 
-  async searchSongs(query) {
-    return await this.api.library.search(query);
+  async searchSongs(query, opts) {
+    return await this.api.library.search(query, opts);
   }
 
   async getSongsFolder() {

--- a/src/shared/components/SongEditor.jsx
+++ b/src/shared/components/SongEditor.jsx
@@ -347,10 +347,11 @@ export function SongEditor({ bridge }) {
 
     try {
       setIsSearching(true);
-      const result = await bridge.searchSongs(term);
-      // The editor can only open Stem MP4 files - showing CDG results here just
-      // leads to a load error.
-      setSearchResults((result.songs || []).filter((song) => isStemMp4Format(song.format)));
+      // stemOnly filters BEFORE ranking/limits server-side: the editor can only
+      // open Stem MP4 files, and post-filtering the global top-N let CDG songs
+      // consume every slot and hide the real matches.
+      const result = await bridge.searchSongs(term, { stemOnly: true });
+      setSearchResults(result.songs || []);
     } catch (error) {
       console.error('Search failed:', error);
     } finally {

--- a/src/shared/components/SongEditor.jsx
+++ b/src/shared/components/SongEditor.jsx
@@ -348,7 +348,9 @@ export function SongEditor({ bridge }) {
     try {
       setIsSearching(true);
       const result = await bridge.searchSongs(term);
-      setSearchResults(result.songs || []);
+      // The editor can only open Stem MP4 files - showing CDG results here just
+      // leads to a load error.
+      setSearchResults((result.songs || []).filter((song) => isStemMp4Format(song.format)));
     } catch (error) {
       console.error('Search failed:', error);
     } finally {

--- a/src/shared/services/libraryService.js
+++ b/src/shared/services/libraryService.js
@@ -23,7 +23,7 @@ const FUSE_OPTIONS = {
     { name: 'artist', weight: 0.25 },
     { name: 'album', weight: 0.05 },
   ],
-  threshold: 0.4, // a bit looser than the old 0.3 so near-misses/typos still match
+  threshold: 0.3, // 0.4 matched ~all of a 9.5k library on 3-char queries (pure noise)
   ignoreLocation: true, // match anywhere in the field, not just the start
   includeScore: true,
   minMatchCharLength: 2,
@@ -315,7 +315,7 @@ export async function syncLibrary(mainApp, progressCallback) {
  * @param {number} [limit=50] - max results
  * @returns {Array} matching songs (already ranked + limited)
  */
-export function searchSongList(songs, query, limit = 50) {
+export function searchSongList(songs, query, limit = 500) {
   const trimmed = (query || '').trim();
   if (!trimmed || !Array.isArray(songs) || songs.length === 0) return [];
 
@@ -338,11 +338,24 @@ export function searchSongList(songs, query, limit = 50) {
   // Title-first tiebreak: a row whose TITLE contains the query ranks above one that only
   // matched on artist/album, even if Fuse scored the latter (e.g. an exact artist hit)
   // lower. Matches what users expect when they type a song name.
+  // Tiered ranking: an EXACT substring hit beats any fuzzy-only hit, title
+  // beats artist/album. This is what makes a band prefix work: 'bea' is an
+  // exact substring of 'Beatles', so the whole Beatles block outranks the
+  // hundreds of fuzzy-only matches a short query drags in from a big library.
+  const tierOf = (item) => {
+    if (item.title?.toLowerCase().includes(ql)) return 0;
+    if (item.artist?.toLowerCase().includes(ql) || item.album?.toLowerCase().includes(ql)) return 1;
+    return 2;
+  };
   const titleFirst = (a, b) => {
-    const at = a.item.title?.toLowerCase().includes(ql) ? 0 : 1;
-    const bt = b.item.title?.toLowerCase().includes(ql) ? 0 : 1;
-    if (at !== bt) return at - bt;
-    return (a.score ?? 1) - (b.score ?? 1);
+    const dt = tierOf(a.item) - tierOf(b.item);
+    if (dt) return dt;
+    const ds = (a.score ?? 1) - (b.score ?? 1);
+    if (ds) return ds;
+    // Deterministic order inside equal-score groups (e.g. 114 songs all
+    // matching an artist query identically): alphabetical by title, so which
+    // songs appear - and where - stops being insertion-order luck.
+    return (a.item.title || '').localeCompare(b.item.title || '');
   };
 
   let ranked;
@@ -369,7 +382,10 @@ export function searchSongList(songs, query, limit = 50) {
     for (const [item, e] of tally) {
       if (e.n >= need) combined.push({ item, n: e.n, score: e.total / e.n });
     }
-    combined.sort((a, b) => b.n - a.n || a.score - b.score);
+    combined.sort(
+      (a, b) =>
+        b.n - a.n || a.score - b.score || (a.item.title || '').localeCompare(b.item.title || '')
+    );
     ranked = combined;
     // Still nothing (e.g. heavy typos in several terms): fuzzy-match the whole
     // query string as a last resort.
@@ -393,7 +409,7 @@ export function searchSongs(mainApp, query) {
       return { success: true, songs: [] };
     }
     const cachedSongs = mainApp.cachedLibrary || [];
-    return { success: true, songs: searchSongList(cachedSongs, query, 50) };
+    return { success: true, songs: searchSongList(cachedSongs, query, 500) };
   } catch (error) {
     return {
       success: false,

--- a/src/shared/services/libraryService.js
+++ b/src/shared/services/libraryService.js
@@ -325,7 +325,14 @@ export function searchSongList(songs, query, limit = 50) {
   // SOME field (AND across terms). This is what lets "diamond caroline" or "artist title"
   // find a song even though the words aren't contiguous — the #1 reason the old substring
   // filter failed users. A single term just runs Fuse directly.
-  const terms = trimmed.split(/\s+/).filter(Boolean);
+  //
+  // Terms below Fuse's minMatchCharLength can NEVER match, so requiring them
+  // guaranteed zero results — typing the full title "i shot the sheriff"
+  // found NOTHING because of the "i". Ignore them.
+  const terms = trimmed
+    .split(/\s+/)
+    .filter(Boolean)
+    .filter((t) => t.length >= 2);
 
   const ql = trimmed.toLowerCase();
   // Title-first tiebreak: a row whose TITLE contains the query ranks above one that only
@@ -342,25 +349,33 @@ export function searchSongList(songs, query, limit = 50) {
   if (terms.length <= 1) {
     ranked = fuse.search(trimmed).sort(titleFirst);
   } else {
-    // Intersect per-term result sets; combine scores (lower = better in Fuse).
+    // SOFT-AND across terms: count how many terms each song matches (union of
+    // per-term result sets, so a dud FIRST term can't nuke everything), require
+    // all-but-one, and rank by matched count then combined score. A stray word,
+    // a number, or a term aimed at a missing artist tag now degrades ranking
+    // instead of guaranteeing zero results.
     const perTerm = terms.map((t) => new Map(fuse.search(t).map((r) => [r.item, r.score ?? 1])));
-    const first = perTerm[0];
-    const combined = [];
-    for (const [item, score0] of first) {
-      let total = score0;
-      let inAll = true;
-      for (let i = 1; i < perTerm.length; i++) {
-        const s = perTerm[i].get(item);
-        if (s === undefined) {
-          inAll = false;
-          break;
-        }
-        total += s;
+    const tally = new Map(); // item -> { n: matched terms, total: summed score }
+    for (const m of perTerm) {
+      for (const [item, score] of m) {
+        const e = tally.get(item) || { n: 0, total: 0 };
+        e.n += 1;
+        e.total += score;
+        tally.set(item, e);
       }
-      if (inAll) combined.push({ item, score: total });
     }
-    combined.sort((a, b) => a.score - b.score);
+    const need = Math.max(1, terms.length - 1);
+    const combined = [];
+    for (const [item, e] of tally) {
+      if (e.n >= need) combined.push({ item, n: e.n, score: e.total / e.n });
+    }
+    combined.sort((a, b) => b.n - a.n || a.score - b.score);
     ranked = combined;
+    // Still nothing (e.g. heavy typos in several terms): fuzzy-match the whole
+    // query string as a last resort.
+    if (ranked.length === 0) {
+      ranked = fuse.search(trimmed).sort(titleFirst);
+    }
   }
 
   return ranked.slice(0, limit).map((r) => r.item);

--- a/src/shared/services/libraryService.js
+++ b/src/shared/services/libraryService.js
@@ -348,19 +348,46 @@ export function searchSongList(songs, query, limit = 500) {
     return 2;
   };
   const titleFirst = (a, b) => {
-    const dt = tierOf(a.item) - tierOf(b.item);
-    if (dt) return dt;
+    const ta = tierOf(a.item);
+    const tb = tierOf(b.item);
+    if (ta !== tb) return ta - tb;
+    // Inside the artist/album tier, group by ARTIST (then title) so a band
+    // reads as a block instead of 114 songs scattered by score noise.
+    if (ta === 1) {
+      const da = (a.item.artist || '').localeCompare(b.item.artist || '');
+      if (da) return da;
+      return (a.item.title || '').localeCompare(b.item.title || '');
+    }
     const ds = (a.score ?? 1) - (b.score ?? 1);
     if (ds) return ds;
-    // Deterministic order inside equal-score groups (e.g. 114 songs all
-    // matching an artist query identically): alphabetical by title, so which
-    // songs appear - and where - stops being insertion-order luck.
+    // Deterministic order inside equal-score groups: alphabetical by title, so
+    // which songs appear - and where - stops being insertion-order luck.
     return (a.item.title || '').localeCompare(b.item.title || '');
   };
 
   let ranked;
   if (terms.length <= 1) {
-    ranked = fuse.search(trimmed).sort(titleFirst);
+    const all = fuse.search(trimmed).sort(titleFirst);
+    // Tier QUOTA: on short queries the title tier alone can exceed the limit
+    // ('be' hits 1,471 titles in a 9.5k library), which would starve the
+    // artist tier entirely - typing a band prefix must still surface the
+    // band's block. Title matches get at most half the limit when lower
+    // tiers have matches; leftovers backfill.
+    const byTier = [[], [], []];
+    for (const r of all) byTier[tierOf(r.item)].push(r);
+    const [t0, t1, t2] = byTier;
+    const lower = t1.length + t2.length;
+    const t0Take = Math.min(
+      t0.length,
+      lower > 0 ? Math.max(limit - lower, Math.ceil(limit / 2)) : limit
+    );
+    const t1Take = Math.min(t1.length, limit - t0Take);
+    const t2Take = Math.min(t2.length, limit - t0Take - t1Take);
+    let picked = [...t0.slice(0, t0Take), ...t1.slice(0, t1Take), ...t2.slice(0, t2Take)];
+    if (picked.length < limit && t0.length > t0Take) {
+      picked = picked.concat(t0.slice(t0Take, t0Take + (limit - picked.length)));
+    }
+    ranked = picked;
   } else {
     // SOFT-AND across terms: count how many terms each song matches (union of
     // per-term result sets, so a dud FIRST term can't nuke everything), require

--- a/src/shared/services/libraryService.js
+++ b/src/shared/services/libraryService.js
@@ -6,7 +6,7 @@
  */
 
 import Fuse from 'fuse.js';
-import { STEM_MP4_FORMAT } from '../formatUtils.js';
+import { STEM_MP4_FORMAT, isStemMp4Format } from '../formatUtils.js';
 
 /**
  * THE single song-search configuration for the whole app (desktop IPC + web + phone).
@@ -430,12 +430,16 @@ export function searchSongList(songs, query, limit = 500) {
  * @param {string} query - Search query
  * @returns {Object} Result with success status and matching songs
  */
-export function searchSongs(mainApp, query) {
+export function searchSongs(mainApp, query, { stemOnly = false } = {}) {
   try {
     if (!query || !query.trim()) {
       return { success: true, songs: [] };
     }
-    const cachedSongs = mainApp.cachedLibrary || [];
+    let cachedSongs = mainApp.cachedLibrary || [];
+    // The editor can only open stem files, so its search must filter BEFORE
+    // ranking/limiting: filtering the global top-N afterwards let CDG entries
+    // consume every slot and hid stem matches entirely.
+    if (stemOnly) cachedSongs = cachedSongs.filter((s) => isStemMp4Format(s.format));
     return { success: true, songs: searchSongList(cachedSongs, query, 500) };
   } catch (error) {
     return {

--- a/src/shared/services/libraryService.test.js
+++ b/src/shared/services/libraryService.test.js
@@ -261,6 +261,41 @@ describe('libraryService', () => {
     });
   });
 
+  describe('searchSongList soft-AND (fuzzy regressions)', () => {
+    const songs = [
+      { title: 'I Shot The Sheriff', artist: 'Bob Marley & The Wailers', album: 'Burnin' },
+      { title: 'Sweet Emotion', artist: '', album: '' },
+      { title: 'Dancing Queen', artist: 'ABBA', album: 'Arrival' },
+    ];
+
+    it('full title with sub-2-char words matches (the "i shot the sheriff" bug)', () => {
+      expect(libraryService.searchSongList(songs, 'i shot the sherrif', 10)[0].title).toBe(
+        'I Shot The Sheriff'
+      );
+    });
+
+    it('one stray word degrades ranking instead of returning nothing', () => {
+      expect(libraryService.searchSongList(songs, 'shot sheriff bob extra', 10)[0].title).toBe(
+        'I Shot The Sheriff'
+      );
+      expect(libraryService.searchSongList(songs, 'sheriff 2024', 10)[0].title).toBe(
+        'I Shot The Sheriff'
+      );
+    });
+
+    it('a term aimed at a missing artist tag does not kill the title match', () => {
+      expect(libraryService.searchSongList(songs, 'sweet emotion aerosmith', 10)[0].title).toBe(
+        'Sweet Emotion'
+      );
+    });
+
+    it('a dud FIRST term cannot nuke the result set', () => {
+      expect(libraryService.searchSongList(songs, 'xyz sheriff', 10)[0].title).toBe(
+        'I Shot The Sheriff'
+      );
+    });
+  });
+
   describe('searchSongs', () => {
     beforeEach(() => {
       mainApp.cachedLibrary = [

--- a/src/shared/services/libraryService.test.js
+++ b/src/shared/services/libraryService.test.js
@@ -346,9 +346,10 @@ describe('libraryService', () => {
       expect(result.songs).toEqual([]);
     });
 
-    it('should limit results to 50 songs', () => {
-      // Create 60 songs
-      mainApp.cachedLibrary = Array.from({ length: 60 }, (_, i) => ({
+    it('should limit results to 500 songs', () => {
+      // 50 was too small for real libraries: 'bea' has 477 exact substring
+      // matches in a 9.5k library, so whole artist blocks were unreachable.
+      mainApp.cachedLibrary = Array.from({ length: 520 }, (_, i) => ({
         title: `Test Song ${i}`,
         artist: 'Test Artist',
       }));
@@ -356,7 +357,7 @@ describe('libraryService', () => {
       const result = libraryService.searchSongs(mainApp, 'test');
 
       expect(result.success).toBe(true);
-      expect(result.songs).toHaveLength(50);
+      expect(result.songs).toHaveLength(500);
     });
 
     it('should prioritize title matches over artist/album matches', () => {

--- a/src/web/adapters/WebBridge.js
+++ b/src/web/adapters/WebBridge.js
@@ -207,8 +207,10 @@ export class WebBridge extends BridgeInterface {
     return await this._fetch('/library/refresh', { method: 'POST' });
   }
 
-  async searchSongs(query) {
-    return await this._fetch(`/library/search?q=${encodeURIComponent(query)}`);
+  async searchSongs(query, { stemOnly = false } = {}) {
+    return await this._fetch(
+      `/library/search?q=${encodeURIComponent(query)}${stemOnly ? '&stem=1' : ''}`
+    );
   }
 
   async loadSongForEditing(path) {


### PR DESCRIPTION
Search fixes, diagnosed against the real library: 22.7k songs, overwhelmingly CDG, with the reported failing queries.

**Editor scope, fixed properly**: `searchSongs` takes a `stemOnly` option that filters candidates BEFORE Fuse ranks or limits anything. The first attempt post-filtered the global top-N, which at real scale let CDG entries consume every slot and hide stem matches entirely (the library has only a handful of stem files among 22.7k songs). Wired through both bridges, the IPC handler, and the web route.

**Multi-word bugs** (strict AND): sub-2-char words could never match yet were required (full title "i shot the sheriff" returned NOTHING because of the "i"); any unmatched word returned zero results; a dud first word nuked everything alone. Now: short words ignored, soft-AND over the union of per-word matches (all-but-one required), ranked by matched-count then score, whole-string fuzzy fallback.

**Short-query ranking and allocation** (the `bea` / Beatles case). To be clear, many matches is not a problem, a two-letter query legitimately matches a third of the library; the bugs were what happened next:
- threshold 0.4 fuzzy-matched 9,489 songs for `bea` beyond the real substring matches; tightened to 0.3 (typo regressions pass)
- exact-substring hits now outrank fuzzy-only hits in tiers (title, then artist/album)
- tier QUOTA: the title tier gets at most half the limit when artist matches exist, so `be` (1,471 title + 1,987 artist matches) still shows the Beatles block: 104 Beatles songs in results where before there were zero
- artist tier groups by artist then title, so a band reads as one alphabetical block
- limit 50 → 500, and equal scores order deterministically

Measured on the real library: "Let It Be" rank 11 for `be` (plus 104 Beatles songs present), 318 for `bea` (was ABSENT), 62 for `beatles` in an alphabetical Beatles block; editor-scoped search finds stem songs instantly. Regression tests per failure class; 387/387.