### PR TITLE
Release v0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![React 19](https://img.shields.io/badge/React-19-blue)](https://react.dev/)
 [![Electron 42](https://img.shields.io/badge/Electron-42-blue)](https://www.electronjs.org/)
-[![Tests](https://img.shields.io/badge/tests-340-green)](./.github/workflows/ci.yml)
+[![Tests](https://img.shields.io/badge/tests-447-green)](./.github/workflows/ci.yml)
 
 Loukai is a free, open source karaoke software that runs locally on your computer to **play** and **create** karaoke files from your own music. Built on M4A Stems (MPEG-4 multi-track audio), it uses industry-standard formats compatible with DJ software, giving you full control over your personal karaoke library.
 
@@ -16,6 +16,8 @@ Loukai is a free, open source karaoke software that runs locally on your compute
 ```
 npx loukai-app
 ```
+
+The first launch downloads Electron once into a per-user cache (`~/.cache/loukai` on Linux, `~/Library/Caches/loukai` on macOS, `%LOCALAPPDATA%\loukai` on Windows); every launch after that starts instantly.
 
 **Key highlights:**
 - **Open Format**: Built on NI Stems — no vendor lock-in, works with Traktor, Mixxx, and other DJ software
@@ -62,6 +64,12 @@ npx loukai-app
 - **Smart Search**: Fuzzy search across titles, artists, and albums
 - **Alphabet Navigation**: Quick filtering by first letter
 - **Pagination**: Efficient handling of large libraries (tested with 23K+ songs)
+
+### Gamepad / Couch Control
+- **Full app navigation with a game controller**: D-pad or left stick moves a visible focus ring through the UI
+- **SDL-backed input in the main process**: controllers work even when the window isn't focused, on every platform
+- **Sensible bindings**: A activates, B closes dialogs/leaves fullscreen, Start toggles play/pause, LB/RB switch tabs
+- **Sliders just work**: left/right on a focused fader adjusts it; up/down moves on so nothing becomes a trap
 
 ### Web Admin Interface
 - **Remote Control**: Full player control from any device on the network
@@ -383,6 +391,16 @@ The karaoke canvas shows helpful information when not playing:
 | `M` | Toggle mute |
 | `F` | Toggle fullscreen canvas |
 
+### Gamepad Bindings
+
+| Control | Action |
+|---------|--------|
+| D-pad / Left stick | Move focus (left/right adjusts a focused slider) |
+| `A` | Activate focused control |
+| `B` | Close dialog / leave fullscreen |
+| `Start` | Play/Pause |
+| `LB` / `RB` | Previous / next tab |
+
 ---
 
 ## Testing
@@ -403,7 +421,7 @@ npm run test:coverage
 npm run test:ui
 ```
 
-**Current Coverage:** 340 tests across 17 test files
+**Current Coverage:** 447 tests across 23 test files
 
 ---
 
@@ -516,6 +534,10 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for development guidelines.
 - Verify server is enabled in Settings
 - Check port is not in use (default: 3069)
 - Try accessing via IP address instead of hostname
+
+### `npx loukai-app` Can't Find Electron
+- Fixed in 0.12.0: earlier versions installed Electron inside npx's cache, which npx itself deletes on the next run
+- If a broken older install lingers, reset with `rm -rf ~/.npm/_npx` and run `npx loukai-app@latest`
 
 ### Build Errors
 ```bash

--- a/com.loukai.app.metainfo.xml
+++ b/com.loukai.app.metainfo.xml
@@ -48,6 +48,18 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="0.12.0" date="2026-08-08">
+      <description>
+        <p>Play from the couch: full gamepad navigation, plus a fix for npx launches</p>
+        <ul>
+          <li>Game controller support: drive the entire app with a gamepad — d-pad or stick moves a visible focus ring, A activates, B closes dialogs, Start toggles play/pause, shoulder buttons switch tabs</li>
+          <li>Controllers are read natively (SDL), so they keep working when the window isn't focused</li>
+          <li>Fixed "npx loukai-app" failing to find Electron on every launch after the first</li>
+          <li>Disabled spellcheck underlines in text fields</li>
+          <li>Security updates for networking dependencies</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.11.0" date="2026-08-02">
       <description>
         <p>Fixes the blank window on startup, plus smarter chords and editor search</p>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,8 @@ src/
 │   ├── audioEngine.js      # Legacy state stub (NO audio I/O — all audio is renderer Web Audio)
 │   ├── settingsManager.js  # JSON settings persistence
 │   ├── statePersistence.js # Auto-save state changes
-│   ├── preload.js          # Context bridge API
+│   ├── gamepadEngine.js    # SDL gamepad polling (works unfocused)
+│   ├── preload.js          # Context bridge API (incl. getGamepads() shim)
 │   ├── handlers/           # IPC handler modules
 │   └── creator/            # Song creation (main-process side)
 │       ├── audioInfo.js        # Pure-JS audio inspection
@@ -71,6 +72,7 @@ src/
 │   ├── components/         # Renderer-specific components
 │   ├── js/                 # Audio engine (vanilla JS)
 │   │   ├── kaiPlayer.js            # Stem playback + PA/IEM routing
+│   │   ├── gamepadNav.js           # Couch navigation (focus ring, geometric d-pad movement)
 │   │   ├── cdgPlayer.js
 │   │   ├── karaokeRenderer.js
 │   │   ├── microphoneEngine.js     # Mic capture + auto-tune chain
@@ -118,6 +120,7 @@ The orchestrator that coordinates all application functionality.
 - WebSocket broadcasting to web clients
 - Library scanning and song catalog management
 - Song queue management
+- Gamepad polling via SDL (`gamepadEngine.js`) — input works even when the window is unfocused; the preload shims `navigator.getGamepads()` over IPC and `gamepadNav.js` in the renderer turns it into geometric focus movement with a 10-foot focus ring
 
 ### 2. Renderer Process (React + Web Audio API)
 
@@ -496,6 +499,7 @@ Channels organized by domain:
 | `creator:*` | Song creation |
 | `effect:*` | Visual effects |
 | `canvas:*` | WebRTC streaming |
+| `gamepad:*` | Gamepad state polling |
 
 ## Technology Stack
 
@@ -507,6 +511,7 @@ Channels organized by domain:
 - **music-metadata** - Audio metadata parsing
 - **yauzl/yazl** - ZIP handling
 - **Fuse.js 7** - Fuzzy search
+- **@kmamal/sdl** - Gamepad input
 
 ### Renderer Process
 - **React 19** - UI framework

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loukai-app",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loukai-app",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loukai-app",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "type": "module",
   "description": "Loukai Karaoke - Free and open source karaoke system for playing and creating stem-based karaoke files",
   "main": "src/main/main.js",


### PR DESCRIPTION
Docs refresh and version bump for the 0.12.0 release.

## Docs
- README: new **Gamepad / Couch Control** feature section and binding table (D-pad/stick focus, A activate, B close/escape, Start play/pause, LB/RB tabs), a note that `npx loukai-app` downloads Electron once into a per-user cache, a troubleshooting entry for the pre-0.12 npx breakage, test counts 340 → 447
- architecture.md: gamepadEngine/gamepadNav in the component maps, `gamepad:*` IPC prefix, @kmamal/sdl in the stack

## Release
- Version 0.12.0 in package.json/lock
- Flathub metainfo release entry for 0.12.0 (validated with `appstreamcli validate`)

## In this release (since v0.11.0)
- Gamepad support: full couch navigation with SDL-backed input in the main process (#109)
- Flathub packaging groundwork: offline-build manifest, asset packing script (#109)
- npx fix: second `npx loukai-app` launch no longer loses Electron to npx cache pruning (#110)
- Security: ip-address and socket.io-parser advisory bumps; spellcheck disabled

## After merge
1. `git tag v0.12.0 && git push origin v0.12.0` — triggers the Build and Release workflow (AppImage/Flatpak/NSIS/DMG to the GitHub release)
2. `npm publish` from the tagged main — **this is the one that actually delivers the npx fix to users**