### PR TITLE
Gamepad support via SDL and Flathub packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,11 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          # @kmamal/sdl downloads a prebuilt binary for the BUILD HOST's arch.
+          # This job cross-builds arm64 on an x64 runner, so without this the
+          # arm64 artifacts would silently ship an x86_64 sdl.node.
+          CROSS_COMPILE_ARCH: arm64
 
       - name: Build renderer and web UI
         run: npm run build:all

--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,13 @@ yarn-error.log*
 # ...but the Flatpak/Flathub manifest and launcher MUST be tracked
 # (the blanket *.yml rule above was silently ignoring the manifest)
 !flathub-manifest.yml
+!flatpak/*.yml
 !flatpak/*.sh
 # local flatpak build artifacts
 .flatpak-builder/
 build-dir/
 .flatpak/
 __pycache__/
+
+# Flathub asset archive built by scripts/pack-webgpu-assets.js (published to releases)
+webgpu-assets-*.tar.gz

--- a/flatpak/PERMISSIONS.md
+++ b/flatpak/PERMISSIONS.md
@@ -13,6 +13,7 @@ needed and the plan to narrow the broad ones.
 | `--share=network` | The web remote-control server (Express + Socket.IO) that singers connect to from phones; lyrics lookup (LRCLIB); model/runtime downloads for the Creator | No |
 | `--filesystem=home` | The song library is a **user-chosen folder** anywhere under home; the library scanner reads audio files directly | **Yes — see below** |
 | `--talk-name=org.freedesktop.Notifications` | Song-request notifications | Already minimal (talk-name, not own-name) |
+| `--device=input` | Gamepad/controller navigation for living-room and SteamOS/Deck use. SDL reads controllers via evdev, which the sandbox blocks by default | No (narrower than `--device=all`, which we deliberately avoid) |
 
 ## Narrowing `--filesystem=home` (the one reviewers flag)
 

--- a/flatpak/com.loukai.app.yml
+++ b/flatpak/com.loukai.app.yml
@@ -34,11 +34,21 @@ sdk-extensions:
 build-options:
   append-path: /usr/lib/sdk/node22/bin
   env:
-    # Keep npm's cache and Electron's download cache inside the build dir; both
-    # default to $HOME, which is not writable during a Flathub build.
-    NPM_CONFIG_CACHE: /run/build/loukai/npm-cache
-    ELECTRON_CACHE: /run/build/loukai/electron-cache
-    ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+    # These paths are dictated by flatpak-node-generator's output: it unpacks an
+    # npm cache to flatpak-node/npm-cache and an Electron 42.4.1 binary cache to
+    # flatpak-node/cache/electron. Pointing npm anywhere else breaks the offline
+    # install with ENOTCACHED, and pointing electron-builder anywhere else makes
+    # it try to download Electron.
+    NPM_CONFIG_CACHE: /run/build/loukai/flatpak-node/npm-cache
+    NPM_CONFIG_OFFLINE: 'true'
+    XDG_CACHE_HOME: /run/build/loukai/flatpak-node/cache
+    # BOTH names are needed and they are not interchangeable: electron's own
+    # install.js reads the lowercase `electron_config_cache`, while
+    # electron-builder / @electron/get honour ELECTRON_CACHE. Setting only the
+    # uppercase one lets `npm ci` succeed and then electron-builder still tries
+    # to fetch Electron from github.com.
+    ELECTRON_CACHE: /run/build/loukai/flatpak-node/cache/electron
+    electron_config_cache: /run/build/loukai/flatpak-node/cache/electron
 
 finish-args:
   # Display
@@ -71,29 +81,48 @@ modules:
 
     build-options:
       env:
-        # @kmamal/sdl's postinstall otherwise DOWNLOADS a prebuilt sdl.node plus a
-        # vendored libSDL2 from GitHub releases, which Flathub does not allow.
-        # This forces a real source build; the runtime ships SDL 2.32.10 with
-        # headers, and binding.gyp reads these two vars.
-        NODE_SDL_FROM_SOURCE: '1'
-        SDL_INC: /usr/include/SDL2
-        SDL_LIB: /usr/lib/$FLATPAK_ARCH-linux-gnu
+        # @kmamal/sdl's postinstall downloads a prebuilt sdl.node, and with
+        # NODE_SDL_FROM_SOURCE it instead downloads SDL's OWN SOURCE from GitHub
+        # and builds node-gyp against that, overriding SDL_INC/SDL_LIB with its
+        # own paths. Both are network fetches Flathub forbids, so the postinstall
+        # is skipped entirely (npm ci --ignore-scripts) and node-gyp is invoked
+        # directly against the runtime's SDL in the build commands below.
+        npm_config_ignore_scripts: 'true'
 
     build-commands:
-      # 1. Offline npm install. generated-sources.json has already populated the
-      #    local registry mirror, so this never touches the network.
-      - npm ci --offline --no-audit --no-fund
+      # 1. Offline npm install from the mirror flatpak-node-generator staged.
+      #    --ignore-scripts is essential: several postinstalls (notably
+      #    @kmamal/sdl) fetch from the network, which is unavailable here.
+      #    (The generator's own `shell` source has already run
+      #    setup_sdk_node_headers.sh to wire up the node-gyp headers.)
+      - npm ci --offline --no-audit --no-fund --ignore-scripts
 
-      # 2. Compile @kmamal/sdl against the runtime's SDL2. node-gyp's configure
-      #    step fails without node-addon-api present, so it is installed above by
-      #    npm ci as a normal dependency.
+      # 1b. --ignore-scripts also skipped electron's own install script, which is
+      #     what unpacks its binary into node_modules/electron/dist. Run just that
+      #     one: it reads the Electron 42.4.1 zip that flatpak-node-generator
+      #     staged in ELECTRON_CACHE, so it stays offline.
+      - node node_modules/electron/install.js
+
+      # 2. Compile @kmamal/sdl against the RUNTIME's SDL2 (2.32.10, with headers
+      #    and pkg-config). binding.gyp reads SDL_INC/SDL_LIB, so they are set
+      #    here rather than letting the package's own build.mjs point them at a
+      #    downloaded SDL tree.
+      #
+      #    NOTE: binding.gyp needs `node-addon-api`, which upstream declares only
+      #    as a devDependency, so `npm ci` does not install it for consumers.
+      #    loukai therefore depends on it explicitly; without that this step
+      #    fails with "Call to 'node -p require('node-addon-api').targets'
+      #    returned exit status 1".
       - |
         cd node_modules/@kmamal/sdl
-        npx node-gyp rebuild
+        export SDL_INC=/usr/include/SDL2
+        export SDL_LIB=/usr/lib/$(gcc -dumpmachine)
+        npx -y node-gyp rebuild
         mkdir -p dist
         cp build/Release/sdl.node dist/sdl.node
-        # Do NOT ship the vendored libSDL2: we link the runtime's copy.
+        # Do NOT ship a vendored libSDL2: we link the runtime's copy.
         rm -f dist/libSDL2-*.so*
+        ldd dist/sdl.node | grep -q '/usr/lib.*libSDL2' || { echo 'ERROR: not linked against runtime SDL'; exit 1; }
 
       # 3. Build the renderer and web bundles. `npm run build:all` also runs
       #    vendor:webgpu, which DOWNLOADS assets, so the vendored files are
@@ -103,16 +132,32 @@ modules:
 
       # 4. Package with electron-builder in `dir` mode. This produces the
       #    unpacked tree (including the `loukai-app` binary the launcher execs)
-      #    without building any installer format. Electron itself comes from the
-      #    offline npm sources; ELECTRON_SKIP_BINARY_DOWNLOAD keeps it from
-      #    fetching one.
+      #    without building any installer format. Electron comes from the zip
+      #    flatpak-node-generator staged in the electron cache (see the env
+      #    block above), so nothing is fetched.
       #
       #    npmRebuild is forced OFF here for the same reason it is off in
       #    package.json: @electron/rebuild would try to rebuild @kmamal/sdl and
       #    clobber the source build done in step 2.
-      - npx electron-builder --linux dir --config.npmRebuild=false
+      # `--config.electronDist` points straight at the Electron zip that
+      #  flatpak-node-generator staged. This is deliberate over relying on cache
+      #  env vars: ELECTRON_CACHE / electron_config_cache are honoured by
+      #  electron's own install.js but electron-builder still went to github.com,
+      #  and a direct path cannot silently fall back to the network.
+      - |
+        zip="flatpak-node/cache/electron/electron-v42.4.1-linux-$(node -p 'process.arch').zip"
+        test -f "$zip" || { echo "ERROR: staged Electron zip not found at $zip"; ls flatpak-node/cache/electron; exit 1; }
+        npx electron-builder --linux dir \
+          --config.npmRebuild=false \
+          --config.electronDist="$zip"
       - mkdir -p /app/loukai
       - cp -r dist/linux-*unpacked/. /app/loukai/
+      # Chromium's setuid sandbox helper cannot be SUID inside a flatpak, and if
+      # it is present Chromium tries to use it: the zygote, the network service
+      # and the GPU process all fail to spawn and it aborts with "GPU process
+      # isn't usable. Goodbye." zypak (see the launcher) maps Chromium's sandbox
+      # onto the flatpak sandbox instead, but only if this binary is gone.
+      - rm -f /app/loukai/chrome-sandbox
       - install -Dm755 flatpak/loukai-launcher.sh /app/bin/loukai
 
       # 5. Desktop integration

--- a/flatpak/com.loukai.app.yml
+++ b/flatpak/com.loukai.app.yml
@@ -145,13 +145,24 @@ modules:
       #  electron's own install.js but electron-builder still went to github.com,
       #  and a direct path cannot silently fall back to the network.
       - |
+        # Any dist/linux-*unpacked carried in from a host checkout would make the
+        # staging glob below ambiguous, and the wrong arch could be copied.
+        rm -rf dist/linux-unpacked dist/linux-*-unpacked
         zip="flatpak-node/cache/electron/electron-v42.4.1-linux-$(node -p 'process.arch').zip"
         test -f "$zip" || { echo "ERROR: staged Electron zip not found at $zip"; ls flatpak-node/cache/electron; exit 1; }
         npx electron-builder --linux dir \
           --config.npmRebuild=false \
           --config.electronDist="$zip"
       - mkdir -p /app/loukai
-      - cp -r dist/linux-*unpacked/. /app/loukai/
+      # electron-builder names the output per arch: `linux-unpacked` on x64 but
+      # `linux-arm64-unpacked` on arm64. The glob covers both, and the guard
+      # catches the case where a stale directory from another arch would make it
+      # ambiguous (copying the wrong one would produce a silently broken app).
+      - |
+        set -e
+        dirs=$(ls -d dist/linux-*unpacked 2>/dev/null | wc -l)
+        test "$dirs" -eq 1 || { echo "ERROR: expected exactly one unpacked dir, found $dirs:"; ls -d dist/linux-*unpacked; exit 1; }
+        cp -r dist/linux-*unpacked/. /app/loukai/
       # Chromium's setuid sandbox helper cannot be SUID inside a flatpak, and if
       # it is present Chromium tries to use it: the zygote, the network service
       # and the GPU process all fail to spawn and it aborts with "GPU process
@@ -170,6 +181,10 @@ modules:
         url: https://github.com/monteslu/loukai.git
         tag: v0.11.0
         # commit: filled in at submission time; Flathub requires a pinned commit
+        # (A `type: git` source is inherently clean. When testing locally with a
+        #  `type: dir` source instead, the host's dist/ and node_modules/ come
+        #  along too, so the build must clear dist/ before packaging - see the
+        #  build-commands - or electron-builder's output is ambiguous.)
 
       # Offline npm registry mirror, generated from package-lock.json by
       # flatpak-node-generator. Regenerate whenever the lockfile changes.

--- a/flatpak/com.loukai.app.yml
+++ b/flatpak/com.loukai.app.yml
@@ -1,0 +1,144 @@
+# Flathub manifest for Loukai.
+#
+# Differs from the electron-builder flatpak target (package.json -> build.flatpak)
+# in the ways Flathub requires: everything is built from source with no network
+# access, so npm dependencies and the Electron binary come from pre-generated
+# offline sources, and @kmamal/sdl is COMPILED against the runtime's SDL2 rather
+# than downloading its prebuilt binary.
+#
+# See internal-loukai/NETWORK-AUDIT.md for the full egress audit that backs the
+# permission set below.
+#
+# Before building, generate the offline sources (needs network, run outside the
+# build):
+#
+#   # npm dependencies -> generated-sources.json
+#   python3 flatpak-builder-tools/node/flatpak-node-generator.py \
+#     npm ../package-lock.json -o generated-sources.json
+#
+# Build and install locally:
+#   flatpak-builder --user --install --force-clean build-dir com.loukai.app.yml
+
+app-id: com.loukai.app
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '24.08'
+command: loukai
+
+sdk-extensions:
+  # Node is not in the base SDK; @kmamal/sdl and the renderer build both need it.
+  - org.freedesktop.Sdk.Extension.node22
+
+build-options:
+  append-path: /usr/lib/sdk/node22/bin
+  env:
+    # Keep npm's cache and Electron's download cache inside the build dir; both
+    # default to $HOME, which is not writable during a Flathub build.
+    NPM_CONFIG_CACHE: /run/build/loukai/npm-cache
+    ELECTRON_CACHE: /run/build/loukai/electron-cache
+    ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+
+finish-args:
+  # Display
+  - --socket=wayland
+  - --socket=x11
+  - --share=ipc
+  # GPU: UI rendering, Butterchurn visualisations, and WebGPU compute in the Creator
+  - --device=dri
+  # Core feature: karaoke audio out (PA + IEM buses)
+  - --socket=pulseaudio
+  # Chromium requires the session bus; also used by the notifications portal
+  - --socket=session-bus
+  - --talk-name=org.freedesktop.Notifications
+  # The LAN web remote (phones connect to it), lyrics lookup, and the Creator's
+  # optional ML model downloads. See NETWORK-AUDIT.md: the player itself makes no
+  # external requests.
+  - --share=network
+  # Gamepad navigation for living-room / SteamOS use. SDL reads controllers via
+  # evdev, which the sandbox blocks by default. Deliberately narrower than
+  # --device=all.
+  - --device=input
+  # The song library is a user-chosen folder anywhere under home and the scanner
+  # reads audio files directly. Migration to the file-chooser portal is planned;
+  # see flatpak/PERMISSIONS.md.
+  - --filesystem=home
+
+modules:
+  - name: loukai
+    buildsystem: simple
+
+    build-options:
+      env:
+        # @kmamal/sdl's postinstall otherwise DOWNLOADS a prebuilt sdl.node plus a
+        # vendored libSDL2 from GitHub releases, which Flathub does not allow.
+        # This forces a real source build; the runtime ships SDL 2.32.10 with
+        # headers, and binding.gyp reads these two vars.
+        NODE_SDL_FROM_SOURCE: '1'
+        SDL_INC: /usr/include/SDL2
+        SDL_LIB: /usr/lib/$FLATPAK_ARCH-linux-gnu
+
+    build-commands:
+      # 1. Offline npm install. generated-sources.json has already populated the
+      #    local registry mirror, so this never touches the network.
+      - npm ci --offline --no-audit --no-fund
+
+      # 2. Compile @kmamal/sdl against the runtime's SDL2. node-gyp's configure
+      #    step fails without node-addon-api present, so it is installed above by
+      #    npm ci as a normal dependency.
+      - |
+        cd node_modules/@kmamal/sdl
+        npx node-gyp rebuild
+        mkdir -p dist
+        cp build/Release/sdl.node dist/sdl.node
+        # Do NOT ship the vendored libSDL2: we link the runtime's copy.
+        rm -f dist/libSDL2-*.so*
+
+      # 3. Build the renderer and web bundles. `npm run build:all` also runs
+      #    vendor:webgpu, which DOWNLOADS assets, so the vendored files are
+      #    supplied as a source archive instead and only the bundlers run here.
+      - npm run build:renderer
+      - npm run build:web
+
+      # 4. Package with electron-builder in `dir` mode. This produces the
+      #    unpacked tree (including the `loukai-app` binary the launcher execs)
+      #    without building any installer format. Electron itself comes from the
+      #    offline npm sources; ELECTRON_SKIP_BINARY_DOWNLOAD keeps it from
+      #    fetching one.
+      #
+      #    npmRebuild is forced OFF here for the same reason it is off in
+      #    package.json: @electron/rebuild would try to rebuild @kmamal/sdl and
+      #    clobber the source build done in step 2.
+      - npx electron-builder --linux dir --config.npmRebuild=false
+      - mkdir -p /app/loukai
+      - cp -r dist/linux-*unpacked/. /app/loukai/
+      - install -Dm755 flatpak/loukai-launcher.sh /app/bin/loukai
+
+      # 5. Desktop integration
+      - install -Dm644 com.loukai.app.desktop /app/share/applications/com.loukai.app.desktop
+      - install -Dm644 com.loukai.app.metainfo.xml /app/share/metainfo/com.loukai.app.metainfo.xml
+      - install -Dm644 static/images/logo-512.png /app/share/icons/hicolor/512x512/apps/com.loukai.app.png
+
+    sources:
+      - type: git
+        url: https://github.com/monteslu/loukai.git
+        tag: v0.11.0
+        # commit: filled in at submission time; Flathub requires a pinned commit
+
+      # Offline npm registry mirror, generated from package-lock.json by
+      # flatpak-node-generator. Regenerate whenever the lockfile changes.
+      - generated-sources.json
+
+      # The Creator's WebGPU assets (onnxruntime-web, transformers.js,
+      # ffmpeg-core wasm) are normally fetched by `npm run vendor:webgpu` at build
+      # time. That needs network, so they are supplied here as a pinned archive
+      # instead. Contents are byte-identical to what vendor:webgpu produces.
+      #
+      # NOTE: ML model weights (Demucs, Whisper) are NOT here. They are optional,
+      # hundreds of MB, user-tiered, and downloaded only when the user opens the
+      # Creator and starts a job. The player never needs them.
+      - type: archive
+        url: https://github.com/monteslu/loukai/releases/download/v0.11.0/webgpu-assets-0.11.0.tar.gz
+        sha256: 0000000000000000000000000000000000000000000000000000000000000000 # TODO: publish the archive and fill this in
+        dest: static/webgpu

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "husky": "^9.1.7",
         "jsdom": "^27.0.0",
         "lint-staged": "^16.2.4",
+        "node-addon-api": "^8.9.1",
         "postcss": "^8.5.6",
         "prettier": "^3.6.2",
         "tailwindcss": "^3.4.18",
@@ -8831,6 +8832,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.1.tgz",
+      "integrity": "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/node-api-version": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.1",
         "@google/generative-ai": "^0.24.1",
+        "@kmamal/sdl": "^0.11.13",
         "@soundtouchjs/audio-worklet": "^0.2.1",
         "aubiojs": "^0.2.1",
         "bcryptjs": "^3.0.2",
@@ -1900,6 +1901,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@kmamal/sdl": {
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/@kmamal/sdl/-/sdl-0.11.13.tgz",
+      "integrity": "sha512-9WmxYNtCggi7Ovq1cU7m/s5WXD/+eKQxDMnL3bU8B5vr5GlaLg4xLykDCpcbWKkJJ2i6llTrdL7LiqikwDFz4w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "tar": "^7.4.3"
       }
     },
     "node_modules/@malept/cross-spawn-promise": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7276,9 +7276,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -11121,9 +11121,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.1",
     "@google/generative-ai": "^0.24.1",
+    "@kmamal/sdl": "^0.11.13",
     "@soundtouchjs/audio-worklet": "^0.2.1",
     "aubiojs": "^0.2.1",
     "bcryptjs": "^3.0.2",
@@ -175,7 +176,8 @@
         "--socket=pulseaudio",
         "--filesystem=home",
         "--share=network",
-        "--talk-name=org.freedesktop.Notifications"
+        "--talk-name=org.freedesktop.Notifications",
+        "--device=input"
       ]
     },
     "win": {
@@ -219,7 +221,11 @@
     },
     "dmg": {
       "writeUpdateInfo": false
-    }
+    },
+    "asarUnpack": [
+      "**/node_modules/@kmamal/**"
+    ],
+    "npmRebuild": false
   },
   "lint-staged": {
     "src/**/*.{js,jsx}": [

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "husky": "^9.1.7",
     "jsdom": "^27.0.0",
     "lint-staged": "^16.2.4",
+    "node-addon-api": "^8.9.1",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
     "tailwindcss": "^3.4.18",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "format": "prettier --write \"src/**/*.{js,jsx,json,css,md}\"",
     "format:check": "prettier --check \"src/**/*.{js,jsx,json,css,md}\"",
     "prepare": "husky",
-    "prepublishOnly": "npm run build:all"
+    "prepublishOnly": "npm run build:all",
+    "pack:webgpu": "node scripts/pack-webgpu-assets.js"
   },
   "keywords": [
     "karaoke",

--- a/scripts/pack-webgpu-assets.js
+++ b/scripts/pack-webgpu-assets.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Pack static/webgpu into a release tarball for the Flathub manifest.
+ *
+ * Flathub builds have no network, so `npm run vendor:webgpu` (which downloads
+ * onnxruntime-web, transformers.js and the ffmpeg-core wasm from jsDelivr)
+ * cannot run there. Instead those same files are published as a pinned archive
+ * and consumed as an `archive` source with a sha256.
+ *
+ * Run AFTER `npm run vendor:webgpu`, attach the output to the release, and put
+ * the printed sha256 into flatpak/com.loukai.app.yml.
+ *
+ * Usage: node scripts/pack-webgpu-assets.js
+ */
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const assetsDir = join(root, 'static', 'webgpu');
+const version = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version;
+const out = join(root, `webgpu-assets-${version}.tar.gz`);
+
+if (!existsSync(assetsDir)) {
+  console.error(`✖ ${assetsDir} does not exist. Run: npm run vendor:webgpu`);
+  process.exit(1);
+}
+
+const entries = readdirSync(assetsDir);
+if (entries.length === 0) {
+  console.error('✖ static/webgpu is empty. Run: npm run vendor:webgpu');
+  process.exit(1);
+}
+
+// Deterministic tar: sorted names, no owner/timestamp noise, so the same inputs
+// always produce the same sha256 and the manifest hash stays reproducible.
+execFileSync(
+  'tar',
+  [
+    '--sort=name',
+    '--owner=0',
+    '--group=0',
+    '--numeric-owner',
+    '--mtime=UTC 2020-01-01',
+    '-czf',
+    out,
+    '-C',
+    assetsDir,
+    '.',
+  ],
+  { stdio: 'inherit' }
+);
+
+const bytes = readFileSync(out);
+const sha256 = createHash('sha256').update(bytes).digest('hex');
+const mb = (bytes.length / 1024 / 1024).toFixed(1);
+
+const total = entries.reduce((n, e) => {
+  const p = join(assetsDir, e);
+  return n + (statSync(p).isFile() ? statSync(p).size : 0);
+}, 0);
+
+console.log(`\n✅ ${out}`);
+console.log(`   ${entries.length} files, ${(total / 1024 / 1024).toFixed(1)} MB raw → ${mb} MB packed`);
+console.log(`\n   sha256: ${sha256}\n`);
+console.log('Put that into flatpak/com.loukai.app.yml under the webgpu-assets archive source.');

--- a/src/main/gamepadEngine.js
+++ b/src/main/gamepadEngine.js
@@ -1,0 +1,172 @@
+/**
+ * GamepadEngine - SDL-backed controller input for living-room / SteamOS use.
+ *
+ * Why SDL instead of the renderer's Gamepad API: Chromium only reports
+ * `mapping: "standard"` for a short list of well-known pads, so most third-party
+ * controllers arrive with uninterpretable button indices. SDL ships the community
+ * game-controller mapping database (the same one Steam feeds), so nearly every pad
+ * resolves to the standard layout. SDL also reads evdev directly, so input keeps
+ * working regardless of window focus.
+ *
+ * SPIKE STATUS: enumeration + open + event streaming only. The IPC bridge, the
+ * `navigator.getGamepads()` shim, and the navigation layer are phase 2/3
+ * (see internal-loukai/PLAN-gamepad-sdl.md).
+ */
+
+import { createRequire } from 'node:module';
+import { EventEmitter } from 'node:events';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * node-sdl exposes NAMED buttons/axes; the web Gamepad API uses positional
+ * indices. This table is the bridge between the two. Order matters: it is the
+ * standard-mapping button order, so the array index IS the standard index.
+ */
+export const STANDARD_BUTTON_ORDER = [
+  'a', // 0
+  'b', // 1
+  'x', // 2
+  'y', // 3
+  'leftShoulder', // 4
+  'rightShoulder', // 5
+  null, // 6  - left trigger, synthesized from the axis
+  null, // 7  - right trigger, synthesized from the axis
+  'back', // 8
+  'start', // 9
+  'leftStick', // 10
+  'rightStick', // 11
+  'dpadUp', // 12
+  'dpadDown', // 13
+  'dpadLeft', // 14
+  'dpadRight', // 15
+  'guide', // 16
+];
+
+/**
+ * Trigger axes are not trustworthy across pads. The X360 pad tested during the
+ * spike reports BOTH triggers pinned at ~0.5 forever (a bipolar axis that never
+ * moves), so a naive `value > 0.5` reads as "half pressed" at rest. Until a pad
+ * is observed producing a real 0..1 sweep, treat a trigger as pressed only when
+ * it is clearly past the top of that dead band, and never report a rest value as
+ * a partial press. Nothing in the v1 navigation layer binds triggers.
+ */
+const TRIGGER_PRESS_THRESHOLD = 0.85;
+const TRIGGER_REST_EPSILON = 0.02;
+
+export class GamepadEngine extends EventEmitter {
+  constructor() {
+    super();
+    this.sdl = null;
+    this.available = false;
+    this.controllers = new Map(); // sdl device id -> { device, handle }
+  }
+
+  /**
+   * Load SDL and open every connected controller. Never throws: a machine
+   * without SDL support (or without permission to read input devices) must
+   * degrade to "no gamepads", not a failed app launch.
+   */
+  initialize() {
+    try {
+      this.sdl = require('@kmamal/sdl');
+    } catch (error) {
+      console.warn('🎮 SDL unavailable, gamepad support disabled:', error.message);
+      return false;
+    }
+
+    this.available = true;
+    console.log(
+      `🎮 SDL ${this.sdl.info.version.runtime.major}.${this.sdl.info.version.runtime.minor} ready`
+    );
+
+    for (const device of this.sdl.controller.devices) {
+      this.openDevice(device);
+    }
+
+    this.sdl.controller.on('deviceAdd', (event) => this.openDevice(event.device));
+    this.sdl.controller.on('deviceRemove', (event) => this.closeDevice(event.device));
+
+    return true;
+  }
+
+  openDevice(device) {
+    if (!device || this.controllers.has(device.id)) return;
+    try {
+      const handle = this.sdl.controller.openDevice(device);
+      this.controllers.set(device.id, { device, handle });
+      console.log(`🎮 Controller connected: ${device.name} (${device.type})`);
+      this.emit('connected', this.describe(device));
+    } catch (error) {
+      console.warn(`🎮 Could not open ${device?.name}:`, error.message);
+    }
+  }
+
+  closeDevice(device) {
+    const entry = this.controllers.get(device?.id);
+    if (!entry) return;
+    try {
+      entry.handle.close();
+    } catch {
+      // Already gone - unplugging races the close.
+    }
+    this.controllers.delete(device.id);
+    console.log(`🎮 Controller disconnected: ${device.name}`);
+    this.emit('disconnected', this.describe(device));
+  }
+
+  describe(device) {
+    return { id: device.id, name: device.name, type: device.type, guid: device.guid };
+  }
+
+  /**
+   * Snapshot every open controller in web-Gamepad-API shape, so the renderer
+   * shim can hand these straight to `navigator.getGamepads()` consumers.
+   */
+  getSnapshot() {
+    const pads = [];
+    let index = 0;
+    for (const { device, handle } of this.controllers.values()) {
+      const axes = handle.axes;
+      const buttons = STANDARD_BUTTON_ORDER.map((name, i) => {
+        if (i === 6) return this.triggerButton(axes.leftTrigger);
+        if (i === 7) return this.triggerButton(axes.rightTrigger);
+        const pressed = Boolean(handle.buttons[name]);
+        return { pressed, touched: pressed, value: pressed ? 1 : 0 };
+      });
+
+      pads.push({
+        id: `${device.name} (SDL ${device.type})`,
+        index: index++,
+        connected: true,
+        mapping: 'standard',
+        buttons,
+        axes: [
+          axes.leftStickX ?? 0,
+          axes.leftStickY ?? 0,
+          axes.rightStickX ?? 0,
+          axes.rightStickY ?? 0,
+        ],
+      });
+    }
+    return pads;
+  }
+
+  triggerButton(value) {
+    const v = value ?? 0;
+    // Pads that park a trigger at a fixed rest value (commonly ~0.5) must read as
+    // fully released, not half-pressed - see TRIGGER_PRESS_THRESHOLD.
+    const atRest = Math.abs(v) < TRIGGER_REST_EPSILON || Math.abs(v - 0.5) < TRIGGER_REST_EPSILON;
+    if (atRest) return { pressed: false, touched: false, value: 0 };
+    return { pressed: v > TRIGGER_PRESS_THRESHOLD, touched: true, value: v };
+  }
+
+  shutdown() {
+    for (const { device } of [...this.controllers.values()]) {
+      this.closeDevice(device);
+    }
+    this.controllers.clear();
+  }
+}
+
+export default GamepadEngine;

--- a/src/main/gamepadEngine.js
+++ b/src/main/gamepadEngine.js
@@ -8,9 +8,10 @@
  * resolves to the standard layout. SDL also reads evdev directly, so input keeps
  * working regardless of window focus.
  *
- * SPIKE STATUS: enumeration + open + event streaming only. The IPC bridge, the
- * `navigator.getGamepads()` shim, and the navigation layer are phase 2/3
- * (see internal-loukai/PLAN-gamepad-sdl.md).
+ * Emits `state` (full snapshot, only when something changed), `connected`, and
+ * `disconnected`. `gamepadHandlers` relays those to the renderer, where the
+ * preload shim backs `navigator.getGamepads()` with them. The navigation layer
+ * that consumes the shim is phase 3 (see internal-loukai/PLAN-gamepad-sdl.md).
  */
 
 import { createRequire } from 'node:module';
@@ -54,12 +55,18 @@ export const STANDARD_BUTTON_ORDER = [
 const TRIGGER_PRESS_THRESHOLD = 0.85;
 const TRIGGER_REST_EPSILON = 0.02;
 
+const POLL_INTERVAL_MS = 16; // ~60 Hz
+/** Analog sticks jitter around rest; ignore movement smaller than this. */
+const AXIS_EPSILON = 0.02;
+
 export class GamepadEngine extends EventEmitter {
   constructor() {
     super();
     this.sdl = null;
     this.available = false;
     this.controllers = new Map(); // sdl device id -> { device, handle }
+    this.pollTimer = null;
+    this.lastSnapshot = [];
   }
 
   /**
@@ -161,11 +168,73 @@ export class GamepadEngine extends EventEmitter {
     return { pressed: v > TRIGGER_PRESS_THRESHOLD, touched: true, value: v };
   }
 
+  /**
+   * Poll at 60 Hz but emit only when something actually changed. Nav cares about
+   * button edges and coarse stick direction, so a raw 60 Hz IPC stream would be
+   * pure waste: an idle controller costs zero messages, and even active input
+   * only sends on real transitions.
+   */
+  start() {
+    if (!this.available || this.pollTimer) return;
+    this.pollTimer = setInterval(() => this.poll(), POLL_INTERVAL_MS);
+    // Don't hold the event loop open on quit.
+    this.pollTimer.unref?.();
+  }
+
+  stop() {
+    if (!this.pollTimer) return;
+    clearInterval(this.pollTimer);
+    this.pollTimer = null;
+  }
+
+  poll() {
+    if (this.controllers.size === 0) {
+      if (this.lastSnapshot.length > 0) {
+        this.lastSnapshot = [];
+        this.emit('state', []);
+      }
+      return;
+    }
+
+    const snapshot = this.getSnapshot();
+    if (this.hasChanged(snapshot, this.lastSnapshot)) {
+      this.lastSnapshot = snapshot;
+      this.emit('state', snapshot);
+    }
+  }
+
+  /**
+   * True when anything a consumer would notice differs. Axes use a deadzone-ish
+   * epsilon so analog stick jitter (which never rests at exactly 0) doesn't
+   * masquerade as input and defeat the whole point of emit-on-change.
+   */
+  hasChanged(next, prev) {
+    if (next.length !== prev.length) return true;
+
+    for (let i = 0; i < next.length; i++) {
+      const a = next[i];
+      const b = prev[i];
+      if (!b || a.id !== b.id) return true;
+
+      for (let j = 0; j < a.buttons.length; j++) {
+        if (a.buttons[j].pressed !== b.buttons[j]?.pressed) return true;
+      }
+
+      for (let j = 0; j < a.axes.length; j++) {
+        if (Math.abs(a.axes[j] - (b.axes[j] ?? 0)) > AXIS_EPSILON) return true;
+      }
+    }
+
+    return false;
+  }
+
   shutdown() {
+    this.stop();
     for (const { device } of [...this.controllers.values()]) {
       this.closeDevice(device);
     }
     this.controllers.clear();
+    this.lastSnapshot = [];
   }
 }
 

--- a/src/main/gamepadEngine.test.js
+++ b/src/main/gamepadEngine.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GamepadEngine, STANDARD_BUTTON_ORDER } from './gamepadEngine.js';
+
+/** Minimal stand-in for an open node-sdl controller handle. */
+function fakeHandle(overrides = {}) {
+  return {
+    buttons: { a: false, b: false, dpadUp: false, dpadLeft: false, ...overrides.buttons },
+    axes: {
+      leftStickX: 0,
+      leftStickY: 0,
+      rightStickX: 0,
+      rightStickY: 0,
+      leftTrigger: 0.5, // the observed rest value on a real X360 pad
+      rightTrigger: 0.5,
+      ...overrides.axes,
+    },
+    close() {},
+  };
+}
+
+function engineWithPad(handleOverrides) {
+  const engine = new GamepadEngine();
+  engine.available = true;
+  engine.controllers.set(1, {
+    device: { id: 1, name: 'Test Pad', type: 'xbox360', guid: 'abc' },
+    handle: fakeHandle(handleOverrides),
+  });
+  return engine;
+}
+
+describe('GamepadEngine', () => {
+  describe('getSnapshot', () => {
+    let engine;
+    beforeEach(() => {
+      engine = engineWithPad();
+    });
+
+    it('reports the standard mapping so getGamepads() consumers work', () => {
+      const [pad] = engine.getSnapshot();
+      expect(pad.mapping).toBe('standard');
+      expect(pad.connected).toBe(true);
+      expect(pad.buttons).toHaveLength(STANDARD_BUTTON_ORDER.length);
+      expect(pad.axes).toHaveLength(4);
+    });
+
+    it('maps SDL named buttons onto standard indices', () => {
+      const pressed = engineWithPad({ buttons: { a: true, dpadUp: true } });
+      const [pad] = pressed.getSnapshot();
+      expect(pad.buttons[0].pressed).toBe(true); // a
+      expect(pad.buttons[12].pressed).toBe(true); // dpadUp
+      expect(pad.buttons[1].pressed).toBe(false); // b
+    });
+
+    it('treats a trigger parked at its rest value as released', () => {
+      // Real X360 pads pin both triggers at ~0.5 forever; a naive threshold
+      // would report a permanent half-press.
+      const [pad] = engine.getSnapshot();
+      expect(pad.buttons[6].pressed).toBe(false);
+      expect(pad.buttons[6].value).toBe(0);
+      expect(pad.buttons[7].pressed).toBe(false);
+    });
+
+    it('reports a fully pulled trigger as pressed', () => {
+      const pulled = engineWithPad({ axes: { leftTrigger: 1 } });
+      const [pad] = pulled.getSnapshot();
+      expect(pad.buttons[6].pressed).toBe(true);
+    });
+  });
+
+  describe('hasChanged', () => {
+    it('ignores analog jitter below the epsilon', () => {
+      const engine = new GamepadEngine();
+      const a = [{ id: 'p', buttons: [{ pressed: false }], axes: [0, 0, 0, 0] }];
+      const b = [{ id: 'p', buttons: [{ pressed: false }], axes: [0.005, 0, 0, 0] }];
+      expect(engine.hasChanged(b, a)).toBe(false);
+    });
+
+    it('detects real stick movement', () => {
+      const engine = new GamepadEngine();
+      const a = [{ id: 'p', buttons: [{ pressed: false }], axes: [0, 0, 0, 0] }];
+      const b = [{ id: 'p', buttons: [{ pressed: false }], axes: [0.9, 0, 0, 0] }];
+      expect(engine.hasChanged(b, a)).toBe(true);
+    });
+
+    it('detects button edges', () => {
+      const engine = new GamepadEngine();
+      const a = [{ id: 'p', buttons: [{ pressed: false }], axes: [0, 0, 0, 0] }];
+      const b = [{ id: 'p', buttons: [{ pressed: true }], axes: [0, 0, 0, 0] }];
+      expect(engine.hasChanged(b, a)).toBe(true);
+    });
+
+    it('detects connect and disconnect', () => {
+      const engine = new GamepadEngine();
+      const pad = { id: 'p', buttons: [{ pressed: false }], axes: [0, 0, 0, 0] };
+      expect(engine.hasChanged([pad], [])).toBe(true);
+      expect(engine.hasChanged([], [pad])).toBe(true);
+    });
+  });
+
+  describe('poll', () => {
+    it('emits only when state actually changes', () => {
+      const engine = engineWithPad();
+      const seen = [];
+      engine.on('state', (pads) => seen.push(pads));
+
+      engine.poll(); // first poll establishes the baseline and emits
+      engine.poll(); // identical state must stay silent
+      engine.poll();
+      expect(seen).toHaveLength(1);
+
+      engine.controllers.get(1).handle.buttons.a = true;
+      engine.poll();
+      expect(seen).toHaveLength(2);
+      expect(seen[1][0].buttons[0].pressed).toBe(true);
+    });
+
+    it('emits an empty state when the last controller goes away', () => {
+      const engine = engineWithPad();
+      const seen = [];
+      engine.poll();
+      engine.on('state', (pads) => seen.push(pads));
+
+      engine.controllers.clear();
+      engine.poll();
+      expect(seen).toEqual([[]]);
+
+      engine.poll(); // already empty, so no repeat
+      expect(seen).toHaveLength(1);
+    });
+  });
+
+  describe('availability', () => {
+    it('reports no pads and never throws when SDL is unavailable', () => {
+      // A machine without SDL (or without permission to read input devices) must
+      // degrade to "no gamepads" rather than breaking app launch.
+      const engine = new GamepadEngine();
+      expect(engine.available).toBe(false);
+      expect(engine.getSnapshot()).toEqual([]);
+      expect(() => engine.start()).not.toThrow(); // start() is a no-op unless available
+      expect(engine.pollTimer).toBe(null);
+      expect(() => engine.shutdown()).not.toThrow();
+    });
+  });
+});

--- a/src/main/gamepadShim.test.js
+++ b/src/main/gamepadShim.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { GAMEPAD_CHANNELS } from '../shared/ipcContracts.js';
+
+// The shim lives inline in preload.js (Electron loads the preload raw and its
+// module resolution won't reach a sibling file). Extract and evaluate the real
+// shipped source so these tests can't drift from what actually runs.
+const preloadSource = readFileSync(path.join(process.cwd(), 'src/main/preload.js'), 'utf8');
+const shimStart = preloadSource.indexOf('function installGamepadShim');
+const shimEnd = preloadSource.indexOf('window.kaiGamepad =');
+if (shimStart === -1 || shimEnd === -1) {
+  throw new Error('installGamepadShim not found in preload.js - did the shim move?');
+}
+const installGamepadShim = new Function(
+  `${preloadSource.slice(shimStart, shimEnd)}\nreturn installGamepadShim;`
+)();
+
+function makeHarness() {
+  const handlers = new Map();
+  const nativePads = [{ id: 'chromium pad' }];
+  const target = { getGamepads: () => nativePads };
+
+  const state = installGamepadShim({
+    on: (channel, handler) => handlers.set(channel, handler),
+    invoke: vi.fn().mockResolvedValue([]),
+    channels: GAMEPAD_CHANNELS,
+    target,
+  });
+
+  return {
+    target,
+    state,
+    nativePads,
+    emit: (channel, payload) => handlers.get(channel)?.({}, payload),
+  };
+}
+
+const sdlPad = () => ({
+  id: 'SDL pad',
+  index: 0,
+  connected: true,
+  mapping: 'standard',
+  buttons: [{ pressed: true }],
+  axes: [0, 0, 0, 0],
+});
+
+describe('gamepadShim', () => {
+  beforeEach(() => {
+    vi.stubGlobal('performance', { now: () => 123 });
+    vi.stubGlobal('window', { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      'Event',
+      class {
+        constructor(type) {
+          this.type = type;
+        }
+      }
+    );
+  });
+
+  it('falls back to Chromium when SDL reports no pads', () => {
+    // The shim can only ADD controller support, never remove it: a box with no
+    // SDL, no controller, or no evdev permission must behave exactly as before.
+    const h = makeHarness();
+    expect(h.target.getGamepads()).toBe(h.nativePads);
+  });
+
+  it('serves SDL pads once main sends state', () => {
+    const h = makeHarness();
+    h.emit(GAMEPAD_CHANNELS.STATE_CHANGE, [sdlPad()]);
+
+    const pads = h.target.getGamepads();
+    expect(pads).toHaveLength(1);
+    expect(pads[0].id).toBe('SDL pad');
+    expect(pads[0].mapping).toBe('standard');
+    expect(pads[0].timestamp).toBe(123);
+  });
+
+  it('reverts to the native implementation on disconnect', () => {
+    const h = makeHarness();
+    h.emit(GAMEPAD_CHANNELS.STATE_CHANGE, [sdlPad()]);
+    expect(h.target.getGamepads()[0].id).toBe('SDL pad');
+
+    h.emit(GAMEPAD_CHANNELS.DISCONNECTED, { id: 1 });
+    expect(h.target.getGamepads()).toBe(h.nativePads);
+  });
+
+  it('dispatches standard connect/disconnect events', () => {
+    const h = makeHarness();
+    h.emit(GAMEPAD_CHANNELS.CONNECTED, { id: 1, name: 'Test Pad' });
+    expect(window.dispatchEvent).toHaveBeenCalled();
+    expect(window.dispatchEvent.mock.calls[0][0].type).toBe('gamepadconnected');
+
+    h.emit(GAMEPAD_CHANNELS.DISCONNECTED, { id: 1, name: 'Test Pad' });
+    expect(window.dispatchEvent.mock.calls[1][0].type).toBe('gamepaddisconnected');
+  });
+
+  it('survives an environment with no navigator', () => {
+    // The test env (jsdom) supplies a global navigator, so pass an explicit null
+    // target to simulate a context that has none.
+    expect(
+      installGamepadShim({
+        on: () => {},
+        invoke: () => Promise.resolve([]),
+        channels: GAMEPAD_CHANNELS,
+        target: null,
+      })
+    ).toBe(null);
+  });
+
+  it('keeps the preload channel literals in sync with the contract', () => {
+    // preload.js is loaded raw (CommonJS) and cannot import the ESM contracts
+    // module, so it duplicates the channel names. Catch drift here.
+    const preload = readFileSync(path.join(process.cwd(), 'src/main/preload.js'), 'utf8');
+    for (const channel of Object.values(GAMEPAD_CHANNELS)) {
+      expect(preload).toContain(`'${channel}'`);
+    }
+  });
+});

--- a/src/main/handlers/gamepadHandlers.js
+++ b/src/main/handlers/gamepadHandlers.js
@@ -1,0 +1,29 @@
+/**
+ * Gamepad IPC Handlers
+ * Relays SDL controller state from the main process to the renderer, where the
+ * preload shim backs `navigator.getGamepads()` with it.
+ */
+
+import { ipcMain } from 'electron';
+import { GAMEPAD_CHANNELS } from '../../shared/ipcContracts.js';
+
+/**
+ * Register gamepad IPC handlers
+ * @param {Object} mainApp - Main application instance
+ */
+export function registerGamepadHandlers(mainApp) {
+  // The renderer primes its shim with this on load, so a controller that was
+  // already connected at launch works without waiting for the first input.
+  ipcMain.handle(GAMEPAD_CHANNELS.GET_SNAPSHOT, () => {
+    return mainApp.gamepadEngine?.getSnapshot() ?? [];
+  });
+
+  const engine = mainApp.gamepadEngine;
+  if (!engine) return;
+
+  engine.on('state', (pads) => mainApp.sendToRenderer(GAMEPAD_CHANNELS.STATE_CHANGE, pads));
+  engine.on('connected', (device) => mainApp.sendToRenderer(GAMEPAD_CHANNELS.CONNECTED, device));
+  engine.on('disconnected', (device) =>
+    mainApp.sendToRenderer(GAMEPAD_CHANNELS.DISCONNECTED, device)
+  );
+}

--- a/src/main/handlers/index.js
+++ b/src/main/handlers/index.js
@@ -35,6 +35,8 @@ import { registerRendererHandlers } from './rendererHandlers.js';
 log('✓ rendererHandlers');
 import { registerAppHandlers } from './appHandlers.js';
 log('✓ appHandlers');
+import { registerGamepadHandlers } from './gamepadHandlers.js';
+log('✓ gamepadHandlers');
 import { registerAutotuneHandlers } from './autotuneHandlers.js';
 log('✓ autotuneHandlers');
 import { registerCreatorHandlers } from './creatorHandlers.js';
@@ -70,6 +72,7 @@ export function registerAllHandlers(mainApp) {
     registerFileHandlers(mainApp);
     registerRendererHandlers(mainApp);
     registerAppHandlers(mainApp);
+    registerGamepadHandlers(mainApp);
 
     // Creator handlers
     registerCreatorHandlers(mainApp);

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, dialog, Menu } from 'electron';
+import { app, BrowserWindow, ipcMain, dialog, Menu, session } from 'electron';
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
@@ -202,6 +202,12 @@ class KaiPlayerApp {
 
     await app.whenReady();
 
+    // Spellcheck is unused (lyric lines are short) and disabling it is correct
+    // hygiene. NOTE: this does NOT stop Chromium's dictionary download from
+    // redirector.gvt1.com at startup, which is still unresolved. See
+    // internal-loukai/NETWORK-AUDIT.md.
+    session.defaultSession.setSpellCheckerEnabled(false);
+
     log('🚀 App starting...', {
       isPackaged: app.isPackaged,
       __dirname,
@@ -265,6 +271,8 @@ class KaiPlayerApp {
         nodeIntegration: true,
         contextIsolation: false,
         preload: path.join(__dirname, 'preload.js'),
+        // Nothing here is prose worth checking (lyric lines are short).
+        spellcheck: false,
       },
       title: 'Loukai',
     };
@@ -412,6 +420,7 @@ class KaiPlayerApp {
       webPreferences: {
         nodeIntegration: true,
         contextIsolation: false,
+        spellcheck: false, // see the main window: avoids the gvt1.com dictionary fetch
       },
       title: 'Canvas Window',
       show: false,

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -226,9 +226,11 @@ class KaiPlayerApp {
     // http://localhost (required for the in-browser WebGPU Creator: dynamic
     // import + cross-origin isolation + WASM threads only work on an http origin,
     // not file://). IPC handlers are set up first so the preload has them.
+    // The gamepad engine must exist BEFORE setupIPC: its handlers subscribe to
+    // the engine's events at registration time.
+    this.initializeGamepadEngine();
     this.setupIPC();
     this.initializeAudioEngine();
-    this.initializeGamepadEngine();
     await this.initializeWebServer();
     this.createMainWindow();
     this.createApplicationMenu();
@@ -832,7 +834,9 @@ class KaiPlayerApp {
   initializeGamepadEngine() {
     try {
       this.gamepadEngine = new GamepadEngine();
-      this.gamepadEngine.initialize();
+      if (this.gamepadEngine.initialize()) {
+        this.gamepadEngine.start();
+      }
     } catch (error) {
       // Gamepad support is a nicety; never let it break app launch.
       console.warn('Gamepad engine unavailable:', error.message);

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -26,6 +26,7 @@ import {
   loadAndSync,
   getBroadcastChannel,
 } from '../shared/services/settingsService.js';
+import { GamepadEngine } from './gamepadEngine.js';
 import { log } from './logger.js';
 
 log('📦 About to import registerAllHandlers...');
@@ -227,6 +228,7 @@ class KaiPlayerApp {
     // not file://). IPC handlers are set up first so the preload has them.
     this.setupIPC();
     this.initializeAudioEngine();
+    this.initializeGamepadEngine();
     await this.initializeWebServer();
     this.createMainWindow();
     this.createApplicationMenu();
@@ -825,6 +827,17 @@ class KaiPlayerApp {
 
     const menu = Menu.buildFromTemplate(template);
     Menu.setApplicationMenu(menu);
+  }
+
+  initializeGamepadEngine() {
+    try {
+      this.gamepadEngine = new GamepadEngine();
+      this.gamepadEngine.initialize();
+    } catch (error) {
+      // Gamepad support is a nicety; never let it break app launch.
+      console.warn('Gamepad engine unavailable:', error.message);
+      this.gamepadEngine = null;
+    }
   }
 
   initializeAudioEngine() {
@@ -2439,6 +2452,10 @@ class KaiPlayerApp {
     // Save settings immediately before exiting
     if (this.settings) {
       await this.settings.saveNow();
+    }
+
+    if (this.gamepadEngine) {
+      this.gamepadEngine.shutdown();
     }
 
     // Save state before exiting

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -1,5 +1,15 @@
 const { ipcRenderer } = require('electron');
 
+// Mirrors GAMEPAD_CHANNELS in shared/ipcContracts.js. Duplicated as literals
+// because the preload is loaded raw (CommonJS) and cannot import the ESM
+// contracts module; a gamepadShim test asserts the two stay in sync.
+const GAMEPAD_CHANNELS = {
+  GET_SNAPSHOT: 'gamepad:getSnapshot',
+  STATE_CHANGE: 'gamepad:state',
+  CONNECTED: 'gamepad:connected',
+  DISCONNECTED: 'gamepad:disconnected',
+};
+
 const api = {
   app: {
     getVersion: () => ipcRenderer.invoke('app:getVersion'),
@@ -304,3 +314,103 @@ const api = {
 
 // Since contextIsolation is disabled, directly assign to window
 window.kaiAPI = api;
+
+/**
+ * navigator.getGamepads() shim, installed from the preload.
+ *
+ * Chromium only reports `mapping: "standard"` for a short list of well-known
+ * pads, so most controllers are unusable through the stock Gamepad API. The main
+ * process reads them through SDL (whose mapping DB covers nearly everything) and
+ * streams normalized state here; this replaces `navigator.getGamepads` so any
+ * standard Gamepad API consumer transparently gets SDL-quality data.
+ *
+ * Deliberately keeps the standard API shape rather than inventing a bespoke
+ * event API, so gamepad-aware code stays portable to the web admin (which has no
+ * SDL and falls through to Chromium's implementation).
+ *
+ * .cjs: the Electron preload is loaded raw (not bundled) and uses require(), so
+ * this cannot be ESM, and the package is "type": "module" so the extension is
+ * what makes Node/vitest treat it as CommonJS.
+ */
+
+/**
+ * @param {object} deps
+ * @param {(channel: string, handler: Function) => void} deps.on - subscribe to main->renderer events
+ * @param {(channel: string) => Promise<any>} deps.invoke - request/response to main
+ * @param {object} deps.channels - GAMEPAD_CHANNELS
+ * @param {object} [deps.target] - object hosting getGamepads (defaults to navigator)
+ */
+function installGamepadShim({ on, invoke, channels, target }) {
+  // `target === undefined` means "use the ambient navigator"; an explicit null
+  // means "there is no navigator here", which must not fall through to a global.
+  const nav = target === undefined ? (typeof navigator !== 'undefined' ? navigator : null) : target;
+  if (!nav) return null;
+
+  const nativeGetGamepads = nav.getGamepads?.bind(nav);
+  let pads = [];
+
+  const state = {
+    /** True once main has told us about at least one SDL pad. */
+    get active() {
+      return pads.length > 0;
+    },
+  };
+
+  nav.getGamepads = () => {
+    // Fall back to Chromium whenever SDL has nothing. A machine with no SDL, no
+    // controller, or no permission to read input devices must be no worse off
+    // than before the shim existed.
+    if (pads.length === 0) {
+      return nativeGetGamepads ? nativeGetGamepads() : [];
+    }
+    return pads;
+  };
+
+  on(channels.STATE_CHANGE, (_event, next) => {
+    const timestamp = performance.now();
+    pads = (next || []).map((pad) => ({ ...pad, timestamp }));
+  });
+
+  on(channels.CONNECTED, (_event, device) => {
+    // Standard-API consumers listen for these rather than polling for arrival.
+    dispatchGamepadEvent('gamepadconnected', device);
+  });
+
+  on(channels.DISCONNECTED, (_event, device) => {
+    pads = [];
+    dispatchGamepadEvent('gamepaddisconnected', device);
+  });
+
+  // Prime from the current state so a controller connected before the window
+  // opened is usable immediately, not only after its first input.
+  invoke(channels.GET_SNAPSHOT)
+    .then((snapshot) => {
+      if (snapshot?.length && pads.length === 0) {
+        const timestamp = performance.now();
+        pads = snapshot.map((pad) => ({ ...pad, timestamp }));
+      }
+    })
+    .catch(() => {
+      // No gamepad support available; the native fallback stays in place.
+    });
+
+  return state;
+}
+
+function dispatchGamepadEvent(type, device) {
+  if (typeof window === 'undefined') return;
+  // GamepadEvent's constructor demands a real Gamepad instance, which we can't
+  // synthesize, so use a plain Event and hang the detail off it.
+  const event = new Event(type);
+  event.gamepadInfo = device;
+  window.dispatchEvent(event);
+}
+
+// Back navigator.getGamepads() with SDL so controllers that Chromium can't map
+// still work. Falls through to Chromium when SDL has no pads, so this can only
+// add support, never remove it.
+window.kaiGamepad = installGamepadShim({
+  on: (channel, handler) => ipcRenderer.on(channel, handler),
+  invoke: (channel) => ipcRenderer.invoke(channel),
+  channels: GAMEPAD_CHANNELS,
+});

--- a/src/renderer/components/App.jsx
+++ b/src/renderer/components/App.jsx
@@ -263,11 +263,22 @@ export function App({ bridge }) {
                   <QueueTab bridge={bridge} />
                 </div>
 
-                {/* Canvas Area (Right 70%) */}
+                {/* Canvas Area (Right 70%). The wrapper is a real focusable
+                    button so the gamepad and keyboard can reach the canvas and
+                    toggle fullscreen, the most useful action in a living room. */}
                 <div className="flex-1 flex flex-col p-0 m-0 min-w-0">
                   <div
                     className="flex-1 flex items-center justify-center bg-white dark:bg-gray-900 cursor-pointer"
                     onClick={toggleCanvasFullscreen}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        toggleCanvasFullscreen();
+                      }
+                    }}
+                    role="button"
+                    tabIndex={0}
+                    aria-label="Toggle fullscreen video"
                   >
                     <canvas
                       id="karaokeCanvas"

--- a/src/renderer/components/App.jsx
+++ b/src/renderer/components/App.jsx
@@ -14,7 +14,8 @@ import { QueueTab } from './QueueTab.jsx';
 import { SongInfoBarWrapper } from './SongInfoBarWrapper.jsx';
 import { TransportControlsWrapper } from './TransportControlsWrapper.jsx';
 import { StatusBar } from './StatusBar.jsx';
-import { TabNavigation } from './TabNavigation.jsx';
+import { TabNavigation, tabStepper } from './TabNavigation.jsx';
+import { GamepadNav } from '../js/gamepadNav.js';
 import { ServerTab } from './ServerTab.jsx';
 import { VisualizationSettings } from '../../shared/components/VisualizationSettings.jsx';
 import { PAQuickMix } from '../../shared/components/PAQuickMix.jsx';
@@ -29,6 +30,14 @@ export function App({ bridge }) {
   // secure context) can command it to create on the host GPU. Works regardless of the
   // open tab — must not depend on the Create tab being mounted.
   useHostCreateListener();
+
+  // Gamepad navigation (phase 3): lets the app be driven from a couch on
+  // SteamOS/Deck/HTPC boxes. Idle unless a controller is actually connected.
+  useEffect(() => {
+    const nav = new GamepadNav({ onTabStep: (delta) => tabStepper.step?.(delta) });
+    nav.start();
+    return () => nav.stop();
+  }, []);
 
   // Update QR code on players when server URL or settings change
   useEffect(() => {

--- a/src/renderer/components/ServerTab.jsx
+++ b/src/renderer/components/ServerTab.jsx
@@ -233,6 +233,7 @@ export function ServerTab({ bridge }) {
                   {serverUrl || 'Not running'}
                 </span>
                 <button
+                  data-gamepad-skip="external"
                   className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-white rounded transition-colors"
                   onClick={handleOpenServer}
                   disabled={!isServerRunning}
@@ -432,6 +433,7 @@ export function ServerTab({ bridge }) {
             </div>
             <div className="flex gap-2">
               <button
+                data-gamepad-skip="external"
                 className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded transition-colors flex-1"
                 onClick={handleOpenAdmin}
               >

--- a/src/renderer/components/TabNavigation.jsx
+++ b/src/renderer/components/TabNavigation.jsx
@@ -4,7 +4,13 @@
  * Manages tab switching between different app sections
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+
+/**
+ * Lets non-React code (the gamepad nav layer) step tabs without lifting this
+ * component's state. Set while TabNavigation is mounted, cleared on unmount.
+ */
+export const tabStepper = { step: null };
 
 export function TabNavigation({ requestsCount = 0 }) {
   const [activeTab, setActiveTab] = useState('player');
@@ -48,6 +54,18 @@ export function TabNavigation({ requestsCount = 0 }) {
       }, 10);
     }
   };
+
+  // Shoulder buttons step through tabs (gamepad nav, phase 3).
+  useEffect(() => {
+    tabStepper.step = (delta) => {
+      const i = tabs.findIndex((t) => t.id === activeTab);
+      const next = tabs[(i + delta + tabs.length) % tabs.length];
+      if (next) handleTabClick(next.id);
+    };
+    return () => {
+      tabStepper.step = null;
+    };
+  });
 
   return (
     <div className="flex border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">

--- a/src/renderer/js/gamepadNav.js
+++ b/src/renderer/js/gamepadNav.js
@@ -79,6 +79,34 @@ const GAMEPAD_SKIP = '[data-gamepad-skip]';
  */
 const OVERLAY = '.fixed.inset-0';
 
+/** Inside the window, so off-canvas panels are not navigable. */
+function isOnScreen(r) {
+  return r.bottom > 0 && r.right > 0 && r.top < window.innerHeight && r.left < window.innerWidth;
+}
+
+/**
+ * True when a scrolling/clipping ancestor has collapsed to nothing around this
+ * element. A collapsed drawer keeps its children in the DOM at full size (the
+ * sidebar animates to `w-0` rather than unmounting), so the child's own box
+ * still looks perfectly visible: only the ancestor reveals that it is hidden.
+ */
+function isClippedByAncestor(el, r) {
+  let n = el.parentElement;
+  while (n && n !== document.body) {
+    const cs = getComputedStyle(n);
+    if (cs.overflow !== 'visible' || cs.overflowX !== 'visible' || cs.overflowY !== 'visible') {
+      const nr = n.getBoundingClientRect();
+      if (nr.width <= 1 || nr.height <= 1) return true;
+      // Fully outside the clipping box means it is scrolled or slid out of view.
+      if (r.right <= nr.left || r.left >= nr.right || r.bottom <= nr.top || r.top >= nr.bottom) {
+        return true;
+      }
+    }
+    n = n.parentElement;
+  }
+  return false;
+}
+
 /** Range sliders are adjusted by the d-pad rather than activated by A. */
 function isSlider(el) {
   return el?.tagName === 'INPUT' && (el.type || '').toLowerCase() === 'range';
@@ -302,7 +330,8 @@ export class GamepadNav {
       if (isTextInput(el)) return false;
       if (el.offsetParent === null && getComputedStyle(el).position !== 'fixed') return false;
       const r = el.getBoundingClientRect();
-      return r.width > 0 && r.height > 0;
+      if (r.width <= 0 || r.height <= 0) return false;
+      return isOnScreen(r) && !isClippedByAncestor(el, r);
     });
   }
 

--- a/src/renderer/js/gamepadNav.js
+++ b/src/renderer/js/gamepadNav.js
@@ -1,0 +1,325 @@
+/**
+ * Gamepad navigation: drive the app from the couch.
+ *
+ * Reads the SDL-backed `navigator.getGamepads()` (see the shim in preload.js) and
+ * turns controller input into focus movement and activation. The whole UI is
+ * already built from real <button> elements, so activation is just a click on
+ * whatever has focus, and the browser's own semantics do the rest.
+ *
+ * Why focus is moved directly instead of synthesizing Tab keypresses: browsers
+ * deliberately ignore synthetic Tab for focus traversal, so a fake keydown would
+ * do nothing. Directional movement is geometric (nearest focusable in the pressed
+ * direction), which matches what a person expects from a d-pad far better than
+ * DOM order does.
+ *
+ * Bindings (v1 is deliberately small):
+ *   D-pad / left stick  move focus
+ *   A                   activate the focused control
+ *   B                   Escape (close dialogs, leave fullscreen)
+ *   Start               play/pause
+ *   LB / RB             previous / next tab
+ */
+
+const REPEAT_DELAY_MS = 400;
+const REPEAT_RATE_MS = 120;
+const STICK_THRESHOLD = 0.6;
+const POLL_INTERVAL_MS = 50;
+
+// Standard Gamepad API indices.
+const BTN = {
+  A: 0,
+  B: 1,
+  LB: 4,
+  RB: 5,
+  START: 9,
+  UP: 12,
+  DOWN: 13,
+  LEFT: 14,
+  RIGHT: 15,
+};
+
+/** Input types that capture typing; everything else is a control the d-pad drives. */
+const TEXT_INPUT_TYPES = new Set([
+  'text',
+  'search',
+  'url',
+  'tel',
+  'email',
+  'password',
+  'number',
+  'date',
+  'datetime-local',
+  'month',
+  'week',
+  'time',
+]);
+
+const FOCUSABLE = [
+  'button:not([disabled])',
+  '[href]',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+export class GamepadNav {
+  constructor({ onTabStep, onTogglePlayback } = {}) {
+    this.onTabStep = onTabStep;
+    this.onTogglePlayback = onTogglePlayback;
+    this.timer = null;
+    this.prev = new Map(); // button index -> { pressed, nextRepeatAt }
+    this.enabled = true;
+  }
+
+  start() {
+    if (this.timer) return;
+    this.timer = setInterval(() => this.poll(), POLL_INTERVAL_MS);
+  }
+
+  stop() {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+    this.prev.clear();
+  }
+
+  /**
+   * Text entry must win over navigation, or the gamepad would fight the editor
+   * (see issue #96, where keyboard handling in the editor was already fragile).
+   * B still passes through so a controller can always back out of a text field.
+   */
+  isTextEntryFocused() {
+    const el = document.activeElement;
+    if (!el) return false;
+    if (el.isContentEditable) return true;
+    if (el.tagName === 'TEXTAREA') return true;
+    if (el.tagName !== 'INPUT') return false;
+    // Only inputs that actually swallow typing count. Checkboxes, sliders and
+    // buttons are <input> too, and suppressing navigation on those would strand
+    // the focus ring on the first checkbox it landed on.
+    return TEXT_INPUT_TYPES.has((el.type || 'text').toLowerCase());
+  }
+
+  poll() {
+    if (!this.enabled) return;
+    const pad = (navigator.getGamepads?.() || []).find(Boolean);
+    if (!pad) {
+      this.prev.clear();
+      return;
+    }
+
+    const now = performance.now();
+    const textEntry = this.isTextEntryFocused();
+
+    for (const [name, index] of Object.entries(BTN)) {
+      const pressed = Boolean(pad.buttons[index]?.pressed);
+      const repeats = name === 'UP' || name === 'DOWN' || name === 'LEFT' || name === 'RIGHT';
+      if (this.edge(index, pressed, now, repeats)) {
+        // While typing, only B (back out) is honored.
+        if (textEntry && name !== 'B') continue;
+        this.dispatch(name);
+      }
+    }
+
+    // Left stick doubles as the d-pad so either works.
+    this.stickEdge(pad, now, textEntry);
+  }
+
+  /**
+   * True on a fresh press, and again on each auto-repeat tick while held.
+   * Repeat only applies to directions: nobody wants a held A button to fire
+   * activation dozens of times.
+   */
+  edge(index, pressed, now, repeats) {
+    const state = this.prev.get(index) || { pressed: false, nextRepeatAt: 0 };
+    let fired = false;
+
+    if (pressed && !state.pressed) {
+      fired = true;
+      state.nextRepeatAt = now + REPEAT_DELAY_MS;
+    } else if (pressed && repeats && now >= state.nextRepeatAt) {
+      fired = true;
+      state.nextRepeatAt = now + REPEAT_RATE_MS;
+    }
+
+    state.pressed = pressed;
+    this.prev.set(index, state);
+    return fired;
+  }
+
+  stickEdge(pad, now, textEntry) {
+    const [x = 0, y = 0] = pad.axes;
+    const dir =
+      y < -STICK_THRESHOLD
+        ? 'UP'
+        : y > STICK_THRESHOLD
+          ? 'DOWN'
+          : x < -STICK_THRESHOLD
+            ? 'LEFT'
+            : x > STICK_THRESHOLD
+              ? 'RIGHT'
+              : null;
+
+    // Key the stick off a synthetic index so it repeats like the d-pad without
+    // colliding with real button state.
+    const STICK_KEY = -1;
+    const state = this.prev.get(STICK_KEY) || { dir: null, nextRepeatAt: 0 };
+    let fired = false;
+
+    if (dir && dir !== state.dir) {
+      fired = true;
+      state.nextRepeatAt = now + REPEAT_DELAY_MS;
+    } else if (dir && now >= state.nextRepeatAt) {
+      fired = true;
+      state.nextRepeatAt = now + REPEAT_RATE_MS;
+    }
+
+    state.dir = dir;
+    this.prev.set(STICK_KEY, state);
+
+    if (fired && dir && !textEntry) this.dispatch(dir);
+  }
+
+  dispatch(name) {
+    switch (name) {
+      case 'UP':
+      case 'DOWN':
+      case 'LEFT':
+      case 'RIGHT':
+        this.moveFocus(name);
+        break;
+      case 'A':
+        this.activate();
+        break;
+      case 'B':
+        this.back();
+        break;
+      case 'START':
+        this.togglePlayback();
+        break;
+      case 'LB':
+        this.onTabStep?.(-1);
+        break;
+      case 'RB':
+        this.onTabStep?.(1);
+        break;
+      default:
+        break;
+    }
+  }
+
+  /** Everything focusable and actually on screen right now. */
+  visibleFocusables() {
+    return [...document.querySelectorAll(FOCUSABLE)].filter((el) => {
+      if (el.offsetParent === null && getComputedStyle(el).position !== 'fixed') return false;
+      const r = el.getBoundingClientRect();
+      return r.width > 0 && r.height > 0;
+    });
+  }
+
+  /**
+   * Geometric focus movement: pick the nearest candidate in the pressed
+   * direction, preferring things that line up with the current element over
+   * things that are merely close.
+   */
+  moveFocus(direction) {
+    const candidates = this.visibleFocusables();
+    if (candidates.length === 0) return;
+
+    const active = document.activeElement;
+    const current = active && candidates.includes(active) ? active.getBoundingClientRect() : null;
+
+    // Nothing focused yet: start at the top-left-most control.
+    if (!current) {
+      const first = candidates.slice().sort((a, b) => {
+        const ra = a.getBoundingClientRect();
+        const rb = b.getBoundingClientRect();
+        return ra.top - rb.top || ra.left - rb.left;
+      })[0];
+      this.focus(first);
+      return;
+    }
+
+    const cx = current.left + current.width / 2;
+    const cy = current.top + current.height / 2;
+
+    let best = null;
+    let bestScore = Infinity;
+
+    for (const el of candidates) {
+      if (el === active) continue;
+      const r = el.getBoundingClientRect();
+      const ex = r.left + r.width / 2;
+      const ey = r.top + r.height / 2;
+      const dx = ex - cx;
+      const dy = ey - cy;
+
+      const inDirection =
+        (direction === 'UP' && dy < -1) ||
+        (direction === 'DOWN' && dy > 1) ||
+        (direction === 'LEFT' && dx < -1) ||
+        (direction === 'RIGHT' && dx > 1);
+      if (!inDirection) continue;
+
+      // Distance along the travel axis, plus a heavy penalty for drifting off
+      // axis, so "down" lands on the row below rather than something diagonal.
+      const along = direction === 'UP' || direction === 'DOWN' ? Math.abs(dy) : Math.abs(dx);
+      const off = direction === 'UP' || direction === 'DOWN' ? Math.abs(dx) : Math.abs(dy);
+      const score = along + off * 3;
+
+      if (score < bestScore) {
+        bestScore = score;
+        best = el;
+      }
+    }
+
+    if (best) this.focus(best);
+  }
+
+  focus(el) {
+    if (!el) return;
+    el.focus({ preventScroll: true });
+    // Not every focusable implements scrollIntoView (and jsdom does not at all).
+    el.scrollIntoView?.({ block: 'nearest', inline: 'nearest', behavior: 'smooth' });
+    // Marks the focus ring as gamepad-driven so it can be styled boldly for a
+    // 10-foot view without affecting mouse users.
+    el.classList.add('gamepad-focus');
+    if (this.lastFocused && this.lastFocused !== el) {
+      this.lastFocused.classList.remove('gamepad-focus');
+    }
+    this.lastFocused = el;
+  }
+
+  activate() {
+    const el = document.activeElement;
+    if (!el || el === document.body) return;
+    el.click();
+  }
+
+  /**
+   * Click the real transport button rather than reaching into player internals,
+   * so play/pause stays correct however the app wires playback.
+   */
+  togglePlayback() {
+    if (this.onTogglePlayback) {
+      this.onTogglePlayback();
+      return;
+    }
+    document.querySelector('[data-gamepad-action="play-pause"]')?.click();
+  }
+
+  back() {
+    const el = document.activeElement;
+    // Leaving a text field is the most common "back" while typing.
+    if (this.isTextEntryFocused() && el?.blur) {
+      el.blur();
+      return;
+    }
+    // Reuse whatever Escape already does (close dialogs, exit fullscreen).
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+  }
+}
+
+export default GamepadNav;

--- a/src/renderer/js/gamepadNav.js
+++ b/src/renderer/js/gamepadNav.js
@@ -71,6 +71,19 @@ const FOCUSABLE = [
  */
 const GAMEPAD_SKIP = '[data-gamepad-skip]';
 
+/**
+ * True for controls that capture typing. Checkboxes, sliders and buttons are
+ * <input> too, so the TYPE matters, not the tag: treating those as text would
+ * strand the focus ring on the first checkbox it reached.
+ */
+function isTextInput(el) {
+  if (!el) return false;
+  if (el.isContentEditable) return true;
+  if (el.tagName === 'TEXTAREA') return true;
+  if (el.tagName !== 'INPUT') return false;
+  return TEXT_INPUT_TYPES.has((el.type || 'text').toLowerCase());
+}
+
 export class GamepadNav {
   constructor({ onTabStep, onTogglePlayback } = {}) {
     this.onTabStep = onTabStep;
@@ -98,15 +111,7 @@ export class GamepadNav {
    * B still passes through so a controller can always back out of a text field.
    */
   isTextEntryFocused() {
-    const el = document.activeElement;
-    if (!el) return false;
-    if (el.isContentEditable) return true;
-    if (el.tagName === 'TEXTAREA') return true;
-    if (el.tagName !== 'INPUT') return false;
-    // Only inputs that actually swallow typing count. Checkboxes, sliders and
-    // buttons are <input> too, and suppressing navigation on those would strand
-    // the focus ring on the first checkbox it landed on.
-    return TEXT_INPUT_TYPES.has((el.type || 'text').toLowerCase());
+    return isTextInput(document.activeElement);
   }
 
   poll() {
@@ -221,6 +226,10 @@ export class GamepadNav {
   visibleFocusables() {
     return [...document.querySelectorAll(FOCUSABLE)].filter((el) => {
       if (el.closest(GAMEPAD_SKIP)) return false;
+      // A gamepad cannot type, so landing on a text field is a dead end: the ring
+      // parks there and the only escape is B. Skip them until there is a way to
+      // enter text with a controller (platform OSK or our own).
+      if (isTextInput(el)) return false;
       if (el.offsetParent === null && getComputedStyle(el).position !== 'fixed') return false;
       const r = el.getBoundingClientRect();
       return r.width > 0 && r.height > 0;

--- a/src/renderer/js/gamepadNav.js
+++ b/src/renderer/js/gamepadNav.js
@@ -24,6 +24,8 @@ const REPEAT_DELAY_MS = 400;
 const REPEAT_RATE_MS = 120;
 const STICK_THRESHOLD = 0.6;
 const POLL_INTERVAL_MS = 50;
+/** Sliders move several steps per press; one 0.5 dB step per tap is unusable. */
+const SLIDER_STEP_MULTIPLIER = 4;
 
 // Standard Gamepad API indices.
 const BTN = {
@@ -76,6 +78,11 @@ const GAMEPAD_SKIP = '[data-gamepad-skip]';
  * <dialog> elements, so they are matched by that shape and then size-checked.
  */
 const OVERLAY = '.fixed.inset-0';
+
+/** Range sliders are adjusted by the d-pad rather than activated by A. */
+function isSlider(el) {
+  return el?.tagName === 'INPUT' && (el.type || '').toLowerCase() === 'range';
+}
 
 /**
  * True for controls that capture typing. Checkboxes, sliders and buttons are
@@ -207,10 +214,18 @@ export class GamepadNav {
 
   dispatch(name) {
     switch (name) {
-      case 'UP':
-      case 'DOWN':
       case 'LEFT':
       case 'RIGHT':
+        // On a slider, left/right is the volume/gain gesture people expect. Up
+        // and down still move focus away, so a slider is never a trap.
+        if (isSlider(document.activeElement)) {
+          this.adjustSlider(document.activeElement, name === 'RIGHT' ? 1 : -1);
+          break;
+        }
+        this.moveFocus(name);
+        break;
+      case 'UP':
+      case 'DOWN':
         this.moveFocus(name);
         break;
       case 'A':
@@ -367,7 +382,37 @@ export class GamepadNav {
   activate() {
     const el = document.activeElement;
     if (!el || el === document.body) return;
+    // A click does not change a range input's value, so A would be a no-op on a
+    // slider. Nudge it up instead, which is at least a visible response.
+    if (isSlider(el)) {
+      this.adjustSlider(el, 1);
+      return;
+    }
     el.click();
+  }
+
+  /**
+   * Move a range input by one step and tell the app about it. React controls
+   * these inputs, so setting `.value` alone updates the DOM but never the state
+   * behind it: the change must be dispatched through the native value setter for
+   * React's synthetic `onChange` to fire.
+   */
+  adjustSlider(el, direction) {
+    const step = Number(el.step) || 1;
+    const min = el.min === '' ? 0 : Number(el.min);
+    const max = el.max === '' ? 100 : Number(el.max);
+    const next = Math.min(
+      max,
+      Math.max(min, Number(el.value) + step * direction * SLIDER_STEP_MULTIPLIER)
+    );
+    if (next === Number(el.value)) return;
+
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
+    if (setter) setter.call(el, String(next));
+    else el.value = String(next);
+
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
   }
 
   /**

--- a/src/renderer/js/gamepadNav.js
+++ b/src/renderer/js/gamepadNav.js
@@ -72,6 +72,12 @@ const FOCUSABLE = [
 const GAMEPAD_SKIP = '[data-gamepad-skip]';
 
 /**
+ * Modal scrims. The app's dialogs are full-screen `fixed inset-0` overlays, not
+ * <dialog> elements, so they are matched by that shape and then size-checked.
+ */
+const OVERLAY = '.fixed.inset-0';
+
+/**
  * True for controls that capture typing. Checkboxes, sliders and buttons are
  * <input> too, so the TYPE matters, not the tag: treating those as text would
  * strand the focus ring on the first checkbox it reached.
@@ -121,6 +127,11 @@ export class GamepadNav {
       this.prev.clear();
       return;
     }
+
+    // A modal that just opened leaves focus behind the scrim. Pull the ring into
+    // it right away rather than making the user press a direction first to
+    // discover the dialog is even reachable.
+    this.syncOverlayFocus();
 
     const now = performance.now();
     const textEntry = this.isTextEntryFocused();
@@ -222,9 +233,53 @@ export class GamepadNav {
     }
   }
 
-  /** Everything focusable and actually on screen right now. */
+  /**
+   * Move the ring into a newly opened modal, and restore sane focus when it
+   * closes. Without this the ring sits on whatever was focused behind the scrim.
+   */
+  syncOverlayFocus() {
+    const overlay = this.topOverlay();
+    if (overlay === this.lastOverlay) return;
+    this.lastOverlay = overlay;
+    if (!overlay) return;
+
+    const inside = this.visibleFocusables();
+    // Prefer the explicit close affordance so B and A agree on the obvious action.
+    const close = inside.find((el) => el.hasAttribute('data-gamepad-close'));
+    this.focus(close || inside[0]);
+  }
+
+  /**
+   * The topmost open modal overlay, if any. Modals here are full-screen
+   * `fixed inset-0` scrims (the song info dialog, the shared confirm dialog)
+   * rather than <dialog> elements, so they are detected by shape.
+   */
+  topOverlay() {
+    const overlays = [...document.querySelectorAll(OVERLAY)].filter((el) => {
+      const cs = getComputedStyle(el);
+      if (cs.display === 'none' || cs.visibility === 'hidden') return false;
+      const r = el.getBoundingClientRect();
+      // A scrim covers essentially the whole window; a toast or dropdown does not.
+      return r.width >= window.innerWidth * 0.9 && r.height >= window.innerHeight * 0.9;
+    });
+    if (overlays.length === 0) return null;
+    // Highest stacking order wins when several are open.
+    return overlays.reduce((top, el) =>
+      Number(getComputedStyle(el).zIndex || 0) >= Number(getComputedStyle(top).zIndex || 0)
+        ? el
+        : top
+    );
+  }
+
+  /**
+   * Everything focusable and actually on screen right now. When a modal is open,
+   * navigation is trapped inside it: otherwise the ring wanders the library
+   * behind the scrim while the dialog sits there uncloseable.
+   */
   visibleFocusables() {
-    return [...document.querySelectorAll(FOCUSABLE)].filter((el) => {
+    const overlay = this.topOverlay();
+    const root = overlay || document;
+    return [...root.querySelectorAll(FOCUSABLE)].filter((el) => {
       if (el.closest(GAMEPAD_SKIP)) return false;
       // A gamepad cannot type, so landing on a text field is a dead end: the ring
       // parks there and the only escape is B. Skip them until there is a way to
@@ -339,6 +394,16 @@ export class GamepadNav {
     // would be a trap with no way back to the UI.
     if (document.fullscreenElement) {
       document.exitFullscreen?.();
+      return;
+    }
+    // Close an open modal. These dialogs close by clicking their scrim or their
+    // X button and do not listen for Escape, so dispatching a key here would do
+    // nothing and leave the dialog stuck open.
+    const overlay = this.topOverlay();
+    if (overlay) {
+      const closer = overlay.querySelector('[data-gamepad-close]');
+      if (closer) closer.click();
+      else overlay.click(); // the scrim's own click handler dismisses it
       return;
     }
     // Otherwise let whatever listens for Escape handle it (dialogs, overlays).

--- a/src/renderer/js/gamepadNav.js
+++ b/src/renderer/js/gamepadNav.js
@@ -63,6 +63,14 @@ const FOCUSABLE = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(',');
 
+/**
+ * Controls the gamepad must never land on. Anything that hands control to an
+ * external browser is a dead end from the couch: the new window is not driven by
+ * the controller and there is no way back. Mouse and keyboard users still get
+ * them; they are only removed from gamepad traversal.
+ */
+const GAMEPAD_SKIP = '[data-gamepad-skip]';
+
 export class GamepadNav {
   constructor({ onTabStep, onTogglePlayback } = {}) {
     this.onTabStep = onTabStep;
@@ -212,6 +220,7 @@ export class GamepadNav {
   /** Everything focusable and actually on screen right now. */
   visibleFocusables() {
     return [...document.querySelectorAll(FOCUSABLE)].filter((el) => {
+      if (el.closest(GAMEPAD_SKIP)) return false;
       if (el.offsetParent === null && getComputedStyle(el).position !== 'fixed') return false;
       const r = el.getBoundingClientRect();
       return r.width > 0 && r.height > 0;
@@ -316,7 +325,14 @@ export class GamepadNav {
       el.blur();
       return;
     }
-    // Reuse whatever Escape already does (close dialogs, exit fullscreen).
+    // Exit fullscreen directly rather than relying on a keydown listener. A
+    // gamepad can put the canvas fullscreen, and if nothing handles Escape that
+    // would be a trap with no way back to the UI.
+    if (document.fullscreenElement) {
+      document.exitFullscreen?.();
+      return;
+    }
+    // Otherwise let whatever listens for Escape handle it (dialogs, overlays).
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
   }

--- a/src/renderer/js/gamepadNav.js
+++ b/src/renderer/js/gamepadNav.js
@@ -96,15 +96,75 @@ function isClippedByAncestor(el, r) {
     const cs = getComputedStyle(n);
     if (cs.overflow !== 'visible' || cs.overflowX !== 'visible' || cs.overflowY !== 'visible') {
       const nr = n.getBoundingClientRect();
+      // The container itself has collapsed to nothing: genuinely hidden.
       if (nr.width <= 1 || nr.height <= 1) return true;
-      // Fully outside the clipping box means it is scrolled or slid out of view.
-      if (r.right <= nr.left || r.left >= nr.right || r.bottom <= nr.top || r.top >= nr.bottom) {
-        return true;
-      }
+      // The container is off-screen (a drawer slid away), taking its contents
+      // with it. Scrolling cannot bring these back; only reopening can.
+      if (!isOnScreen(nr)) return true;
+      // Otherwise the element may simply be scrolled out of view. That is
+      // reachable, so long as SOME ancestor between it and this clipping box can
+      // scroll it back in. Checking only `n` was wrong: a scrollable panel is
+      // often wrapped in an overflow-hidden layout div, and that outer div
+      // rejected everything its scrolling child could legitimately reveal.
+      const outside =
+        r.right <= nr.left || r.left >= nr.right || r.bottom <= nr.top || r.top >= nr.bottom;
+      if (outside && !hasScrollableAncestorUpTo(el, n)) return true;
     }
     n = n.parentElement;
   }
   return false;
+}
+
+/**
+ * On screen already, or scrollable into view. An element below the fold is a
+ * legitimate target (focus() scrolls to it); one belonging to a panel that has
+ * been slid off-screen is not, and that case is caught by isClippedByAncestor.
+ */
+function isReachableByScrolling(el, r) {
+  if (isOnScreen(r)) return true;
+  // Horizontally off-window is never scrolled into view by this app's layouts;
+  // that is the signature of a drawer slid away rather than content below.
+  if (r.right <= 0 || r.left >= window.innerWidth) return false;
+  return true;
+}
+
+/**
+ * Is there a scrollable container between `el` and `stop` (inclusive) that could
+ * bring `el` into view? A scrolling list nested inside an overflow-hidden layout
+ * wrapper is the normal case, so the whole chain must be considered.
+ */
+function hasScrollableAncestorUpTo(el, stop) {
+  let n = el.parentElement;
+  while (n) {
+    if (isScrollable(n)) return true;
+    if (n === stop) break;
+    n = n.parentElement;
+  }
+  return false;
+}
+
+/** A container the user (or we) can scroll to reveal more content. */
+function isScrollable(n) {
+  const cs = getComputedStyle(n);
+  const scrollableY =
+    (cs.overflowY === 'auto' || cs.overflowY === 'scroll') && n.scrollHeight > n.clientHeight + 1;
+  const scrollableX =
+    (cs.overflowX === 'auto' || cs.overflowX === 'scroll') && n.scrollWidth > n.clientWidth + 1;
+  return scrollableY || scrollableX;
+}
+
+/**
+ * What actually wears the focus ring. Checkboxes and radios are tiny and usually
+ * sit inside a <label> next to the text explaining them, so ring the label: it
+ * shows what is selected instead of a lone 16px box.
+ */
+function ringTargetFor(el) {
+  const type = (el.type || '').toLowerCase();
+  if (el.tagName === 'INPUT' && (type === 'checkbox' || type === 'radio')) {
+    const label = el.closest('label');
+    if (label) return label;
+  }
+  return el;
 }
 
 /** Range sliders are adjusted by the d-pad rather than activated by A. */
@@ -144,6 +204,9 @@ export class GamepadNav {
     clearInterval(this.timer);
     this.timer = null;
     this.prev.clear();
+    // The ring is a plain class now, not tied to :focus, so it would linger.
+    this.lastRingTarget?.classList.remove('gamepad-focus');
+    this.lastRingTarget = null;
   }
 
   /**
@@ -331,7 +394,10 @@ export class GamepadNav {
       if (el.offsetParent === null && getComputedStyle(el).position !== 'fixed') return false;
       const r = el.getBoundingClientRect();
       if (r.width <= 0 || r.height <= 0) return false;
-      return isOnScreen(r) && !isClippedByAncestor(el, r);
+      // Below the fold is fine: focus() scrolls it into view. Only reject things
+      // no amount of scrolling can reveal (see isClippedByAncestor).
+      if (!isReachableByScrolling(el, r)) return false;
+      return !isClippedByAncestor(el, r);
     });
   }
 
@@ -397,14 +463,22 @@ export class GamepadNav {
   focus(el) {
     if (!el) return;
     el.focus({ preventScroll: true });
+    // Keep the ring near the middle rather than letting it ride the edge of the
+    // viewport. `nearest` scrolls the bare minimum, so the selection creeps to
+    // the bottom of the screen and the next item is already out of sight.
     // Not every focusable implements scrollIntoView (and jsdom does not at all).
-    el.scrollIntoView?.({ block: 'nearest', inline: 'nearest', behavior: 'smooth' });
+    el.scrollIntoView?.({ block: 'center', inline: 'nearest', behavior: 'smooth' });
     // Marks the focus ring as gamepad-driven so it can be styled boldly for a
     // 10-foot view without affecting mouse users.
-    el.classList.add('gamepad-focus');
-    if (this.lastFocused && this.lastFocused !== el) {
-      this.lastFocused.classList.remove('gamepad-focus');
+    // Ring the wrapping label when there is one, so a 16px checkbox highlights
+    // together with the text that says what it does. A bare checkbox alone gives
+    // no clue what is selected from across a room.
+    const ringTarget = ringTargetFor(el);
+    ringTarget.classList.add('gamepad-focus');
+    if (this.lastRingTarget && this.lastRingTarget !== ringTarget) {
+      this.lastRingTarget.classList.remove('gamepad-focus');
     }
+    this.lastRingTarget = ringTarget;
     this.lastFocused = el;
   }
 

--- a/src/renderer/js/gamepadNav.test.js
+++ b/src/renderer/js/gamepadNav.test.js
@@ -326,6 +326,109 @@ describe('GamepadNav', () => {
     });
   });
 
+  describe('hidden drawers', () => {
+    /**
+     * The sidebar collapses by sliding off-screen (margin-left: -320px), keeping
+     * its full width and its children's boxes intact. Per-element size checks
+     * therefore see it as perfectly visible, and the ring walked into a drawer
+     * the user could not see, which reads as the app losing focus.
+     */
+    function offScreenDrawer() {
+      document.body.innerHTML = '';
+      const drawer = document.createElement('div');
+      drawer.slideTo = (left) => {
+        drawer.getBoundingClientRect = () => ({
+          top: 0,
+          left,
+          width: 320,
+          height: 600,
+          right: left + 320,
+          bottom: 600,
+        });
+      };
+      drawer.slideTo(-320);
+      Object.defineProperty(drawer, 'offsetParent', { get: () => document.body });
+      const inner = document.createElement('button');
+      inner.textContent = 'hidden control';
+      inner.getBoundingClientRect = () => ({
+        top: 10,
+        left: -300,
+        width: 279,
+        height: 24,
+        right: -21,
+        bottom: 34,
+      });
+      Object.defineProperty(inner, 'offsetParent', { get: () => drawer });
+      drawer.appendChild(inner);
+      document.body.appendChild(drawer);
+
+      const onScreen = document.createElement('button');
+      onScreen.textContent = 'visible';
+      onScreen.getBoundingClientRect = () => ({
+        top: 10,
+        left: 100,
+        width: 100,
+        height: 30,
+        right: 200,
+        bottom: 40,
+      });
+      Object.defineProperty(onScreen, 'offsetParent', { get: () => document.body });
+      document.body.appendChild(onScreen);
+      return { inner, onScreen, drawer };
+    }
+
+    it('ignores controls in a drawer slid off-screen', () => {
+      const { inner, onScreen } = offScreenDrawer();
+      const focusables = nav.visibleFocusables();
+      expect(focusables).not.toContain(inner);
+      expect(focusables).toContain(onScreen);
+    });
+
+    it('still navigates the drawer once it slides back on-screen', () => {
+      const { inner, drawer } = offScreenDrawer();
+      // The real sidebar slides the whole panel back, children with it.
+      drawer.slideTo(0);
+      inner.getBoundingClientRect = () => ({
+        top: 10,
+        left: 20,
+        width: 279,
+        height: 24,
+        right: 299,
+        bottom: 34,
+      });
+      expect(nav.visibleFocusables()).toContain(inner);
+    });
+
+    it('ignores controls clipped by a zero-width ancestor', () => {
+      document.body.innerHTML = '';
+      const collapsed = document.createElement('div');
+      collapsed.style.overflow = 'hidden';
+      collapsed.getBoundingClientRect = () => ({
+        top: 0,
+        left: 0,
+        width: 0,
+        height: 600,
+        right: 0,
+        bottom: 600,
+      });
+      Object.defineProperty(collapsed, 'offsetParent', { get: () => document.body });
+      const inner = document.createElement('button');
+      inner.getBoundingClientRect = () => ({
+        top: 10,
+        left: 0,
+        width: 279,
+        height: 24,
+        right: 279,
+        bottom: 34,
+      });
+      Object.defineProperty(inner, 'offsetParent', { get: () => collapsed });
+      collapsed.appendChild(inner);
+      document.body.appendChild(collapsed);
+
+      expect(nav.visibleFocusables()).not.toContain(inner);
+    });
+  });
+
   describe('sliders', () => {
     function slider(props = {}) {
       document.body.innerHTML = '';

--- a/src/renderer/js/gamepadNav.test.js
+++ b/src/renderer/js/gamepadNav.test.js
@@ -326,6 +326,100 @@ describe('GamepadNav', () => {
     });
   });
 
+  describe('sliders', () => {
+    function slider(props = {}) {
+      document.body.innerHTML = '';
+      const el = document.createElement('input');
+      el.type = 'range';
+      el.min = props.min ?? '-60';
+      el.max = props.max ?? '12';
+      el.step = props.step ?? '0.5';
+      el.value = props.value ?? '0';
+      el.getBoundingClientRect = () => ({
+        top: 0,
+        left: 0,
+        width: 200,
+        height: 20,
+        right: 200,
+        bottom: 20,
+      });
+      Object.defineProperty(el, 'offsetParent', { get: () => document.body });
+      document.body.appendChild(el);
+      el.focus();
+      return el;
+    }
+
+    it('RIGHT raises the value instead of moving focus off the slider', () => {
+      // Clicking a range input does nothing, so without this a slider is a
+      // control the gamepad can reach but never operate.
+      const el = slider({ value: '0' });
+      setPad(pad({ buttons: [BTN.RIGHT] }));
+      nav.poll();
+
+      expect(Number(el.value)).toBeGreaterThan(0);
+      expect(document.activeElement).toBe(el);
+    });
+
+    it('LEFT lowers the value', () => {
+      const el = slider({ value: '0' });
+      setPad(pad({ buttons: [BTN.LEFT] }));
+      nav.poll();
+
+      expect(Number(el.value)).toBeLessThan(0);
+    });
+
+    it('fires input and change so React state updates', () => {
+      // React-controlled inputs ignore a bare .value assignment; the event has to
+      // go through the native setter or the UI silently reverts.
+      const el = slider({ value: '0' });
+      const onInput = vi.fn();
+      const onChange = vi.fn();
+      el.addEventListener('input', onInput);
+      el.addEventListener('change', onChange);
+
+      nav.adjustSlider(el, 1);
+
+      expect(onInput).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    it('clamps at the ends', () => {
+      const atMax = slider({ value: '12' });
+      nav.adjustSlider(atMax, 1);
+      expect(Number(atMax.value)).toBe(12);
+
+      const atMin = slider({ value: '-60' });
+      nav.adjustSlider(atMin, -1);
+      expect(Number(atMin.value)).toBe(-60);
+    });
+
+    it('UP and DOWN still leave the slider, so it is never a trap', () => {
+      const el = slider();
+      const other = document.createElement('button');
+      other.getBoundingClientRect = () => ({
+        top: 100,
+        left: 0,
+        width: 100,
+        height: 30,
+        right: 100,
+        bottom: 130,
+      });
+      Object.defineProperty(other, 'offsetParent', { get: () => document.body });
+      document.body.appendChild(other);
+      el.focus();
+
+      nav.moveFocus('DOWN');
+      expect(document.activeElement).toBe(other);
+    });
+
+    it('A nudges the slider rather than doing nothing', () => {
+      const el = slider({ value: '0' });
+      setPad(pad({ buttons: [BTN.A] }));
+      nav.poll();
+      expect(Number(el.value)).toBeGreaterThan(0);
+    });
+  });
+
   describe('modals', () => {
     function openModal() {
       document.body.innerHTML = '';

--- a/src/renderer/js/gamepadNav.test.js
+++ b/src/renderer/js/gamepadNav.test.js
@@ -176,6 +176,44 @@ describe('GamepadNav', () => {
     });
   });
 
+  describe('external-window controls', () => {
+    it('never lands on controls that open an external browser', () => {
+      // A browser window is not driven by the controller, so landing there from
+      // the couch is a dead end with no way back.
+      const [start, external, safe] = layout([
+        { top: 0, left: 0 },
+        { top: 50, left: 0 },
+        { top: 100, left: 0 },
+      ]);
+      external.setAttribute('data-gamepad-skip', 'external');
+      start.focus();
+
+      nav.moveFocus('DOWN');
+      expect(document.activeElement).toBe(safe);
+      expect(document.activeElement).not.toBe(external);
+    });
+
+    it('skips anything inside a skipped container', () => {
+      document.body.innerHTML = '';
+      const wrapper = document.createElement('div');
+      wrapper.setAttribute('data-gamepad-skip', 'external');
+      const inner = document.createElement('button');
+      inner.getBoundingClientRect = () => ({
+        top: 50,
+        left: 0,
+        width: 100,
+        height: 30,
+        right: 100,
+        bottom: 80,
+      });
+      Object.defineProperty(inner, 'offsetParent', { get: () => document.body });
+      wrapper.appendChild(inner);
+      document.body.appendChild(wrapper);
+
+      expect(nav.visibleFocusables()).not.toContain(inner);
+    });
+  });
+
   describe('activation', () => {
     it('A clicks the focused control', () => {
       const [button] = layout([{ top: 0, left: 0 }]);
@@ -259,6 +297,47 @@ describe('GamepadNav', () => {
       performance.now.mockReturnValue(1000 + 500); // past REPEAT_DELAY_MS
       nav.poll();
       expect(moveFocus).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('fullscreen', () => {
+    it('B exits fullscreen instead of relying on an Escape listener', () => {
+      // A gamepad can put the canvas fullscreen; with no Escape handler mounted
+      // that would strand the user with no way back to the UI.
+      const exitFullscreen = vi.fn();
+      Object.defineProperty(document, 'fullscreenElement', {
+        value: document.createElement('canvas'),
+        configurable: true,
+      });
+      document.exitFullscreen = exitFullscreen;
+
+      nav.back();
+
+      expect(exitFullscreen).toHaveBeenCalled();
+      Object.defineProperty(document, 'fullscreenElement', {
+        value: null,
+        configurable: true,
+      });
+    });
+
+    it('reaches a focusable canvas wrapper', () => {
+      // The canvas area is a role=button wrapper so the gamepad can toggle
+      // fullscreen, the most useful action in a living room.
+      const [start, canvasArea] = layout([
+        { top: 0, left: 0 },
+        { top: 100, left: 0, tag: 'div' },
+      ]);
+      canvasArea.setAttribute('role', 'button');
+      canvasArea.setAttribute('tabindex', '0');
+      const onClick = vi.fn();
+      canvasArea.addEventListener('click', onClick);
+      start.focus();
+
+      nav.moveFocus('DOWN');
+      expect(document.activeElement).toBe(canvasArea);
+
+      nav.activate();
+      expect(onClick).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/renderer/js/gamepadNav.test.js
+++ b/src/renderer/js/gamepadNav.test.js
@@ -193,6 +193,32 @@ describe('GamepadNav', () => {
       expect(document.activeElement).not.toBe(external);
     });
 
+    it('never lands on a text field, since a gamepad cannot type', () => {
+      const [start, textField, safe] = layout([
+        { top: 0, left: 0 },
+        { top: 50, left: 0, tag: 'input' },
+        { top: 100, left: 0 },
+      ]);
+      textField.type = 'text';
+      start.focus();
+
+      nav.moveFocus('DOWN');
+      expect(document.activeElement).toBe(safe);
+      expect(document.activeElement).not.toBe(textField);
+    });
+
+    it('still lands on checkboxes and sliders', () => {
+      const [start, checkbox] = layout([
+        { top: 0, left: 0 },
+        { top: 50, left: 0, tag: 'input' },
+      ]);
+      checkbox.type = 'checkbox';
+      start.focus();
+
+      nav.moveFocus('DOWN');
+      expect(document.activeElement).toBe(checkbox);
+    });
+
     it('skips anything inside a skipped container', () => {
       document.body.innerHTML = '';
       const wrapper = document.createElement('div');

--- a/src/renderer/js/gamepadNav.test.js
+++ b/src/renderer/js/gamepadNav.test.js
@@ -1,0 +1,271 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GamepadNav } from './gamepadNav.js';
+
+/** Build a standard-shaped pad with the named buttons held down. */
+function pad({ buttons = [], axes = [0, 0, 0, 0] } = {}) {
+  const list = Array.from({ length: 17 }, (_, i) => ({ pressed: buttons.includes(i) }));
+  return { id: 'test pad', mapping: 'standard', buttons: list, axes };
+}
+
+const BTN = { A: 0, B: 1, LB: 4, RB: 5, START: 9, UP: 12, DOWN: 13, LEFT: 14, RIGHT: 15 };
+
+/** Place buttons at known screen positions so geometric focus is testable. */
+function layout(positions) {
+  document.body.innerHTML = '';
+  return positions.map(({ top, left, width = 100, height = 30, tag = 'button' }, i) => {
+    const el = document.createElement(tag);
+    el.textContent = `el${i}`;
+    el.getBoundingClientRect = () => ({
+      top,
+      left,
+      width,
+      height,
+      right: left + width,
+      bottom: top + height,
+    });
+    // jsdom reports no layout, so make the visibility filter pass.
+    Object.defineProperty(el, 'offsetParent', { get: () => document.body });
+    document.body.appendChild(el);
+    return el;
+  });
+}
+
+describe('GamepadNav', () => {
+  let nav;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    nav = new GamepadNav();
+    vi.spyOn(performance, 'now').mockReturnValue(1000);
+  });
+
+  function setPad(p) {
+    navigator.getGamepads = () => [p];
+  }
+
+  describe('text entry suppression', () => {
+    it('ignores navigation while a text field has focus', () => {
+      // Guards against reintroducing editor keyboard bugs (issue #96).
+      const [button, input] = layout([
+        { top: 0, left: 0 },
+        { top: 100, left: 0, tag: 'input' },
+      ]);
+      input.type = 'text';
+      input.focus();
+      const moveFocus = vi.spyOn(nav, 'moveFocus');
+      const activate = vi.spyOn(nav, 'activate');
+
+      setPad(pad({ buttons: [BTN.DOWN, BTN.A] }));
+      nav.poll();
+
+      expect(moveFocus).not.toHaveBeenCalled();
+      expect(activate).not.toHaveBeenCalled();
+      expect(document.activeElement).toBe(input);
+      expect(button).toBeTruthy();
+    });
+
+    it('still lets B back out of a text field', () => {
+      const [input] = layout([{ top: 0, left: 0, tag: 'input' }]);
+      input.type = 'text';
+      input.focus();
+      expect(document.activeElement).toBe(input);
+
+      setPad(pad({ buttons: [BTN.B] }));
+      nav.poll();
+
+      expect(document.activeElement).not.toBe(input);
+    });
+
+    it('still navigates when a checkbox or slider has focus', () => {
+      // Checkboxes and range sliders are <input> but capture no typing. Treating
+      // them as text entry stranded the focus ring on the first one it reached.
+      const [checkbox, slider, button] = layout([
+        { top: 0, left: 0, tag: 'input' },
+        { top: 50, left: 0, tag: 'input' },
+        { top: 100, left: 0 },
+      ]);
+      checkbox.type = 'checkbox';
+      slider.type = 'range';
+
+      checkbox.focus();
+      expect(nav.isTextEntryFocused()).toBe(false);
+      nav.moveFocus('DOWN');
+      expect(document.activeElement).toBe(slider);
+
+      nav.moveFocus('DOWN');
+      expect(document.activeElement).toBe(button);
+    });
+
+    it('treats real text inputs as typing', () => {
+      const [input] = layout([{ top: 0, left: 0, tag: 'input' }]);
+      input.type = 'text';
+      input.focus();
+      expect(nav.isTextEntryFocused()).toBe(true);
+    });
+
+    it('ignores stick movement while typing', () => {
+      const [input] = layout([{ top: 0, left: 0, tag: 'input' }]);
+      input.type = 'text';
+      input.focus();
+      const moveFocus = vi.spyOn(nav, 'moveFocus');
+
+      setPad(pad({ axes: [0, 1, 0, 0] })); // stick fully down
+      nav.poll();
+
+      expect(moveFocus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('directional focus', () => {
+    it('moves to the element below on DOWN', () => {
+      const [top, bottom] = layout([
+        { top: 0, left: 0 },
+        { top: 100, left: 0 },
+      ]);
+      top.focus();
+
+      nav.moveFocus('DOWN');
+      expect(document.activeElement).toBe(bottom);
+    });
+
+    it('prefers the aligned element over a closer diagonal one', () => {
+      // "Down" should land on the row directly below, not drift sideways.
+      const [start, diagonal, aligned] = layout([
+        { top: 0, left: 0 },
+        { top: 40, left: 500 },
+        { top: 100, left: 0 },
+      ]);
+      start.focus();
+
+      nav.moveFocus('DOWN');
+      expect(document.activeElement).toBe(aligned);
+      expect(document.activeElement).not.toBe(diagonal);
+    });
+
+    it('does not move when nothing lies in that direction', () => {
+      const [only] = layout([{ top: 100, left: 0 }]);
+      only.focus();
+
+      nav.moveFocus('UP');
+      expect(document.activeElement).toBe(only);
+    });
+
+    it('focuses the top-left control when nothing is focused yet', () => {
+      const [lower, upper] = layout([
+        { top: 200, left: 0 },
+        { top: 10, left: 0 },
+      ]);
+      document.body.focus();
+
+      nav.moveFocus('DOWN');
+      expect(document.activeElement).toBe(upper);
+      expect(document.activeElement).not.toBe(lower);
+    });
+
+    it('skips disabled controls', () => {
+      const [start, disabled, enabled] = layout([
+        { top: 0, left: 0 },
+        { top: 50, left: 0 },
+        { top: 100, left: 0 },
+      ]);
+      disabled.setAttribute('disabled', '');
+      start.focus();
+
+      nav.moveFocus('DOWN');
+      expect(document.activeElement).toBe(enabled);
+    });
+  });
+
+  describe('activation', () => {
+    it('A clicks the focused control', () => {
+      const [button] = layout([{ top: 0, left: 0 }]);
+      const onClick = vi.fn();
+      button.addEventListener('click', onClick);
+      button.focus();
+
+      setPad(pad({ buttons: [BTN.A] }));
+      nav.poll();
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('Start clicks the tagged transport button', () => {
+      const [button] = layout([{ top: 0, left: 0 }]);
+      button.setAttribute('data-gamepad-action', 'play-pause');
+      const onClick = vi.fn();
+      button.addEventListener('click', onClick);
+
+      setPad(pad({ buttons: [BTN.START] }));
+      nav.poll();
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('shoulder buttons step tabs', () => {
+      const onTabStep = vi.fn();
+      const tabNav = new GamepadNav({ onTabStep });
+
+      setPad(pad({ buttons: [BTN.RB] }));
+      tabNav.poll();
+      expect(onTabStep).toHaveBeenCalledWith(1);
+
+      setPad(pad({ buttons: [BTN.LB] }));
+      tabNav.poll();
+      expect(onTabStep).toHaveBeenCalledWith(-1);
+    });
+  });
+
+  describe('edge detection and repeat', () => {
+    it('fires once per press, not once per poll', () => {
+      const [button] = layout([{ top: 0, left: 0 }]);
+      const onClick = vi.fn();
+      button.addEventListener('click', onClick);
+      button.focus();
+
+      setPad(pad({ buttons: [BTN.A] }));
+      nav.poll();
+      nav.poll();
+      nav.poll();
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not auto-repeat activation while A is held', () => {
+      const [button] = layout([{ top: 0, left: 0 }]);
+      const onClick = vi.fn();
+      button.addEventListener('click', onClick);
+      button.focus();
+
+      setPad(pad({ buttons: [BTN.A] }));
+      nav.poll();
+      performance.now.mockReturnValue(5000); // long past any repeat delay
+      nav.poll();
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('auto-repeats direction when held past the delay', () => {
+      layout([
+        { top: 0, left: 0 },
+        { top: 100, left: 0 },
+        { top: 200, left: 0 },
+      ]);
+      const moveFocus = vi.spyOn(nav, 'moveFocus');
+
+      setPad(pad({ buttons: [BTN.DOWN] }));
+      nav.poll(); // initial press
+      expect(moveFocus).toHaveBeenCalledTimes(1);
+
+      performance.now.mockReturnValue(1000 + 500); // past REPEAT_DELAY_MS
+      nav.poll();
+      expect(moveFocus).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('is inert when no controller is connected', () => {
+    navigator.getGamepads = () => [];
+    const moveFocus = vi.spyOn(nav, 'moveFocus');
+    expect(() => nav.poll()).not.toThrow();
+    expect(moveFocus).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/js/gamepadNav.test.js
+++ b/src/renderer/js/gamepadNav.test.js
@@ -429,6 +429,81 @@ describe('GamepadNav', () => {
     });
   });
 
+  describe('focus ring target', () => {
+    it('rings the wrapping label for a checkbox, not the 16px box', () => {
+      document.body.innerHTML = '';
+      const label = document.createElement('label');
+      const box = document.createElement('input');
+      box.type = 'checkbox';
+      box.getBoundingClientRect = () => ({
+        top: 0,
+        left: 0,
+        width: 16,
+        height: 16,
+        right: 16,
+        bottom: 16,
+      });
+      Object.defineProperty(box, 'offsetParent', { get: () => label });
+      const text = document.createElement('span');
+      text.textContent = 'Enable Waveforms';
+      label.append(box, text);
+      document.body.appendChild(label);
+
+      nav.focus(box);
+
+      expect(label.classList.contains('gamepad-focus')).toBe(true);
+      expect(box.classList.contains('gamepad-focus')).toBe(false);
+      expect(document.activeElement).toBe(box); // real focus stays on the input
+    });
+
+    it('rings a plain button directly', () => {
+      const [button] = layout([{ top: 0, left: 0 }]);
+      nav.focus(button);
+      expect(button.classList.contains('gamepad-focus')).toBe(true);
+    });
+
+    it('clears the ring when navigation stops', () => {
+      const [button] = layout([{ top: 0, left: 0 }]);
+      nav.start();
+      nav.focus(button);
+      expect(button.classList.contains('gamepad-focus')).toBe(true);
+
+      nav.stop();
+      expect(button.classList.contains('gamepad-focus')).toBe(false);
+    });
+  });
+
+  describe('scrolling', () => {
+    it('can reach controls below the fold', () => {
+      // The viewport check must not exclude off-screen-but-scrollable content,
+      // or the ring gets stuck at the bottom edge of the window.
+      document.body.innerHTML = '';
+      const below = document.createElement('button');
+      below.getBoundingClientRect = () => ({
+        top: window.innerHeight + 200,
+        left: 20,
+        width: 100,
+        height: 30,
+        right: 120,
+        bottom: window.innerHeight + 230,
+      });
+      Object.defineProperty(below, 'offsetParent', { get: () => document.body });
+      document.body.appendChild(below);
+
+      expect(nav.visibleFocusables()).toContain(below);
+    });
+
+    it('centers the focused element instead of scrolling the bare minimum', () => {
+      const [button] = layout([{ top: 0, left: 0 }]);
+      const scrollIntoView = vi.fn();
+      button.scrollIntoView = scrollIntoView;
+
+      nav.focus(button);
+
+      expect(scrollIntoView).toHaveBeenCalledWith(expect.objectContaining({ block: 'center' }));
+    });
+  });
+
   describe('sliders', () => {
     function slider(props = {}) {
       document.body.innerHTML = '';

--- a/src/renderer/js/gamepadNav.test.js
+++ b/src/renderer/js/gamepadNav.test.js
@@ -326,6 +326,85 @@ describe('GamepadNav', () => {
     });
   });
 
+  describe('modals', () => {
+    function openModal() {
+      document.body.innerHTML = '';
+      const behind = document.createElement('button');
+      behind.textContent = 'behind';
+      behind.getBoundingClientRect = () => ({
+        top: 0,
+        left: 0,
+        width: 100,
+        height: 30,
+        right: 100,
+        bottom: 30,
+      });
+      Object.defineProperty(behind, 'offsetParent', { get: () => document.body });
+      document.body.appendChild(behind);
+
+      const overlay = document.createElement('div');
+      overlay.className = 'fixed inset-0';
+      overlay.getBoundingClientRect = () => ({
+        top: 0,
+        left: 0,
+        width: window.innerWidth,
+        height: window.innerHeight,
+        right: window.innerWidth,
+        bottom: window.innerHeight,
+      });
+      const closeBtn = document.createElement('button');
+      closeBtn.setAttribute('data-gamepad-close', '');
+      closeBtn.textContent = 'x';
+      closeBtn.getBoundingClientRect = () => ({
+        top: 10,
+        left: 10,
+        width: 30,
+        height: 30,
+        right: 40,
+        bottom: 40,
+      });
+      Object.defineProperty(closeBtn, 'offsetParent', { get: () => overlay });
+      overlay.appendChild(closeBtn);
+      document.body.appendChild(overlay);
+      return { behind, overlay, closeBtn };
+    }
+
+    it('traps navigation inside an open modal', () => {
+      // Otherwise the ring wanders the library behind the scrim while the dialog
+      // sits there uncloseable.
+      const { behind, closeBtn } = openModal();
+      const focusables = nav.visibleFocusables();
+      expect(focusables).toContain(closeBtn);
+      expect(focusables).not.toContain(behind);
+    });
+
+    it('pulls focus into a modal as soon as it opens', () => {
+      const { closeBtn } = openModal();
+      navigator.getGamepads = () => [pad()];
+      nav.poll();
+      expect(document.activeElement).toBe(closeBtn);
+    });
+
+    it('B closes the modal via its close button', () => {
+      const { closeBtn } = openModal();
+      const onClick = vi.fn();
+      closeBtn.addEventListener('click', onClick);
+
+      nav.back();
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('B clicks the scrim when a modal has no tagged close button', () => {
+      const { overlay, closeBtn } = openModal();
+      closeBtn.removeAttribute('data-gamepad-close');
+      const onClick = vi.fn();
+      overlay.addEventListener('click', onClick);
+
+      nav.back();
+      expect(onClick).toHaveBeenCalled();
+    });
+  });
+
   describe('fullscreen', () => {
     it('B exits fullscreen instead of relying on an Escape listener', () => {
       // A gamepad can put the canvas fullscreen; with no Escape handler mounted

--- a/src/renderer/styles/tailwind.css
+++ b/src/renderer/styles/tailwind.css
@@ -104,3 +104,19 @@
   -webkit-font-feature-settings: 'liga';
   -webkit-font-smoothing: antialiased;
 }
+
+/*
+ * Gamepad navigation focus ring (10-foot UI).
+ *
+ * The default focus outline is nearly invisible from a couch, so the element
+ * the gamepad has landed on gets a deliberately loud ring. Scoped to the class
+ * the nav layer applies, so mouse and keyboard users see no change.
+ */
+.gamepad-focus:focus,
+.gamepad-focus:focus-visible {
+  outline: 4px solid #3b82f6 !important;
+  outline-offset: 2px !important;
+  border-radius: 4px;
+  box-shadow: 0 0 0 8px rgba(59, 130, 246, 0.25) !important;
+  scroll-margin: 80px;
+}

--- a/src/renderer/styles/tailwind.css
+++ b/src/renderer/styles/tailwind.css
@@ -118,8 +118,9 @@
  * left edge, and tabs showed only their bottom and sides. An inset shadow lives
  * within the element's own box and cannot be clipped by an ancestor.
  */
-.gamepad-focus:focus,
-.gamepad-focus:focus-visible {
+/* Applied and removed by the nav layer, so it does not depend on :focus. The
+   ring can sit on a wrapping <label> whose checkbox holds the real focus. */
+.gamepad-focus {
   outline: none !important;
   box-shadow:
     inset 0 0 0 4px #3b82f6,

--- a/src/renderer/styles/tailwind.css
+++ b/src/renderer/styles/tailwind.css
@@ -108,15 +108,22 @@
 /*
  * Gamepad navigation focus ring (10-foot UI).
  *
- * The default focus outline is nearly invisible from a couch, so the element
- * the gamepad has landed on gets a deliberately loud ring. Scoped to the class
- * the nav layer applies, so mouse and keyboard users see no change.
+ * The default focus outline is nearly invisible from a couch, so the element the
+ * gamepad has landed on gets a deliberately loud ring. Scoped to the class the
+ * nav layer applies, so mouse and keyboard users see no change.
+ *
+ * The ring is drawn INSIDE the element with an inset shadow, not with `outline`.
+ * An outline paints outside the border box, so ancestors with `overflow-hidden`
+ * (the main layout columns, the tab strip) clip it: the canvas showed only its
+ * left edge, and tabs showed only their bottom and sides. An inset shadow lives
+ * within the element's own box and cannot be clipped by an ancestor.
  */
 .gamepad-focus:focus,
 .gamepad-focus:focus-visible {
-  outline: 4px solid #3b82f6 !important;
-  outline-offset: 2px !important;
+  outline: none !important;
+  box-shadow:
+    inset 0 0 0 4px #3b82f6,
+    inset 0 0 0 8px rgba(59, 130, 246, 0.3) !important;
   border-radius: 4px;
-  box-shadow: 0 0 0 8px rgba(59, 130, 246, 0.25) !important;
   scroll-margin: 80px;
 }

--- a/src/shared/components/LibraryPanel.jsx
+++ b/src/shared/components/LibraryPanel.jsx
@@ -29,6 +29,7 @@ function SongInfoModal({ song, onClose }) {
         <div className="flex justify-between items-center px-5 py-4 border-b border-gray-700 dark:border-gray-800">
           <h2 className="m-0 text-lg font-semibold text-white">Song Information</h2>
           <button
+            data-gamepad-close
             className="bg-none border-none text-white text-[32px] leading-none cursor-pointer p-0 w-8 h-8 flex items-center justify-center rounded transition-colors hover:bg-gray-700 dark:hover:bg-gray-800"
             onClick={onClose}
           >

--- a/src/shared/components/PlayerControls.jsx
+++ b/src/shared/components/PlayerControls.jsx
@@ -112,6 +112,7 @@ export function PlayerControls({
 
         <button
           onClick={isPlaying ? onPause : onPlay}
+          data-gamepad-action="play-pause"
           title={loading ? 'Loading...' : isPlaying ? 'Pause' : 'Play'}
           className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition disabled:opacity-50 flex items-center justify-center"
           disabled={loading}

--- a/src/shared/components/PlayerControls.jsx
+++ b/src/shared/components/PlayerControls.jsx
@@ -253,6 +253,7 @@ export function PlayerControls({
         {onOpenViewer && (
           <button
             onClick={onOpenViewer}
+            data-gamepad-skip="external"
             className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition flex items-center justify-center"
             title="Open Browser Viewer"
           >

--- a/src/shared/components/PlayerControls.jsx
+++ b/src/shared/components/PlayerControls.jsx
@@ -242,6 +242,7 @@ export function PlayerControls({
         {onOpenCanvasWindow && (
           <button
             onClick={onOpenCanvasWindow}
+            data-gamepad-skip="external"
             className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition flex items-center justify-center"
             title="Open Canvas Window"
           >

--- a/src/shared/hooks/useConfirm.jsx
+++ b/src/shared/hooks/useConfirm.jsx
@@ -58,6 +58,7 @@ export function useConfirm() {
               <button
                 type="button"
                 autoFocus
+                data-gamepad-close
                 onClick={() => close(false)}
                 className="px-4 py-2 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 rounded transition-colors"
               >

--- a/src/shared/ipcContracts.js
+++ b/src/shared/ipcContracts.js
@@ -240,6 +240,20 @@ export const CREATOR_CHANNELS = {
 };
 
 // ============================================================================
+// GAMEPAD CHANNELS
+// ============================================================================
+
+export const GAMEPAD_CHANNELS = {
+  // Renderer asks for the full controller state (used to prime the shim on load)
+  GET_SNAPSHOT: 'gamepad:getSnapshot',
+
+  // Events (main -> renderer)
+  STATE_CHANGE: 'gamepad:state',
+  CONNECTED: 'gamepad:connected',
+  DISCONNECTED: 'gamepad:disconnected',
+};
+
+// ============================================================================
 // ALL CHANNELS (for validation)
 // ============================================================================
 
@@ -263,6 +277,7 @@ export const ALL_CHANNELS = {
   ...RENDERER_CHANNELS,
   ...SHELL_CHANNELS,
   ...CREATOR_CHANNELS,
+  ...GAMEPAD_CHANNELS,
 };
 
 // ============================================================================


### PR DESCRIPTION
Two work streams, with the Flathub work stacked on the gamepad spike.

## Gamepad / couch navigation

- **Main-process gamepad engine** (`gamepadEngine.js`) using @kmamal/sdl, so controllers work regardless of renderer focus, with an IPC bridge and a `navigator.getGamepads()` shim in the preload.
- **10-foot navigation** (`gamepadNav.js`): D-pad/stick focus movement with an unclippable focus ring that follows scroll, A to activate, B to close modals, slider operation, fullscreen escape.
- Navigation correctness passes: trap focus in modals, skip popups/text fields/external-window traps, ignore controls in hidden drawers and off-screen panels, ring the checkbox label, reach the canvas.
- ~990 lines of new tests (`gamepadNav.test.js`, `gamepadEngine.test.js`, `gamepadShim.test.js`).

## Flathub packaging

- `flatpak/com.loukai.app.yml` manifest that completes a fully offline flatpak-builder build, installs, and runs with the gamepad working inside the sandbox. Notable fights documented in the commit messages: @kmamal/sdl's postinstall bypassed in favor of direct node-gyp against the runtime's SDL (with an ldd assertion), Electron staged explicitly via `--config.electronDist`, chrome-sandbox deleted so zypak takes over.
- `scripts/pack-webgpu-assets.js` to stage the WebGPU assets for offline builds.
- Staging glob disambiguated per-arch (x64 vs arm64 unpacked dirs) with a loud guard; previously the wrong architecture's files could be copied silently.
- Spellcheck disabled; network egress documented in `flatpak/PERMISSIONS.md`.

`node-addon-api` added as an explicit dependency (build-time only) since binding.gyp needs it but @kmamal/sdl only declares it as a devDependency.

arm64 compilation is untested locally (no QEMU); CI and Flathub's native builders will exercise it.