### PR TITLE
Editor: Evaluate/Reevaluate Chords button

### DIFF
--- a/src/renderer/js/songLoaders.js
+++ b/src/renderer/js/songLoaders.js
@@ -30,7 +30,7 @@ export function backfillChordsCdg(app) {
     });
     const other = toStem(buf);
     const loadedPath = app.currentSong?.path;
-    const worker = new Worker(new URL('../workers/chordWorker.js', import.meta.url), {
+    const worker = new Worker(new URL('../../shared/workers/chordWorker.js', import.meta.url), {
       type: 'module',
     });
     const transfers = [other.left.buffer];
@@ -71,7 +71,7 @@ export function backfillChords(app, songData) {
       };
     const other = toStem(otherBuf);
     const bass = toStem(bassBuf);
-    const worker = new Worker(new URL('../workers/chordWorker.js', import.meta.url), {
+    const worker = new Worker(new URL('../../shared/workers/chordWorker.js', import.meta.url), {
       type: 'module',
     });
     const transfers = [other.left.buffer];

--- a/src/shared/components/ChordEditor.jsx
+++ b/src/shared/components/ChordEditor.jsx
@@ -77,7 +77,7 @@ function TimeField({ value, onCommit }) {
   );
 }
 
-export function ChordEditor({ chords, onChange }) {
+export function ChordEditor({ chords, onChange, onAnalyze, analyzing = false }) {
   const [selectedIndex, setSelectedIndex] = useState(null);
   const [open, setOpen] = useState(false);
   const list = chords || [];
@@ -98,16 +98,33 @@ export function ChordEditor({ chords, onChange }) {
 
   return (
     <div className="mt-4 border border-gray-200 dark:border-gray-700 rounded-lg">
-      <button
-        type="button"
-        onClick={() => setOpen(!open)}
-        className="w-full flex items-center justify-between px-3 py-2 text-left"
-      >
-        <span className="font-semibold text-gray-900 dark:text-gray-100">
-          Chords ({list.length})
-        </span>
-        <span className="material-icons text-gray-500">{open ? 'expand_less' : 'expand_more'}</span>
-      </button>
+      <div className="w-full flex items-center gap-2 px-3 py-2">
+        <button
+          type="button"
+          onClick={() => setOpen(!open)}
+          className="flex-1 flex items-center justify-between text-left"
+        >
+          <span className="font-semibold text-gray-900 dark:text-gray-100">
+            Chords ({list.length})
+          </span>
+          <span className="material-icons text-gray-500">
+            {open ? 'expand_less' : 'expand_more'}
+          </span>
+        </button>
+        {onAnalyze && (
+          <button
+            type="button"
+            onClick={onAnalyze}
+            disabled={analyzing}
+            className="flex items-center gap-1 px-3 py-1 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white text-xs transition-colors hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50"
+          >
+            <span className={`material-icons text-base ${analyzing ? 'animate-spin' : ''}`}>
+              {analyzing ? 'autorenew' : 'graphic_eq'}
+            </span>
+            {analyzing ? 'Analyzing…' : list.length > 0 ? 'Reevaluate Chords' : 'Evaluate Chords'}
+          </button>
+        )}
+      </div>
       {open && (
         <div className="px-3 pb-3 max-h-[300px] overflow-y-auto">
           <datalist id="chord-name-options">

--- a/src/shared/components/SongEditor.jsx
+++ b/src/shared/components/SongEditor.jsx
@@ -680,6 +680,75 @@ export function SongEditor({ bridge }) {
     setHasChanges(true);
   };
 
+  // Evaluate/Reevaluate chords (issue #93): fetch the bass + harmony stems the
+  // editor already has URLs for, decode, run the shared detection worker, and
+  // stage the result - the normal Save persists it to the file.
+  const [isAnalyzingChords, setIsAnalyzingChords] = useState(false);
+  const handleAnalyzeChords = async () => {
+    const files = songData?.audioFiles || [];
+    const find = (name) => files.find((f) => f.name?.toLowerCase().includes(name));
+    const otherFile = find('other') || find('music');
+    if (!otherFile) {
+      showToast('No harmony stem available to analyze', 'error');
+      return;
+    }
+    try {
+      setIsAnalyzingChords(true);
+      const ctx = new (window.AudioContext || window.webkitAudioContext)();
+      const decode = async (f) => {
+        if (!f) return null;
+        // Electron hands the raw bytes straight over (fetch() on its blob URLs
+        // is CSP-blocked); the web admin fetches its same-origin HTTP URLs.
+        let buf;
+        if (f.audioData?.byteLength) {
+          buf = f.audioData.buffer.slice(
+            f.audioData.byteOffset,
+            f.audioData.byteOffset + f.audioData.byteLength
+          );
+        } else if (f.downloadUrl) {
+          buf = await (await fetch(f.downloadUrl)).arrayBuffer();
+        } else {
+          return null;
+        }
+        const audio = await ctx.decodeAudioData(buf);
+        return {
+          left: audio.getChannelData(0).slice(),
+          right: audio.numberOfChannels > 1 ? audio.getChannelData(1).slice() : undefined,
+          sampleRate: audio.sampleRate,
+        };
+      };
+      const other = await decode(otherFile);
+      const bass = await decode(find('bass'));
+      ctx.close();
+      const worker = new Worker(new URL('../workers/chordWorker.js', import.meta.url), {
+        type: 'module',
+      });
+      const chords = await new Promise((resolve, reject) => {
+        worker.onmessage = (e) => {
+          worker.terminate();
+          if (e.data.ok) resolve(e.data.chords);
+          else reject(new Error(e.data.error));
+        };
+        worker.onerror = (e) => {
+          worker.terminate();
+          reject(new Error(e.message || 'analysis worker failed'));
+        };
+        const transfers = [other.left.buffer];
+        if (other.right) transfers.push(other.right.buffer);
+        if (bass?.left) transfers.push(bass.left.buffer);
+        if (bass?.right) transfers.push(bass.right.buffer);
+        worker.postMessage({ other, bass, sampleRate: other.sampleRate }, transfers);
+      });
+      setChordsData(chords);
+      setHasChanges(true);
+      showToast(`Chords analyzed: ${chords.length} segments - Save to keep them`, 'success');
+    } catch (e) {
+      showToast(`Chord analysis failed: ${e.message}`, 'error');
+    } finally {
+      setIsAnalyzingChords(false);
+    }
+  };
+
   const handleAddLineAfter = (index) => {
     const currentLine = lyricsData[index];
     const nextLine = lyricsData[index + 1];
@@ -1395,6 +1464,8 @@ export function SongEditor({ bridge }) {
                     setChordsData(next);
                     setHasChanges(true);
                   }}
+                  onAnalyze={handleAnalyzeChords}
+                  analyzing={isAnalyzingChords}
                 />
               </div>
             </>

--- a/src/shared/workers/chordWorker.js
+++ b/src/shared/workers/chordWorker.js
@@ -3,7 +3,7 @@
  * library song that predates the chord track. Runs off the UI thread; the
  * player posts transferable Float32Arrays, we post back the segment list.
  */
-import { detectChords } from '../../shared/creator/chordDetect.js';
+import { detectChords } from '../creator/chordDetect.js';
 
 self.onmessage = (e) => {
   const { other, bass, sampleRate } = e.data;


### PR DESCRIPTION
Stacked on #103 (contains its commit; merge #103 first and this rebases clean, or merge this and it carries both).

A button in the editor's Chords section header runs chord detection on demand: "Evaluate Chords" when the song has no track, "Reevaluate Chords" when it does. It decodes the bass and harmony stems the editor already holds (Electron passes raw bytes since fetch() on its blob URLs is CSP-blocked; web fetches its HTTP URLs), runs the shared detection worker off the UI thread, and stages the result with the editor dirty, so the normal Save button persists to the mp4, exactly the requested flow.

Verified live end to end: seeded a file with one dummy chord, Reevaluate produced 48 segments, Save wrote all 48 to the file with lyrics intact. 388/388 tests, both bundles build.
EOF