### PR TITLE
Fix main-process crash when state events fire after the web server stops

### DIFF
--- a/src/main/webServer.js
+++ b/src/main/webServer.js
@@ -63,6 +63,9 @@ class WebServer {
     // Viewer sockets keyed by viewerId for WebRTC signaling
     this.viewerSockets = new Map();
 
+    // appState subscriptions owned by the current start(); see stop()
+    this.stateListeners = null;
+
     this.setupMiddleware();
     this.setupRoutes();
   }
@@ -2290,36 +2293,56 @@ class WebServer {
   }
 
   setupStateChangeListeners() {
-    // Subscribe to mixer state changes and broadcast to admin clients
-    this.mainApp.appState.on('mixerChanged', (mixerState) => {
-      this.io.to('admin-clients').emit('mixer-update', mixerState);
-    });
+    // start() runs this on every (re)start, so drop any previous set first or
+    // a settings-change restart stacks duplicate broadcasts.
+    this.removeStateChangeListeners();
 
-    // Subscribe to effects state changes and broadcast to admin clients
-    this.mainApp.appState.on('effectsChanged', (effectsState) => {
-      this.io.to('admin-clients').emit('effects-update', effectsState);
-    });
+    this.stateListeners = {
+      // Broadcast mixer state changes to admin clients
+      mixerChanged: (mixerState) => {
+        this.io.to('admin-clients').emit('mixer-update', mixerState);
+      },
 
-    // Subscribe to queue changes and broadcast to admin clients
-    this.mainApp.appState.on('queueChanged', (queue) => {
-      const currentSong = this.mainApp.appState.state.currentSong;
-      this.io.to('admin-clients').emit('queue-update', {
-        queue,
-        currentSong,
-      });
-    });
+      // Broadcast effects state changes to admin clients
+      effectsChanged: (effectsState) => {
+        this.io.to('admin-clients').emit('effects-update', effectsState);
+      },
 
-    // Subscribe to current song changes and broadcast to admin clients (includes isLoading state)
-    this.mainApp.appState.on('currentSongChanged', (currentSong) => {
-      this.io.to('admin-clients').emit('current-song-update', currentSong);
-    });
+      // Broadcast queue changes to admin clients
+      queueChanged: (queue) => {
+        const currentSong = this.mainApp.appState.state.currentSong;
+        this.io.to('admin-clients').emit('queue-update', {
+          queue,
+          currentSong,
+        });
+      },
 
-    // Subscribe to playback state changes and broadcast to admin clients
-    this.mainApp.appState.on('playbackChanged', (playbackState) => {
-      this.io.to('admin-clients').emit('playback-state-update', playbackState);
-    });
+      // Broadcast current song changes to admin clients (includes isLoading state)
+      currentSongChanged: (currentSong) => {
+        this.io.to('admin-clients').emit('current-song-update', currentSong);
+      },
+
+      // Broadcast playback state changes to admin clients
+      playbackChanged: (playbackState) => {
+        this.io.to('admin-clients').emit('playback-state-update', playbackState);
+      },
+    };
+
+    for (const [event, handler] of Object.entries(this.stateListeners)) {
+      this.mainApp.appState.on(event, handler);
+    }
 
     log('✅ State change listeners configured for WebSocket broadcasting');
+  }
+
+  removeStateChangeListeners() {
+    if (!this.stateListeners) {
+      return;
+    }
+    for (const [event, handler] of Object.entries(this.stateListeners)) {
+      this.mainApp.appState.off(event, handler);
+    }
+    this.stateListeners = null;
   }
 
   setupSocketHandlers() {
@@ -2597,6 +2620,13 @@ class WebServer {
   }
 
   stop() {
+    // Unsubscribe BEFORE dropping io: during shutdown the renderer is still
+    // emitting state over IPC for a moment, and a listener firing after
+    // `this.io = null` crashes the main process (uncaught "reading 'to' of
+    // null" — seen when quitting via Ctrl-C in a terminal launch, where the
+    // window outlives cleanup()).
+    this.removeStateChangeListeners();
+
     if (this.io) {
       this.io.close();
       this.io = null;

--- a/src/main/webServer.test.js
+++ b/src/main/webServer.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// webServer.js pulls in streamingHandlers, which imports electron.
+vi.mock('electron', () => ({
+  ipcMain: { on: vi.fn(), handle: vi.fn() },
+  shell: { openExternal: vi.fn() },
+  app: { getPath: vi.fn(() => '/tmp'), getVersion: vi.fn(() => '0.0.0') },
+}));
+
+const WebServer = (await import('./webServer.js')).default;
+
+/**
+ * The appState subscriptions are the regression surface here: stop() must
+ * detach them (a listener firing after `io = null` crashed the main process
+ * during shutdown), and a restart must not stack duplicates.
+ */
+describe('WebServer state change listeners', () => {
+  let webServer;
+  let appState;
+
+  const STATE_EVENTS = [
+    'mixerChanged',
+    'effectsChanged',
+    'queueChanged',
+    'currentSongChanged',
+    'playbackChanged',
+  ];
+
+  beforeEach(() => {
+    appState = new EventEmitter();
+    appState.state = { currentSong: null };
+    webServer = new WebServer({ appState });
+  });
+
+  it('subscribes once per state event', () => {
+    webServer.setupStateChangeListeners();
+    for (const event of STATE_EVENTS) {
+      expect(appState.listenerCount(event)).toBe(1);
+    }
+  });
+
+  it('does not stack duplicate listeners across restarts', () => {
+    webServer.setupStateChangeListeners();
+    webServer.setupStateChangeListeners();
+    webServer.setupStateChangeListeners();
+    for (const event of STATE_EVENTS) {
+      expect(appState.listenerCount(event)).toBe(1);
+    }
+  });
+
+  it('detaches all listeners on stop()', () => {
+    webServer.setupStateChangeListeners();
+    webServer.stop();
+    for (const event of STATE_EVENTS) {
+      expect(appState.listenerCount(event)).toBe(0);
+    }
+  });
+
+  it('survives state events emitted after stop()', () => {
+    webServer.setupStateChangeListeners();
+    webServer.stop(); // nulls io
+
+    // The shutdown crash: renderer IPC still updates playback state while the
+    // app quits. With the listeners detached this must be a no-op, not a
+    // TypeError on `this.io.to`.
+    expect(() => {
+      appState.emit('playbackChanged', { isPlaying: false });
+      appState.emit('mixerChanged', {});
+      appState.emit('queueChanged', []);
+    }).not.toThrow();
+  });
+
+  it('broadcasts to admin clients while running', () => {
+    const emit = vi.fn();
+    webServer.io = { to: vi.fn(() => ({ emit })), close: vi.fn() };
+    webServer.setupStateChangeListeners();
+
+    appState.emit('playbackChanged', { isPlaying: true });
+    expect(webServer.io.to).toHaveBeenCalledWith('admin-clients');
+    expect(emit).toHaveBeenCalledWith('playback-state-update', { isPlaying: true });
+  });
+});


### PR DESCRIPTION
## The bug

Quitting a terminal/npx launch with Ctrl-C printed repeated uncaught exceptions from the main process:

```
TypeError: Cannot read properties of null (reading 'to')
    at AppState.<anonymous> (src/main/webServer.js:2319)
```

`setupStateChangeListeners()` subscribes five appState listeners (`mixerChanged`, `effectsChanged`, `queueChanged`, `currentSongChanged`, `playbackChanged`) that all dereference `this.io`, but `stop()` only nulled `io` and never unsubscribed them. During shutdown the renderer keeps sending `renderer:updatePlaybackState` over IPC for a moment after `cleanup()` stops the server, so the still-subscribed listener hit `null.to(...)`. Desktop window-close quits rarely show it because the renderer dies first; a terminal Ctrl-C tears down main while the window is still alive.

Two more consequences of the same root cause, not just cosmetic:
- Disabling the web server from the Server tab while a song plays crashed the same way on the next state change.
- Every re-enable stacked five more duplicate listeners, since `start()` re-ran the setup unconditionally.

Pre-existing bug (not an 0.12 regression); it surfaced now because npx launches run in a terminal.

## The fix

- `stop()` detaches the subscriptions before dropping `io`.
- `setupStateChangeListeners()` is idempotent: it removes any previous set before subscribing, so restarts can't stack duplicates.

## Tests

New `src/main/webServer.test.js` (electron mocked): one listener per event, no duplicates across repeated setup, all detached after `stop()`, state events after `stop()` are a no-op instead of a TypeError, and the running path still broadcasts to `admin-clients`. Full suite: 452 passing.