### PR TITLE
Fix npx: second launch always failed with "Could not find Electron"

### DIFF
--- a/bin/loukai.js
+++ b/bin/loukai.js
@@ -6,31 +6,165 @@
  * Launches the Loukai Karaoke Electron app in production mode.
  *
  * Usage: npx loukai-app
+ *
+ * Electron resolution: Electron is a devDependency (electron-builder bundles
+ * its own framework copy and would duplicate ~200MB into installers if it were
+ * a runtime dependency), so production/npx installs don't receive it from npm.
+ * It must NOT be installed into the package's own node_modules either: npx
+ * revalidates its cache on later runs and prunes any package the dependency
+ * tree doesn't declare, which deletes Electron after the first launch
+ * (https://github.com/monteslu/loukai/issues — "Could not find Electron" on
+ * the second `npx loukai-app`).
+ *
+ * So the launcher resolves Electron in this order:
+ *   1. A normally-installed electron package (the dev repo, or any environment
+ *      that installed it) — same as always.
+ *   2. A per-user runtime directory outside npm's reach, keyed by the Electron
+ *      version this package declares. npm never inventories it, so nothing
+ *      ever prunes it.
+ *   3. Install Electron into that runtime directory now (first launch only),
+ *      then use it. Repairs half-extracted installs the same way.
  */
 
-import { spawn } from 'child_process';
+import { spawn, execFileSync } from 'child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
+import os from 'os';
 import path from 'path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const appRoot = path.join(__dirname, '..');
 
-// Find the electron binary
 const require = createRequire(import.meta.url);
 
-let electronPath;
+function electronRange() {
+  const pkg = JSON.parse(readFileSync(path.join(appRoot, 'package.json'), 'utf-8'));
+  return (
+    (pkg.devDependencies && pkg.devDependencies.electron) ||
+    (pkg.dependencies && pkg.dependencies.electron) ||
+    'latest'
+  );
+}
+
+// Per-user cache location, overridable for tests/relocation.
+function runtimeBaseDir() {
+  if (process.env.LOUKAI_ELECTRON_DIR) return process.env.LOUKAI_ELECTRON_DIR;
+  switch (process.platform) {
+    case 'darwin':
+      return path.join(os.homedir(), 'Library', 'Caches', 'loukai', 'electron');
+    case 'win32':
+      return path.join(
+        process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local'),
+        'loukai',
+        'electron'
+      );
+    default:
+      return path.join(
+        process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache'),
+        'loukai',
+        'electron'
+      );
+  }
+}
+
+function runtimeDir(range) {
+  // One directory per declared range: bumping Electron in a release lands in a
+  // fresh directory instead of fighting a stale install.
+  return path.join(runtimeBaseDir(), range.replace(/[^\w.-]/g, '_'));
+}
+
+// Resolve the electron binary from a directory that has electron in its
+// node_modules. Returns null if the package is missing or its binary isn't
+// extracted (electron's index.js throws in that case).
+function resolveElectronFrom(dir) {
+  try {
+    const req = createRequire(path.join(dir, 'noop.js'));
+    const electronPath = req('electron');
+    if (typeof electronPath === 'string' && existsSync(electronPath)) {
+      return electronPath;
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+function npm(args, cwd) {
+  execFileSync('npm', args, {
+    cwd,
+    stdio: 'inherit',
+    // npm is npm.cmd on Windows; execFile needs a shell to find it.
+    shell: process.platform === 'win32',
+  });
+}
+
+function installRuntimeElectron(dir, range) {
+  mkdirSync(dir, { recursive: true });
+  const manifest = path.join(dir, 'package.json');
+  if (!existsSync(manifest)) {
+    writeFileSync(
+      manifest,
+      JSON.stringify({ name: 'loukai-electron-runtime', private: true }, null, 2)
+    );
+  }
+  console.log(`Downloading Electron ${range} (one-time setup)…`);
+  npm(['install', `electron@${range}`, '--no-audit', '--no-fund', '--loglevel', 'error'], dir);
+
+  let electronPath = resolveElectronFrom(dir);
+  if (electronPath) return electronPath;
+
+  // Package present but the binary isn't extracted (interrupted download?):
+  // electron's own installer is the repair.
+  const installJs = path.join(dir, 'node_modules', 'electron', 'install.js');
+  if (existsSync(installJs)) {
+    console.log('Electron install incomplete; repairing…');
+    execFileSync(process.execPath, [installJs], {
+      cwd: path.join(dir, 'node_modules', 'electron'),
+      stdio: 'inherit',
+    });
+    electronPath = resolveElectronFrom(dir);
+    if (electronPath) return electronPath;
+  }
+  return null;
+}
+
+function findElectron() {
+  // 1. Normally-installed electron (dev repo, or a consumer that installed it).
+  try {
+    const electronPath = require('electron');
+    if (typeof electronPath === 'string' && existsSync(electronPath)) {
+      return electronPath;
+    }
+  } catch {
+    // not installed here — use the runtime directory
+  }
+
+  const range = electronRange();
+  const dir = runtimeDir(range);
+
+  // 2. Already in the per-user runtime directory (every launch after the first).
+  const cached = resolveElectronFrom(dir);
+  if (cached) return cached;
+
+  // 3. First launch (or a damaged cache): install it there now.
+  return installRuntimeElectron(dir, range);
+}
+
+let electronPath = null;
 try {
-  electronPath = require('electron');
+  electronPath = findElectron();
 } catch (err) {
-  console.error('Error: Could not find Electron.');
-  console.error('Make sure electron is installed: npm install electron');
+  console.error('Error: could not set up Electron.');
+  console.error(err.message);
   process.exit(1);
 }
 
-if (typeof electronPath !== 'string') {
-  console.error('Error: Invalid electron path');
+if (!electronPath) {
+  console.error('Error: could not set up Electron.');
+  console.error('Check your network connection and try again, or install it manually:');
+  console.error('  npm install electron');
   process.exit(1);
 }
 

--- a/scripts/ensure-electron.js
+++ b/scripts/ensure-electron.js
@@ -1,26 +1,27 @@
 #!/usr/bin/env node
 /**
- * Ensure Electron is installed AND correctly extracted.
+ * Ensure an installed Electron is correctly extracted (repair-only).
  *
  * Electron lives in `devDependencies` because electron-builder requires it
  * there (and bundles its own copy into the DMG/installer — Electron in
  * `dependencies`/`optionalDependencies` makes electron-builder copy the whole
- * ~200MB Electron package into the app on top of the framework). But a
- * production/npx install skips devDependencies, so Electron is absent at
- * runtime. `postinstall` still runs for those installs, so this bridges the gap
- * with two jobs:
+ * ~200MB Electron package into the app on top of the framework).
  *
- *  1. INSTALL: if Electron is missing (production/npx consumer), install it from
- *     the version range declared in our own package.json. In the dev repo
- *     Electron is already present, so this never triggers.
+ * REPAIR: if Electron is present but its dist/ is incomplete (e.g. an
+ * interrupted first install), re-run Electron's own install.js. Historical
+ * note: this job used to hand-roll download + system-unzip because Electron's
+ * old extract-zip (bundling the dead yauzl@2) silently stalled on Node 24.
+ * Electron now extracts with the native @electron-internal/extract-zip
+ * (verified working on Node 24 with Electron 42), so its own installer is the
+ * repair.
  *
- *  2. REPAIR: if Electron is present but its dist/ is incomplete (e.g. an
- *     interrupted first install), re-run Electron's own install.js. Historical
- *     note: this job used to hand-roll download + system-unzip because
- *     Electron's old extract-zip (bundling the dead yauzl@2) silently stalled
- *     on Node 24. Electron now extracts with the native
- *     @electron-internal/extract-zip (verified working on Node 24 with
- *     Electron 42), so its own installer is the repair.
+ * If Electron is missing entirely (production/npx consumer — devDependencies
+ * are skipped there), this does NOTHING: bin/loukai.js installs Electron into
+ * a per-user runtime directory at launch instead. It used to `npm install`
+ * Electron into this package's own node_modules here, but anything npm's
+ * dependency tree doesn't declare gets pruned by npx's cache revalidation on
+ * the next run, which broke every `npx loukai-app` launch after the first.
+ * The launch-time install is outside npm's reach and self-heals.
  *
  * When Electron is already present and healthy, this is a silent no-op.
  * Best-effort throughout: it never fails the install; if it can't finish it
@@ -65,19 +66,6 @@ function resolveElectronDir() {
   }
 }
 
-function declaredElectronRange() {
-  try {
-    const pkg = require(join(projectDir, 'package.json'));
-    return (
-      (pkg.devDependencies && pkg.devDependencies.electron) ||
-      (pkg.dependencies && pkg.dependencies.electron) ||
-      null
-    );
-  } catch {
-    return null;
-  }
-}
-
 function isInstalled(electronDir, version, platformPath) {
   try {
     const distVersion = readFileSync(join(electronDir, 'dist', 'version'), 'utf-8').replace(/^v/, '');
@@ -87,17 +75,6 @@ function isInstalled(electronDir, version, platformPath) {
     return false;
   }
   return existsSync(join(electronDir, 'dist', platformPath));
-}
-
-function installElectron(range) {
-  const spec = `electron@${range || 'latest'}`;
-  log(`Electron not found; installing ${spec} (devDependency is skipped by production/npx installs)…`);
-  // --no-save: don't touch package.json; install into this package's node_modules.
-  execFileSync(
-    'npm',
-    ['install', spec, '--no-save', '--no-audit', '--no-fund', '--loglevel', 'error'],
-    { cwd: projectDir, stdio: 'inherit', env: { ...process.env, npm_config_save: 'false' } }
-  );
 }
 
 function main() {
@@ -113,30 +90,16 @@ function main() {
     return;
   }
 
-  // ---- Job 1: ensure the Electron package is present ----
-  let electronDir = resolveElectronDir();
+  // Missing entirely = production/npx consumer; bin/loukai.js handles that at
+  // launch (see header). Only an existing install gets repaired here.
+  const electronDir = resolveElectronDir();
   if (electronDir == null) {
-    const range = declaredElectronRange();
-    if (range == null) {
-      return; // we don't declare Electron at all — nothing to do
-    }
-    try {
-      installElectron(range);
-    } catch (err) {
-      log(`Could not install Electron automatically: ${err.message}`);
-      log('Install it manually with `npm install electron`, then re-run.');
-      return;
-    }
-    electronDir = resolveElectronDir();
-    if (electronDir == null) {
-      log('Electron still not resolvable after install; aborting (best-effort).');
-      return;
-    }
+    return;
   }
 
   const { version } = require(join(electronDir, 'package.json'));
 
-  // ---- Job 2: ensure the binary is actually extracted ----
+  // ---- Ensure the binary is actually extracted ----
   if (isInstalled(electronDir, version, platformPath)) {
     return; // healthy — silent no-op (the common dev-repo case)
   }


### PR DESCRIPTION
## The bug

`npx loukai-app` worked once, then every later run printed "Could not find Electron" forever. Not platform-specific (reported on macOS, reproduced on Linux with npm 11.13 against an isolated npm cache: run 1 launches, runs 2+ fail).

Root cause: the postinstall installed Electron `--no-save` into the package's own `node_modules` inside npx's cache directory. Since npm 10, npx revalidates its cache on subsequent runs and reifies; anything the dependency tree doesn't declare is extraneous and gets pruned. Electron is (necessarily) only a devDependency, so it was deleted on run 2, and because `loukai-app` itself was unchanged, postinstall never ran again to restore it. The launcher's catch-all error message hid the real failure.

## The fix

`bin/loukai.js` resolves Electron at launch time, in order:

1. A normally-installed electron package — the dev repo and any environment that installs it; behavior unchanged.
2. A per-user runtime directory npm never inventories and so can never prune: `~/.cache/loukai/electron/<range>` (Linux), `~/Library/Caches/loukai/electron/<range>` (macOS), `%LOCALAPPDATA%\loukai\electron\<range>` (Windows). `LOUKAI_ELECTRON_DIR` overrides.
3. One-time install into that directory on first launch.

Launch-time (instead of postinstall) means any damaged state heals on the next run, the same direction Electron itself took (Electron 42's `index.js` re-downloads a missing binary on require; the launcher keeps an `install.js` repair as backstop). Resolution failures now print the underlying error.

`ensure-electron.js` keeps only the dev-repo extraction repair; its install job is gone, which also removes a side effect where it duplicated the entire ~170-package dependency tree nested inside the cached package.

## Not affected

- Packaged builds (DMG/NSIS/AppImage/Flatpak): `bin/` isn't in the electron-builder files list and postinstall doesn't run there; they bundle their own framework.
- Dev repo: `require('electron')` hits step 1; `npm run dev`/`npm start` don't use this launcher at all.
- electron stays in devDependencies; electron-builder unchanged.

## Verification (npm pack + clean consumer install)

- postinstall is a silent no-op; no Electron, no nested duplicate tree in the consumer's `node_modules`
- run 1: one-time download into the runtime dir, launches
- run 2: launches from cache in ~180ms, no npm invocation
- forced reify between runs (`npm install left-pad`, the npx-prune equivalent): runtime dir untouched, run 3 launches
- deleted `dist/electron` binary: self-repairs on next launch
- dev repo launch path and all 447 tests unchanged/passing

Fixes the same latent fragility for `npm install loukai-app` consumers (any later `npm install` in such a project could prune the undeclared Electron the same way).