### PR TITLE
Release v0.11.0

### DIFF
--- a/com.loukai.app.metainfo.xml
+++ b/com.loukai.app.metainfo.xml
@@ -48,6 +48,18 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="0.11.0" date="2026-08-02">
+      <description>
+        <p>Fixes the blank window on startup, plus smarter chords and editor search</p>
+        <ul>
+          <li>Fixes the app opening to a blank window on new installs and updates (a bad default in saved settings crashed the player screen; existing installs heal automatically)</li>
+          <li>Fixes the editor keyboard freezing after deleting or retiming lyric lines</li>
+          <li>Chord detection v2: bass-first root notes for much more accurate chords</li>
+          <li>Evaluate/Reevaluate Chords button in the song editor</li>
+          <li>Editor search overhaul: better multi-word matching, artist matches on short queries, stem-song-only results</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.10.1" date="2026-07-21">
       <description>
         <p>Security dependency updates</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loukai-app",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loukai-app",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loukai-app",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "type": "module",
   "description": "Loukai Karaoke - Free and open source karaoke system for playing and creating stem-based karaoke files",
   "main": "src/main/main.js",


### PR DESCRIPTION
Version bump for the v0.11.0 release.

Ships everything on main since v0.10.1:

- **Fix #106**: blank window on startup. A legacy object-shaped `mixer.stems` default poisoned `settings.json` and crashed the renderer on mount; defaults corrected and existing installs self-heal on next launch (#107)
- **Fix #96**: editor keyboard freeze after deleting/retiming lyric lines (IME composition fix #101, stable row keys #97)
- Chord detection v2 with bass-first root notes + Evaluate/Reevaluate Chords button in the editor (#103, #104)
- Editor search overhaul: soft-AND multi-word matching, artist-match tier quotas, stem-song-only results (#102)
- CI: audit gate scoped to production dependencies (#107)

After merging, tag `v0.11.0` on main to trigger the build/publish workflow.