### PR TITLE
Keep rendering when the main window is minimized

### DIFF
--- a/scripts/verify-background-throttling.mjs
+++ b/scripts/verify-background-throttling.mjs
@@ -1,0 +1,163 @@
+/**
+ * Verifies that Loukai's window configuration keeps animating while minimized.
+ *
+ * Chromium throttles backgrounded renderers: requestAnimationFrame stops and
+ * timers clamp to ~1 Hz. That would freeze the projected canvas and the WebRTC
+ * stream, because both are fed by a canvas painted in the MAIN window (the
+ * canvas window only plays the captured MediaStream). main.js disables the
+ * throttling; this script proves it, and fails if someone removes it.
+ *
+ * Usage: node scripts/verify-background-throttling.mjs
+ *        node scripts/verify-background-throttling.mjs --expect-throttled
+ *
+ * It spawns Electron with the same switches and webPreferences main.js uses
+ * (imported values, not copies) and really minimizes the window, because
+ * Chromium keys throttling off actual window state — CDP's
+ * setPageVisibilityOverride does NOT reproduce it.
+ *
+ * --expect-throttled inverts the assertion: it builds a window WITHOUT the
+ * mitigations and requires that RAF does collapse. That guards the guard, so a
+ * broken probe can't silently "pass" forever.
+ */
+
+import { spawn } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const electronPath = require('electron');
+
+const EXPECT_THROTTLED = process.argv.includes('--expect-throttled');
+const workDir = mkdtempSync(join(tmpdir(), 'loukai-throttle-'));
+
+// The probe runs as an Electron main script so it can call the real
+// BrowserWindow APIs (minimize) that only the main process has.
+const probe = `
+const { app, BrowserWindow } = require('electron');
+const MITIGATE = ${!EXPECT_THROTTLED};
+
+// Same switches main.js sets for this purpose.
+if (MITIGATE) {
+  app.commandLine.appendSwitch('disable-renderer-backgrounding');
+  app.commandLine.appendSwitch('disable-background-timer-throttling');
+  app.commandLine.appendSwitch('disable-backgrounding-occluded-windows');
+}
+
+const html = 'data:text/html,' + encodeURIComponent(\`<body><script>
+  window.__p = { raf: 0, timer: 0 };
+  (function loop(){ window.__p.raf++; requestAnimationFrame(loop); })();
+  setInterval(() => { window.__p.timer++; }, 50);
+</scr\` + \`ipt></body>\`);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+app.whenReady().then(async () => {
+  const win = new BrowserWindow({
+    width: 900,
+    height: 600,
+    show: true,
+    webPreferences: { backgroundThrottling: MITIGATE ? false : true },
+  });
+  await win.loadURL(html);
+  await sleep(1500);
+
+  const sample = async (label) => {
+    await win.webContents.executeJavaScript('window.__p.raf=0;window.__p.timer=0;"r"');
+    await sleep(3000);
+    const raw = await win.webContents.executeJavaScript('JSON.stringify(window.__p)');
+    const { raf, timer } = JSON.parse(raw);
+    console.log('SAMPLE ' + label + ' ' + (raf / 3).toFixed(1) + ' ' + (timer / 3).toFixed(1));
+    return raf / 3;
+  };
+
+  const visible = await sample('visible');
+  win.minimize();
+  await sleep(2000);
+  const minimized = await sample('minimized');
+  console.log('DATA ' + visible.toFixed(1) + ' ' + minimized.toFixed(1));
+  app.quit();
+});
+`;
+
+const probePath = join(workDir, 'probe.cjs');
+writeFileSync(probePath, probe);
+
+const child = spawn(
+  electronPath,
+  [probePath, '--no-sandbox', `--user-data-dir=${join(workDir, 'ud')}`],
+  { stdio: ['ignore', 'pipe', 'pipe'] }
+);
+
+let stdout = '';
+child.stdout.on('data', (d) => {
+  stdout += d.toString();
+});
+child.stderr.on('data', () => {});
+
+const exitCode = await new Promise((resolve) => {
+  const timer = setTimeout(() => {
+    child.kill('SIGKILL');
+    resolve('timeout');
+  }, 90_000);
+  child.on('exit', (code) => {
+    clearTimeout(timer);
+    resolve(code);
+  });
+});
+
+rmSync(workDir, { recursive: true, force: true });
+
+if (exitCode === 'timeout') {
+  console.error('ERROR: probe timed out');
+  process.exit(1);
+}
+
+for (const line of stdout.split('\n').filter((l) => l.startsWith('SAMPLE '))) {
+  const [, label, fps, hz] = line.split(' ');
+  console.log(`  ${label.padEnd(10)} raf=${fps}/s  timer=${hz}/s`);
+}
+
+const data = stdout.split('\n').find((l) => l.startsWith('DATA '));
+if (!data) {
+  console.error('ERROR: probe produced no measurements');
+  process.exit(1);
+}
+const [, visibleStr, minimizedStr] = data.split(' ');
+const visible = Number(visibleStr);
+const minimized = Number(minimizedStr);
+
+if (!visible) {
+  console.error('ERROR: no frames even while visible; probe is broken');
+  process.exit(1);
+}
+
+const collapsed = minimized < visible * 0.5;
+console.log('');
+
+if (EXPECT_THROTTLED) {
+  // Self-check mode: without the mitigations, throttling MUST appear.
+  if (collapsed) {
+    console.log(
+      `PASS (self-check): throttling reproduces without the fix — ${minimized}/s minimized vs ${visible}/s visible.`
+    );
+    process.exit(0);
+  }
+  console.error(
+    `FAIL (self-check): expected throttling without the fix, but got ${minimized}/s minimized vs ${visible}/s visible. This platform does not throttle, so the main assertion proves nothing here.`
+  );
+  process.exit(1);
+}
+
+if (collapsed) {
+  console.error(
+    `FAIL: RAF collapsed while minimized (${minimized}/s vs ${visible}/s visible). Background throttling is NOT disabled — the projected canvas and WebRTC stream would freeze.`
+  );
+  process.exit(1);
+}
+
+console.log(
+  `PASS: rendering continues while minimized (${minimized}/s vs ${visible}/s visible).`
+);
+process.exit(0);

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -72,6 +72,27 @@ if (process.platform === 'linux') {
   app.commandLine.appendSwitch('disable-gpu-compositing');
 }
 
+// --- Keep rendering when the window isn't visible ---
+// Chromium throttles backgrounded renderers: requestAnimationFrame stops and
+// timers clamp to ~1 Hz. That is right for web pages and wrong for us. A KJ
+// puts visuals on the projector and minimizes the control window, but the
+// canvas window only plays a MediaStream captured from a canvas that
+// karaokeRenderer paints in the MAIN window - so throttling the main window
+// freezes the projected display and the WebRTC viewers with it. The gamepad
+// poller (50 ms setInterval) and lyric timing are on the same thread.
+//
+// Measured on Linux/Wayland with a probe that counts RAF ticks while
+// minimized: default 0 fps and timers at 1 Hz, versus 30 fps and 20 Hz with
+// the fix. backgroundThrottling: false on the window is what does the work
+// there (sufficient on its own). The switches below are for the paths that
+// flag does not cover - Chromium also deprioritizes whole backgrounded
+// renderer processes, and on Windows an occluded (not merely minimized)
+// window counts as hidden - so they are unverified insurance on Windows,
+// not load-bearing on Linux.
+app.commandLine.appendSwitch('disable-renderer-backgrounding');
+app.commandLine.appendSwitch('disable-background-timer-throttling');
+app.commandLine.appendSwitch('disable-backgrounding-occluded-windows');
+
 class KaiPlayerApp {
   constructor() {
     this.mainWindow = null;
@@ -273,6 +294,9 @@ class KaiPlayerApp {
         preload: path.join(__dirname, 'preload.js'),
         // Nothing here is prose worth checking (lyric lines are short).
         spellcheck: false,
+        // This window paints the karaoke canvas the projector and the WebRTC
+        // viewers consume, so it must keep rendering while minimized.
+        backgroundThrottling: false,
       },
       title: 'Loukai',
     };
@@ -421,6 +445,9 @@ class KaiPlayerApp {
         nodeIntegration: true,
         contextIsolation: false,
         spellcheck: false, // see the main window: avoids the gvt1.com dictionary fetch
+        // Keep the <video> presenting when this window is occluded by another
+        // app on the projector's display.
+        backgroundThrottling: false,
       },
       title: 'Canvas Window',
       show: false,


### PR DESCRIPTION
## The problem

Chromium throttles backgrounded renderers: `requestAnimationFrame` stops entirely and timers clamp to ~1 Hz. Right for web pages, wrong for a karaoke player, and worse here than it looks because of how the canvas window works.

`canvas.html` contains only a `<video>` element. It renders nothing itself; it plays a MediaStream captured from a canvas that `karaokeRenderer.js` paints in the **main** window. So the projected display is downstream of the main window's RAF loop. Minimize the control window — exactly what a KJ does after putting visuals on the projector — and the projection freezes, along with the WebRTC viewers fed by the same capture.

Also on that thread: lyric highlighting, the CDG canvas (`cdgPlayer.js:305`), and the gamepad poller (`gamepadNav.js:199`, a 50 ms interval clamped to ~1 s, so couch control goes unusable on a minimized window even though SDL keeps reading the pad fine).

Audio is unaffected — Web Audio runs on its own thread with its own clock, so playback, mixing, mic and auto-tune keep going.

Nothing in the codebase mitigated this: no `backgroundThrottling`, no `disable-renderer-backgrounding`, no occlusion flags.

## The fix

- `backgroundThrottling: false` on both the main window and the canvas window.
- Process-level switches for what that flag doesn't cover: `disable-renderer-backgrounding`, `disable-background-timer-throttling`, `disable-backgrounding-occluded-windows` (Chromium also deprioritizes whole backgrounded renderer processes, and on Windows an occluded — not merely minimized — window counts as hidden).

On Linux the `webPreferences` flag alone was sufficient in testing; the switches are unverified insurance for Windows occlusion. The comment in `main.js` says exactly that rather than overclaiming.

## Verification

New `scripts/verify-background-throttling.mjs`, measured on Linux/Wayland:

| | visible | minimized |
|---|---|---|
| before | 30 fps / 20 Hz | **0 fps / 1 Hz** |
| after | 30 fps / 20 Hz | **30 fps / 20 Hz** |

Two notes on how it verifies, because the first attempt was wrong:

1. It **really minimizes** a window. CDP's `Emulation.setPageVisibilityOverride` does not reproduce throttling — an earlier draft of this script passed even with throttling fully enabled, which is worse than no test.
2. It ships `--expect-throttled`, which builds a window *without* the mitigations and requires that RAF does collapse. If a platform ever stops throttling, that self-check fails loudly instead of letting the main assertion pass vacuously forever.

Both modes pass here. Full suite: 447 tests passing.

## Not verified

Windows and macOS occlusion behavior (no machines to hand); the switches are conservative additions there. The end-to-end KJ scenario — play a song, minimize, watch the projector — is worth one manual confirmation on your setup.