### PR TITLE
Draw tooltips in React instead of asking the OS for them

### DIFF
--- a/src/renderer/components/AudioDeviceSettings.jsx
+++ b/src/renderer/components/AudioDeviceSettings.jsx
@@ -12,6 +12,7 @@
 
 import React from 'react';
 import { PortalSelect } from './PortalSelect.jsx';
+import { Tooltip } from '../../shared/components/Tooltip.jsx';
 
 export function AudioDeviceSettings({
   bus, // 'PA' | 'IEM' | 'mic' renders just that bus's slice (three-row Audio tab, #49); unset = legacy full block
@@ -76,19 +77,20 @@ export function AudioDeviceSettings({
             placeholder="Default"
           />
         </div>
-        <label
-          className="flex items-center cursor-pointer select-none text-gray-900 dark:text-gray-100 text-sm"
-          title="IEM is for in-ear monitoring; separate devices drift over long songs"
-        >
-          <input
-            type="checkbox"
-            id="iemMonoVocals"
-            className="w-4 h-4 mr-2 cursor-pointer"
-            checked={settings.iemMonoVocals ?? true}
-            onChange={(e) => onSettingChange && onSettingChange('iemMonoVocals', e.target.checked)}
-          />
-          Vocals in Mono (single earpiece)
-        </label>
+        <Tooltip text={'IEM is for in-ear monitoring; separate devices drift over long songs'}>
+          <label className="flex items-center cursor-pointer select-none text-gray-900 dark:text-gray-100 text-sm">
+            <input
+              type="checkbox"
+              id="iemMonoVocals"
+              className="w-4 h-4 mr-2 cursor-pointer"
+              checked={settings.iemMonoVocals ?? true}
+              onChange={(e) =>
+                onSettingChange && onSettingChange('iemMonoVocals', e.target.checked)
+              }
+            />
+            Vocals in Mono (single earpiece)
+          </label>
+        </Tooltip>
       </div>
     );
   }
@@ -135,13 +137,14 @@ export function AudioDeviceSettings({
       <div className="my-5 p-5 bg-gray-50 dark:bg-gray-800 rounded-lg">
         <h3 className="flex items-center justify-between m-0 mb-4 text-lg text-gray-900 dark:text-gray-100">
           Audio Devices
-          <button
-            onClick={onRefreshDevices}
-            className="px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white rounded transition-colors text-base"
-            title="Refresh device list"
-          >
-            ↻
-          </button>
+          <Tooltip text={'Refresh device list'}>
+            <button
+              onClick={onRefreshDevices}
+              className="px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white rounded transition-colors text-base"
+            >
+              ↻
+            </button>
+          </Tooltip>
         </h3>
 
         <div className="my-3">

--- a/src/renderer/components/MixerTab.jsx
+++ b/src/renderer/components/MixerTab.jsx
@@ -9,6 +9,7 @@
 import React, { useState, useEffect } from 'react';
 import { MixerPanel } from '../../shared/components/MixerPanel.jsx';
 import { AudioDeviceSettings } from './AudioDeviceSettings.jsx';
+import { Tooltip } from '../../shared/components/Tooltip.jsx';
 
 export function MixerTab({ bridge }) {
   const [mixerState, setMixerState] = useState({
@@ -225,13 +226,14 @@ export function MixerTab({ bridge }) {
       <div className="mb-8">
         <h2 className="m-0 mb-5 text-2xl text-gray-900 dark:text-gray-100 flex items-center justify-between">
           Audio Mixer
-          <button
-            onClick={handleRefreshDevices}
-            className="px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white rounded transition-colors text-base"
-            title="Refresh device list"
-          >
-            ↻
-          </button>
+          <Tooltip text={'Refresh device list'}>
+            <button
+              onClick={handleRefreshDevices}
+              className="px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white rounded transition-colors text-base"
+            >
+              ↻
+            </button>
+          </Tooltip>
         </h2>
         <MixerPanel
           mixerState={mixerState}

--- a/src/renderer/components/StatusBar.jsx
+++ b/src/renderer/components/StatusBar.jsx
@@ -5,6 +5,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import { Tooltip } from '../../shared/components/Tooltip.jsx';
 
 export function StatusBar({ bridge }) {
   const [statusText, _setStatusText] = useState('Ready');
@@ -74,13 +75,14 @@ export function StatusBar({ bridge }) {
       </div>
       <div className="flex-1 text-center">
         {webUrl && (
-          <span
-            className="text-blue-500 dark:text-blue-400 cursor-pointer hover:underline"
-            onClick={handleUrlClick}
-            title="Click to open in browser"
-          >
-            🌐 {webUrl}
-          </span>
+          <Tooltip text={'Click to open in browser'}>
+            <span
+              className="text-blue-500 dark:text-blue-400 cursor-pointer hover:underline"
+              onClick={handleUrlClick}
+            >
+              🌐 {webUrl}
+            </span>
+          </Tooltip>
         )}
       </div>
       <div className="flex-1 flex gap-4 justify-end">

--- a/src/shared/components/ChordEditor.jsx
+++ b/src/shared/components/ChordEditor.jsx
@@ -5,6 +5,7 @@
  */
 
 import { useState } from 'react';
+import { Tooltip } from './Tooltip.jsx';
 
 const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
 // The detector's vocabulary as pick-list suggestions; typing stays free-form
@@ -155,17 +156,18 @@ export function ChordEditor({ chords, onChange, onAnalyze, analyzing = false }) 
                   : 'bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-750 hover:border-gray-400 dark:hover:border-gray-500'
               }`}
             >
-              <span
-                title={`Play chord ${i + 1} as a tone`}
-                className="flex items-center justify-center min-w-[36px] h-9 bg-gray-200 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-sm font-semibold text-gray-700 dark:text-gray-200 cursor-pointer transition-all flex-shrink-0 hover:bg-blue-600 hover:text-white dark:hover:bg-blue-500"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setSelectedIndex(i);
-                  playChordTone(c.chord, c.end - c.start);
-                }}
-              >
-                {i + 1}
-              </span>
+              <Tooltip text={`Play chord ${i + 1} as a tone`}>
+                <span
+                  className="flex items-center justify-center min-w-[36px] h-9 bg-gray-200 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-sm font-semibold text-gray-700 dark:text-gray-200 cursor-pointer transition-all flex-shrink-0 hover:bg-blue-600 hover:text-white dark:hover:bg-blue-500"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setSelectedIndex(i);
+                    playChordTone(c.chord, c.end - c.start);
+                  }}
+                >
+                  {i + 1}
+                </span>
+              </Tooltip>
               <TimeField value={c.start} onCommit={(v) => update(i, { start: v })} />
               <span className="text-gray-400 text-xs">to</span>
               <TimeField value={c.end} onCommit={(v) => update(i, { end: v })} />
@@ -176,22 +178,26 @@ export function ChordEditor({ chords, onChange, onAnalyze, analyzing = false }) 
                 value={c.chord}
                 onChange={(e) => update(i, { chord: e.target.value })}
               />
-              <button
-                type="button"
-                onClick={() => addAfter(i)}
-                title="Add chord after"
-                className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
-              >
-                <span className="material-icons text-gray-500 text-base leading-none">add</span>
-              </button>
-              <button
-                type="button"
-                onClick={() => remove(i)}
-                title="Delete chord"
-                className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
-              >
-                <span className="material-icons text-gray-500 text-base leading-none">delete</span>
-              </button>
+              <Tooltip text="Add chord after">
+                <button
+                  type="button"
+                  onClick={() => addAfter(i)}
+                  className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+                >
+                  <span className="material-icons text-gray-500 text-base leading-none">add</span>
+                </button>
+              </Tooltip>
+              <Tooltip text="Delete chord">
+                <button
+                  type="button"
+                  onClick={() => remove(i)}
+                  className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+                >
+                  <span className="material-icons text-gray-500 text-base leading-none">
+                    delete
+                  </span>
+                </button>
+              </Tooltip>
             </div>
           ))}
         </div>

--- a/src/shared/components/LibraryPanel.jsx
+++ b/src/shared/components/LibraryPanel.jsx
@@ -11,6 +11,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { getFormatIcon, formatDuration } from '../formatUtils.js';
+import { Tooltip } from './Tooltip.jsx';
 
 function SongInfoModal({ song, onClose }) {
   if (!song) return null;
@@ -611,22 +612,24 @@ export function LibraryPanel({ bridge, showSetFolder = false, showFullRefresh = 
                     </td>
                     <td className="px-3 py-1.5 text-xs leading-relaxed border-b border-gray-200 dark:border-gray-800/50">
                       <div className="flex flex-row gap-1 items-center">
-                        <button
-                          className="w-7 h-7 min-w-[28px] min-h-[28px] max-w-[28px] max-h-[28px] p-0 flex items-center justify-center bg-transparent border border-gray-200 dark:border-gray-700 rounded text-gray-700 dark:text-white cursor-pointer transition-all flex-shrink-0 hover:bg-gray-100 dark:hover:bg-gray-800 hover:border-blue-600"
-                          onClick={() => handleAddToQueue(song)}
-                          title="Add to Queue"
-                        >
-                          <span className="material-icons text-base leading-none">
-                            playlist_add
-                          </span>
-                        </button>
-                        <button
-                          className="w-7 h-7 min-w-[28px] min-h-[28px] max-w-[28px] max-h-[28px] p-0 flex items-center justify-center bg-transparent border border-gray-200 dark:border-gray-700 rounded text-gray-700 dark:text-white cursor-pointer transition-all flex-shrink-0 hover:bg-gray-100 dark:hover:bg-gray-800 hover:border-blue-600"
-                          onClick={() => handleShowInfo(song)}
-                          title="Song Info"
-                        >
-                          <span className="material-icons text-base leading-none">info</span>
-                        </button>
+                        <Tooltip text="Add to Queue">
+                          <button
+                            className="w-7 h-7 min-w-[28px] min-h-[28px] max-w-[28px] max-h-[28px] p-0 flex items-center justify-center bg-transparent border border-gray-200 dark:border-gray-700 rounded text-gray-700 dark:text-white cursor-pointer transition-all flex-shrink-0 hover:bg-gray-100 dark:hover:bg-gray-800 hover:border-blue-600"
+                            onClick={() => handleAddToQueue(song)}
+                          >
+                            <span className="material-icons text-base leading-none">
+                              playlist_add
+                            </span>
+                          </button>
+                        </Tooltip>
+                        <Tooltip text="Song Info">
+                          <button
+                            className="w-7 h-7 min-w-[28px] min-h-[28px] max-w-[28px] max-h-[28px] p-0 flex items-center justify-center bg-transparent border border-gray-200 dark:border-gray-700 rounded text-gray-700 dark:text-white cursor-pointer transition-all flex-shrink-0 hover:bg-gray-100 dark:hover:bg-gray-800 hover:border-blue-600"
+                            onClick={() => handleShowInfo(song)}
+                          >
+                            <span className="material-icons text-base leading-none">info</span>
+                          </button>
+                        </Tooltip>
                       </div>
                     </td>
                   </tr>

--- a/src/shared/components/LyricLine.jsx
+++ b/src/shared/components/LyricLine.jsx
@@ -16,8 +16,8 @@
  */
 
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { createPortal } from 'react-dom';
 import { PortalSelect } from './PortalSelect.jsx';
+import { Tooltip } from './Tooltip.jsx';
 
 // Singer options for the dropdown
 const SINGER_OPTIONS = [
@@ -37,43 +37,12 @@ const REPEAT_DELAY = 400;
 const REPEAT_INTERVAL = 80;
 
 /**
- * PortalTooltip - Tooltip that renders via portal for consistent positioning
- */
-function PortalTooltip({ text, targetRect, visible }) {
-  if (!visible || !targetRect) return null;
-
-  // Position tooltip above the button, centered
-  const style = {
-    position: 'fixed',
-    left: targetRect.left + targetRect.width / 2,
-    top: targetRect.top - 4,
-    transform: 'translate(-50%, -100%)',
-    zIndex: 10000,
-  };
-
-  return createPortal(
-    <div
-      style={style}
-      className="px-2 py-1 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded shadow-lg whitespace-nowrap pointer-events-none"
-    >
-      {text}
-      {/* Arrow pointing down */}
-      <div className="absolute left-1/2 -translate-x-1/2 top-full w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-gray-900 dark:border-t-gray-700" />
-    </div>,
-    document.body
-  );
-}
-
-/**
  * TimeAdjustButton - Button for adjusting time values with hold-to-repeat
  */
 function TimeAdjustButton({ direction, onAdjust, tooltip, isStart }) {
-  const [showTooltip, setShowTooltip] = useState(false);
-  const [tooltipRect, setTooltipRect] = useState(null);
-  const buttonRef = useRef(null);
+  const [repeating, setRepeating] = useState(false);
   const intervalRef = useRef(null);
   const timeoutRef = useRef(null);
-  const tooltipTimeoutRef = useRef(null);
 
   const doAdjust = useCallback(
     (e) => {
@@ -88,8 +57,8 @@ function TimeAdjustButton({ direction, onAdjust, tooltip, isStart }) {
     (e) => {
       // Prevent text selection during hold
       e.preventDefault();
-      // Hide tooltip during adjustment
-      setShowTooltip(false);
+      // Hide the hint while the button is doing its repeat gesture
+      setRepeating(true);
       // Do first adjustment immediately
       doAdjust(e);
 
@@ -106,6 +75,7 @@ function TimeAdjustButton({ direction, onAdjust, tooltip, isStart }) {
   );
 
   const stopRepeat = useCallback(() => {
+    setRepeating(false);
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
@@ -116,29 +86,9 @@ function TimeAdjustButton({ direction, onAdjust, tooltip, isStart }) {
     }
   }, []);
 
-  const handleMouseEnter = useCallback(() => {
-    // Delay tooltip show slightly to avoid flicker
-    tooltipTimeoutRef.current = setTimeout(() => {
-      if (buttonRef.current) {
-        setTooltipRect(buttonRef.current.getBoundingClientRect());
-        setShowTooltip(true);
-      }
-    }, 400);
-  }, []);
-
-  const handleMouseLeave = useCallback(() => {
-    if (tooltipTimeoutRef.current) {
-      clearTimeout(tooltipTimeoutRef.current);
-      tooltipTimeoutRef.current = null;
-    }
-    setShowTooltip(false);
-    stopRepeat();
-  }, [stopRepeat]);
-
   // Cleanup on unmount
   useEffect(() => {
     return () => {
-      if (tooltipTimeoutRef.current) clearTimeout(tooltipTimeoutRef.current);
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
@@ -156,21 +106,18 @@ function TimeAdjustButton({ direction, onAdjust, tooltip, isStart }) {
   const tooltipText = `${tooltip} (${shortcutKey}, shift for ±0.5s)`;
 
   return (
-    <>
+    <Tooltip text={tooltipText} suppressed={repeating}>
       <button
-        ref={buttonRef}
         type="button"
         className="w-6 h-7 flex items-center justify-center bg-gray-200 dark:bg-gray-600 hover:bg-blue-500 hover:text-white dark:hover:bg-blue-500 border border-gray-300 dark:border-gray-500 rounded text-gray-700 dark:text-gray-200 font-bold text-base cursor-pointer transition-colors select-none"
         onMouseDown={startRepeat}
         onMouseUp={stopRepeat}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
+        onMouseLeave={stopRepeat}
         onClick={(e) => e.stopPropagation()}
       >
         {symbol}
       </button>
-      <PortalTooltip text={tooltipText} targetRect={tooltipRect} visible={showTooltip} />
-    </>
+    </Tooltip>
   );
 }
 
@@ -179,48 +126,16 @@ function TimeAdjustButton({ direction, onAdjust, tooltip, isStart }) {
  * Wraps button in span to ensure tooltip works even when disabled
  */
 function IconButton({ icon, tooltip, onClick, className, disabled = false }) {
-  const [showTooltip, setShowTooltip] = useState(false);
-  const [tooltipRect, setTooltipRect] = useState(null);
-  const wrapperRef = useRef(null);
-  const tooltipTimeoutRef = useRef(null);
-
-  const handleMouseEnter = useCallback(() => {
-    tooltipTimeoutRef.current = setTimeout(() => {
-      if (wrapperRef.current) {
-        setTooltipRect(wrapperRef.current.getBoundingClientRect());
-        setShowTooltip(true);
-      }
-    }, 400);
-  }, []);
-
-  const handleMouseLeave = useCallback(() => {
-    if (tooltipTimeoutRef.current) {
-      clearTimeout(tooltipTimeoutRef.current);
-      tooltipTimeoutRef.current = null;
-    }
-    setShowTooltip(false);
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      if (tooltipTimeoutRef.current) clearTimeout(tooltipTimeoutRef.current);
-    };
-  }, []);
-
   return (
-    <>
-      <span
-        ref={wrapperRef}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-        className="inline-flex"
-      >
+    // The span wrapper keeps the hint working on a disabled button, which fires
+    // no pointer events of its own.
+    <Tooltip text={tooltip}>
+      <span className="inline-flex">
         <button type="button" className={className} disabled={disabled} onClick={onClick}>
           <span className="material-icons text-base">{icon}</span>
         </button>
       </span>
-      <PortalTooltip text={tooltip} targetRect={tooltipRect} visible={showTooltip} />
-    </>
+    </Tooltip>
   );
 }
 
@@ -228,49 +143,15 @@ function IconButton({ icon, tooltip, onClick, className, disabled = false }) {
  * LineNumberButton - Clickable line number with play functionality and tooltip
  */
 function LineNumberButton({ index, onClick }) {
-  const [showTooltip, setShowTooltip] = useState(false);
-  const [tooltipRect, setTooltipRect] = useState(null);
-  const buttonRef = useRef(null);
-  const tooltipTimeoutRef = useRef(null);
-
-  const handleMouseEnter = useCallback(() => {
-    tooltipTimeoutRef.current = setTimeout(() => {
-      if (buttonRef.current) {
-        setTooltipRect(buttonRef.current.getBoundingClientRect());
-        setShowTooltip(true);
-      }
-    }, 400);
-  }, []);
-
-  const handleMouseLeave = useCallback(() => {
-    if (tooltipTimeoutRef.current) {
-      clearTimeout(tooltipTimeoutRef.current);
-      tooltipTimeoutRef.current = null;
-    }
-    setShowTooltip(false);
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      if (tooltipTimeoutRef.current) clearTimeout(tooltipTimeoutRef.current);
-    };
-  }, []);
-
-  const tooltipText = `Play line ${index + 1} (p)`;
-
   return (
-    <>
+    <Tooltip text={`Play line ${index + 1} (p)`}>
       <span
-        ref={buttonRef}
         className="flex items-center justify-center min-w-[36px] h-9 bg-gray-200 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-sm font-semibold text-gray-700 dark:text-gray-200 cursor-pointer transition-all flex-shrink-0 hover:bg-blue-600 hover:text-white dark:hover:bg-blue-500"
         onClick={onClick}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
       >
         {index + 1}
       </span>
-      <PortalTooltip text={tooltipText} targetRect={tooltipRect} visible={showTooltip} />
-    </>
+    </Tooltip>
   );
 }
 
@@ -419,28 +300,31 @@ export function LyricLine({
           tooltip="Earlier"
           isStart={true}
         />
-        <input
-          type="number"
-          className={`w-[58px] px-1 py-1.5 bg-gray-100 dark:bg-gray-700 rounded text-gray-900 dark:text-white text-xs text-center font-mono focus:outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
-            hasOverlap
-              ? 'border-2 border-red-500 dark:border-red-400 focus:border-red-600 dark:focus:border-red-300'
-              : 'border border-gray-300 dark:border-gray-600 focus:border-blue-500 dark:focus:border-blue-400'
-          }`}
-          value={startDraft ?? startTime.toFixed(1)}
-          onChange={handleStartTimeChange}
-          onBlur={() => setStartDraft(null)}
-          step="0.1"
-          min="0"
-          onClick={(e) => {
-            e.stopPropagation();
-            onSelect(index);
-          }}
-          title={
+        <Tooltip
+          text={
             hasOverlap
               ? 'Warning: This line overlaps with the previous line for the same singer'
               : 'Start time (d/f to adjust)'
           }
-        />
+        >
+          <input
+            type="number"
+            className={`w-[58px] px-1 py-1.5 bg-gray-100 dark:bg-gray-700 rounded text-gray-900 dark:text-white text-xs text-center font-mono focus:outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
+              hasOverlap
+                ? 'border-2 border-red-500 dark:border-red-400 focus:border-red-600 dark:focus:border-red-300'
+                : 'border border-gray-300 dark:border-gray-600 focus:border-blue-500 dark:focus:border-blue-400'
+            }`}
+            value={startDraft ?? startTime.toFixed(1)}
+            onChange={handleStartTimeChange}
+            onBlur={() => setStartDraft(null)}
+            step="0.1"
+            min="0"
+            onClick={(e) => {
+              e.stopPropagation();
+              onSelect(index);
+            }}
+          />
+        </Tooltip>
         <TimeAdjustButton
           direction="increase"
           onAdjust={onAdjustStartTime}
@@ -457,20 +341,21 @@ export function LyricLine({
           tooltip="Earlier"
           isStart={false}
         />
-        <input
-          type="number"
-          className="w-[58px] px-1 py-1.5 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white text-xs text-center font-mono focus:outline-none focus:border-blue-500 dark:focus:border-blue-400 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-          value={endDraft ?? endTime.toFixed(1)}
-          onChange={handleEndTimeChange}
-          onBlur={() => setEndDraft(null)}
-          step="0.1"
-          min="0"
-          onClick={(e) => {
-            e.stopPropagation();
-            onSelect(index);
-          }}
-          title="End time (j/k to adjust)"
-        />
+        <Tooltip text="End time (j/k to adjust)">
+          <input
+            type="number"
+            className="w-[58px] px-1 py-1.5 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white text-xs text-center font-mono focus:outline-none focus:border-blue-500 dark:focus:border-blue-400 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+            value={endDraft ?? endTime.toFixed(1)}
+            onChange={handleEndTimeChange}
+            onBlur={() => setEndDraft(null)}
+            step="0.1"
+            min="0"
+            onClick={(e) => {
+              e.stopPropagation();
+              onSelect(index);
+            }}
+          />
+        </Tooltip>
         <TimeAdjustButton
           direction="increase"
           onAdjust={onAdjustEndTime}

--- a/src/shared/components/LyricRejection.jsx
+++ b/src/shared/components/LyricRejection.jsx
@@ -7,6 +7,8 @@
  * - Copy, Accept, Delete actions
  */
 
+import { Tooltip } from './Tooltip.jsx';
+
 export function LyricRejection({ rejection, rejectionIndex, onAccept, onDelete }) {
   const handleCopy = async () => {
     try {
@@ -24,13 +26,14 @@ export function LyricRejection({ rejection, rejectionIndex, onAccept, onDelete }
           <span className="material-icons">block</span>
           Rejected Update (Line {rejection.line_num})
         </span>
-        <button
-          className="p-1 hover:bg-red-100 dark:hover:bg-red-900 rounded transition"
-          title="Delete this rejection"
-          onClick={() => onDelete(rejectionIndex)}
-        >
-          <span className="material-icons text-gray-600 dark:text-gray-400">delete</span>
-        </button>
+        <Tooltip text="Delete this rejection">
+          <button
+            className="p-1 hover:bg-red-100 dark:hover:bg-red-900 rounded transition"
+            onClick={() => onDelete(rejectionIndex)}
+          >
+            <span className="material-icons text-gray-600 dark:text-gray-400">delete</span>
+          </button>
+        </Tooltip>
       </div>
       <div className="space-y-3">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
@@ -50,22 +53,24 @@ export function LyricRejection({ rejection, rejectionIndex, onAccept, onDelete }
               {rejection.new_text}
             </div>
             <div className="flex gap-2 mt-2">
-              <button
-                className="flex items-center gap-1 px-3 py-1.5 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 text-sm rounded-lg transition"
-                title="Copy proposed text"
-                onClick={handleCopy}
-              >
-                <span className="material-icons text-sm">content_copy</span>
-                Copy
-              </button>
-              <button
-                className="flex items-center gap-1 px-3 py-1.5 bg-green-600 hover:bg-green-700 text-white text-sm rounded-lg transition"
-                title="Accept proposed text and replace current lyric"
-                onClick={() => onAccept(rejectionIndex)}
-              >
-                <span className="material-icons text-sm">check_circle</span>
-                Accept
-              </button>
+              <Tooltip text="Copy proposed text">
+                <button
+                  className="flex items-center gap-1 px-3 py-1.5 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 text-sm rounded-lg transition"
+                  onClick={handleCopy}
+                >
+                  <span className="material-icons text-sm">content_copy</span>
+                  Copy
+                </button>
+              </Tooltip>
+              <Tooltip text="Accept proposed text and replace current lyric">
+                <button
+                  className="flex items-center gap-1 px-3 py-1.5 bg-green-600 hover:bg-green-700 text-white text-sm rounded-lg transition"
+                  onClick={() => onAccept(rejectionIndex)}
+                >
+                  <span className="material-icons text-sm">check_circle</span>
+                  Accept
+                </button>
+              </Tooltip>
             </div>
           </div>
         </div>

--- a/src/shared/components/LyricSuggestion.jsx
+++ b/src/shared/components/LyricSuggestion.jsx
@@ -7,6 +7,8 @@
  * - Add as New Line, Copy, Delete actions
  */
 
+import { Tooltip } from './Tooltip.jsx';
+
 function formatTime(seconds) {
   if (!seconds || isNaN(seconds)) return '0:00';
   const mins = Math.floor(seconds / 60);
@@ -34,13 +36,14 @@ export function LyricSuggestion({ suggestion, suggestionIndex, onAccept, onDelet
           <span className="material-icons">lightbulb</span>
           Suggested Missing Line ({startTime} - {endTime})
         </span>
-        <button
-          className="p-1 hover:bg-blue-100 dark:hover:bg-blue-900 rounded transition"
-          title="Delete this suggestion"
-          onClick={() => onDelete(suggestionIndex)}
-        >
-          <span className="material-icons text-gray-600 dark:text-gray-400">delete</span>
-        </button>
+        <Tooltip text="Delete this suggestion">
+          <button
+            className="p-1 hover:bg-blue-100 dark:hover:bg-blue-900 rounded transition"
+            onClick={() => onDelete(suggestionIndex)}
+          >
+            <span className="material-icons text-gray-600 dark:text-gray-400">delete</span>
+          </button>
+        </Tooltip>
       </div>
       <div className="space-y-3">
         <div>
@@ -57,22 +60,24 @@ export function LyricSuggestion({ suggestion, suggestionIndex, onAccept, onDelet
           {suggestion.pitch_activity && <span>Pitch Activity: {suggestion.pitch_activity}</span>}
         </div>
         <div className="flex gap-2">
-          <button
-            className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition"
-            title="Add this as a new lyric line"
-            onClick={() => onAccept(suggestionIndex)}
-          >
-            <span className="material-icons text-sm">add_circle</span>
-            Add as New Line
-          </button>
-          <button
-            className="flex items-center gap-2 px-4 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 rounded-lg transition"
-            title="Copy suggested text"
-            onClick={handleCopy}
-          >
-            <span className="material-icons text-sm">content_copy</span>
-            Copy Text
-          </button>
+          <Tooltip text="Add this as a new lyric line">
+            <button
+              className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition"
+              onClick={() => onAccept(suggestionIndex)}
+            >
+              <span className="material-icons text-sm">add_circle</span>
+              Add as New Line
+            </button>
+          </Tooltip>
+          <Tooltip text="Copy suggested text">
+            <button
+              className="flex items-center gap-2 px-4 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 rounded-lg transition"
+              onClick={handleCopy}
+            >
+              <span className="material-icons text-sm">content_copy</span>
+              Copy Text
+            </button>
+          </Tooltip>
         </div>
       </div>
     </div>

--- a/src/shared/components/MixerPanel.jsx
+++ b/src/shared/components/MixerPanel.jsx
@@ -6,6 +6,7 @@
  */
 
 import { StemStrip } from './StemStrip.jsx';
+import { Tooltip } from './Tooltip.jsx';
 import { resolveStemEntry, orderStems, CANONICAL_STEMS } from '../utils/stemGain.js';
 import { isMixdownStem } from '../utils/stemClassify.js';
 
@@ -87,11 +88,13 @@ export function MixerPanel({
                 onChange={(e) => handleGainChangeLocal(bus.id, e.target.value)}
                 onDoubleClick={(e) => handleDoubleClick(bus.id, e)}
                 data-bus={bus.id}
-                title="Master (double-click = 0 dB)"
               />
-              <span className="text-sm font-mono text-gray-700 dark:text-gray-300 w-16">
-                {gain.toFixed(1)} dB
-              </span>
+              {/* Hint on the readout, not the slider (see StemStrip). */}
+              <Tooltip text="Master (double-click = 0 dB)">
+                <span className="text-sm font-mono text-gray-700 dark:text-gray-300 w-16">
+                  {gain.toFixed(1)} dB
+                </span>
+              </Tooltip>
               <button
                 className={`px-3 py-1 rounded text-sm font-semibold transition ${
                   muted

--- a/src/shared/components/PlayerControls.jsx
+++ b/src/shared/components/PlayerControls.jsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useEffect, useRef } from 'react';
+import { Tooltip } from './Tooltip.jsx';
 import { formatDuration } from '../formatUtils.js';
 import { shiftKeyName, KEY_SHIFT_MIN, KEY_SHIFT_MAX } from '../utils/musicKey.js';
 
@@ -99,45 +100,48 @@ export function PlayerControls({
     >
       <div className="flex items-center gap-3">
         {/* Transport Controls */}
-        <button
-          onClick={onRestart}
-          title="Restart Track"
-          className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition disabled:opacity-50 flex items-center justify-center"
-          disabled={loading}
-        >
-          <span className="material-icons text-gray-700 dark:text-gray-300 text-2xl leading-none">
-            replay
-          </span>
-        </button>
-
-        <button
-          onClick={isPlaying ? onPause : onPlay}
-          data-gamepad-action="play-pause"
-          title={loading ? 'Loading...' : isPlaying ? 'Pause' : 'Play'}
-          className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition disabled:opacity-50 flex items-center justify-center"
-          disabled={loading}
-        >
-          {loading ? (
-            <span className="material-icons text-gray-700 dark:text-gray-300 text-2xl leading-none animate-spin">
-              hourglass_empty
+        <Tooltip text="Restart Track">
+          <button
+            onClick={onRestart}
+            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition disabled:opacity-50 flex items-center justify-center"
+            disabled={loading}
+          >
+            <span className="material-icons text-gray-700 dark:text-gray-300 text-2xl leading-none">
+              replay
             </span>
-          ) : (
-            <span className="material-icons text-blue-600 dark:text-blue-400 text-2xl leading-none">
-              {isPlaying ? 'pause' : 'play_arrow'}
-            </span>
-          )}
-        </button>
+          </button>
+        </Tooltip>
 
-        <button
-          onClick={onNext}
-          title="Next Track"
-          className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition disabled:opacity-50 flex items-center justify-center"
-          disabled={loading}
-        >
-          <span className="material-icons text-gray-700 dark:text-gray-300 text-2xl leading-none">
-            skip_next
-          </span>
-        </button>
+        <Tooltip text={loading ? 'Loading...' : isPlaying ? 'Pause' : 'Play'}>
+          <button
+            onClick={isPlaying ? onPause : onPlay}
+            data-gamepad-action="play-pause"
+            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition disabled:opacity-50 flex items-center justify-center"
+            disabled={loading}
+          >
+            {loading ? (
+              <span className="material-icons text-gray-700 dark:text-gray-300 text-2xl leading-none animate-spin">
+                hourglass_empty
+              </span>
+            ) : (
+              <span className="material-icons text-blue-600 dark:text-blue-400 text-2xl leading-none">
+                {isPlaying ? 'pause' : 'play_arrow'}
+              </span>
+            )}
+          </button>
+        </Tooltip>
+
+        <Tooltip text="Next Track">
+          <button
+            onClick={onNext}
+            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition disabled:opacity-50 flex items-center justify-center"
+            disabled={loading}
+          >
+            <span className="material-icons text-gray-700 dark:text-gray-300 text-2xl leading-none">
+              skip_next
+            </span>
+          </button>
+        </Tooltip>
 
         {/* Progress Bar */}
         <div className="flex-1 mx-4">
@@ -166,10 +170,7 @@ export function PlayerControls({
         {/* Key shift (issue #90): per-loaded-song, resets on load, never saved */}
         {onKeyShift && (
           <>
-            <div
-              className="flex items-center flex-shrink-0"
-              title="Key shift (music and guide vocal, never the mic)"
-            >
+            <div className="flex items-center flex-shrink-0">
               <button
                 onClick={() => onKeyShift(keyShift - 1)}
                 disabled={loading || keyShift <= KEY_SHIFT_MIN}
@@ -179,21 +180,23 @@ export function PlayerControls({
                   remove
                 </span>
               </button>
-              <span
-                className={`text-sm font-mono text-center px-0.5 ${
-                  keyShift !== 0
-                    ? 'text-blue-600 dark:text-blue-400 font-semibold'
-                    : 'text-gray-500 dark:text-gray-400'
-                }`}
-              >
-                {keyShift === 0
-                  ? songKey || 'Key'
-                  : `${keyShift > 0 ? '+' : ''}${keyShift}${
-                      songKey && shiftKeyName(songKey, keyShift)
-                        ? ` ${shiftKeyName(songKey, keyShift)}`
-                        : ''
-                    }`}
-              </span>
+              <Tooltip text="Key shift (music and guide vocal, never the mic)">
+                <span
+                  className={`text-sm font-mono text-center px-0.5 ${
+                    keyShift !== 0
+                      ? 'text-blue-600 dark:text-blue-400 font-semibold'
+                      : 'text-gray-500 dark:text-gray-400'
+                  }`}
+                >
+                  {keyShift === 0
+                    ? songKey || 'Key'
+                    : `${keyShift > 0 ? '+' : ''}${keyShift}${
+                        songKey && shiftKeyName(songKey, keyShift)
+                          ? ` ${shiftKeyName(songKey, keyShift)}`
+                          : ''
+                      }`}
+                </span>
+              </Tooltip>
               <button
                 onClick={() => onKeyShift(keyShift + 1)}
                 disabled={loading || keyShift >= KEY_SHIFT_MAX}
@@ -212,56 +215,60 @@ export function PlayerControls({
 
         {/* Effects Controls */}
         {onPreviousEffect && (
-          <button
-            onClick={onPreviousEffect}
-            title="Previous Effect"
-            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition flex items-center justify-center"
-          >
-            <span className="material-icons text-gray-700 dark:text-gray-300 leading-none">
-              chevron_left
-            </span>
-          </button>
+          <Tooltip text="Previous Effect">
+            <button
+              onClick={onPreviousEffect}
+              className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition flex items-center justify-center"
+            >
+              <span className="material-icons text-gray-700 dark:text-gray-300 leading-none">
+                chevron_left
+              </span>
+            </button>
+          </Tooltip>
         )}
-        <span
-          className="px-3 py-1 bg-gray-100 dark:bg-gray-900 text-gray-700 dark:text-gray-300 rounded-lg text-sm font-medium min-w-[120px] text-center"
-          title={currentEffect || 'No Effect'}
-        >
-          {truncateEffectName(currentEffect || 'No Effect')}
-        </span>
+        {/* Full name on hover: the label itself is truncated to 28 chars. */}
+        <Tooltip text={currentEffect || 'No Effect'}>
+          <span className="px-3 py-1 bg-gray-100 dark:bg-gray-900 text-gray-700 dark:text-gray-300 rounded-lg text-sm font-medium min-w-[120px] text-center">
+            {truncateEffectName(currentEffect || 'No Effect')}
+          </span>
+        </Tooltip>
         {onNextEffect && (
-          <button
-            onClick={onNextEffect}
-            title="Next Effect"
-            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition flex items-center justify-center"
-          >
-            <span className="material-icons text-gray-700 dark:text-gray-300 leading-none">
-              chevron_right
-            </span>
-          </button>
+          <Tooltip text="Next Effect">
+            <button
+              onClick={onNextEffect}
+              className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition flex items-center justify-center"
+            >
+              <span className="material-icons text-gray-700 dark:text-gray-300 leading-none">
+                chevron_right
+              </span>
+            </button>
+          </Tooltip>
         )}
         {onOpenCanvasWindow && (
-          <button
-            onClick={onOpenCanvasWindow}
-            data-gamepad-skip="external"
-            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition flex items-center justify-center"
-            title="Open Canvas Window"
-          >
-            <span className="material-icons text-gray-700 dark:text-gray-300 leading-none">
-              open_in_new
-            </span>
-          </button>
+          <Tooltip text="Open Canvas Window">
+            <button
+              onClick={onOpenCanvasWindow}
+              data-gamepad-skip="external"
+              className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition flex items-center justify-center"
+            >
+              <span className="material-icons text-gray-700 dark:text-gray-300 leading-none">
+                open_in_new
+              </span>
+            </button>
+          </Tooltip>
         )}
         {onOpenViewer && (
-          <button
-            onClick={onOpenViewer}
-            data-gamepad-skip="external"
-            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition flex items-center justify-center"
-            title="Open Browser Viewer"
-          >
-            <span className="material-icons text-gray-700 dark:text-gray-300 leading-none">
-              open_in_new
-            </span>
-          </button>
+          <Tooltip text="Open Browser Viewer">
+            <button
+              onClick={onOpenViewer}
+              data-gamepad-skip="external"
+              className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition flex items-center justify-center"
+            >
+              <span className="material-icons text-gray-700 dark:text-gray-300 leading-none">
+                open_in_new
+              </span>
+            </button>
+          </Tooltip>
         )}
       </div>
     </div>

--- a/src/shared/components/QueueList.jsx
+++ b/src/shared/components/QueueList.jsx
@@ -5,75 +5,24 @@
  * Works with both ElectronBridge and WebBridge via callbacks
  */
 
-import { useState, useRef, useCallback } from 'react';
+import { useState } from 'react';
 import { useConfirm } from '../hooks/useConfirm.jsx';
-import { createPortal } from 'react-dom';
+import { Tooltip } from './Tooltip.jsx';
 
 /**
- * PortalTooltip - Tooltip that renders via portal for consistent positioning on Wayland
- */
-function PortalTooltip({ text, targetRect, visible }) {
-  if (!visible || !targetRect) return null;
-
-  const style = {
-    position: 'fixed',
-    left: targetRect.left + targetRect.width / 2,
-    top: targetRect.top - 4,
-    transform: 'translate(-50%, -100%)',
-    zIndex: 10000,
-  };
-
-  return createPortal(
-    <div
-      style={style}
-      className="px-2 py-1 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded shadow-lg whitespace-nowrap pointer-events-none"
-    >
-      {text}
-      <div className="absolute left-1/2 -translate-x-1/2 top-full w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-gray-900 dark:border-t-gray-700" />
-    </div>,
-    document.body
-  );
-}
-
-/**
- * TooltipButton - Button with portal-based tooltip
+ * TooltipButton - icon button with a hint.
+ *
+ * The tooltip used to be hand-rolled here (this file predates the shared
+ * component); it now delegates, which also fixes the stale-anchor drift the
+ * local copy had.
  */
 function TooltipButton({ icon, tooltip, onClick, className, iconSize = 'text-base' }) {
-  const [showTooltip, setShowTooltip] = useState(false);
-  const [tooltipRect, setTooltipRect] = useState(null);
-  const buttonRef = useRef(null);
-  const tooltipTimeoutRef = useRef(null);
-
-  const handleMouseEnter = useCallback(() => {
-    tooltipTimeoutRef.current = setTimeout(() => {
-      if (buttonRef.current) {
-        setTooltipRect(buttonRef.current.getBoundingClientRect());
-        setShowTooltip(true);
-      }
-    }, 400);
-  }, []);
-
-  const handleMouseLeave = useCallback(() => {
-    if (tooltipTimeoutRef.current) {
-      clearTimeout(tooltipTimeoutRef.current);
-      tooltipTimeoutRef.current = null;
-    }
-    setShowTooltip(false);
-  }, []);
-
   return (
-    <>
-      <button
-        ref={buttonRef}
-        onClick={onClick}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-        className={className}
-      >
+    <Tooltip text={tooltip}>
+      <button onClick={onClick} className={className}>
         <span className={`material-icons ${iconSize}`}>{icon}</span>
       </button>
-      <PortalTooltip text={tooltip} targetRect={tooltipRect} visible={showTooltip} />
-    </>
+    </Tooltip>
   );
 }
 
@@ -309,19 +258,18 @@ export function QueueList({
                 {index + 1}
               </div>
               <div className="flex-1 min-w-0">
-                <div
-                  className="font-medium text-gray-900 dark:text-white whitespace-nowrap overflow-hidden text-ellipsis mb-0.5 text-sm"
-                  title={item.title}
-                >
-                  {item.title}
-                </div>
-                <div
-                  className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap overflow-hidden text-ellipsis"
-                  title={`${item.artist}${requesterText}`}
-                >
-                  {item.artist}
-                  {requesterText}
-                </div>
+                {/* Hover reveals the full text: these lines are ellipsized. */}
+                <Tooltip text={item.title}>
+                  <div className="font-medium text-gray-900 dark:text-white whitespace-nowrap overflow-hidden text-ellipsis mb-0.5 text-sm">
+                    {item.title}
+                  </div>
+                </Tooltip>
+                <Tooltip text={`${item.artist}${requesterText}`}>
+                  <div className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap overflow-hidden text-ellipsis">
+                    {item.artist}
+                    {requesterText}
+                  </div>
+                </Tooltip>
               </div>
               <div className="flex gap-1 flex-shrink-0">
                 {/* Up/Down reorder buttons - only show if more than one item */}

--- a/src/shared/components/QuickSearch.jsx
+++ b/src/shared/components/QuickSearch.jsx
@@ -5,6 +5,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { getFormatIcon } from '../formatUtils.js';
+import { Tooltip } from './Tooltip.jsx';
 
 export function QuickSearch({ bridge, requester = 'KJ' }) {
   const [searchResults, setSearchResults] = useState([]);
@@ -107,15 +108,16 @@ export function QuickSearch({ bridge, requester = 'KJ' }) {
                     {song.artist}
                   </div>
                 </div>
-                <button
-                  className="p-2 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition flex-shrink-0"
-                  onClick={() => handleAddFromSearch(song)}
-                  title="Add to Queue"
-                >
-                  <span className="material-icons text-gray-700 dark:text-gray-300">
-                    playlist_add
-                  </span>
-                </button>
+                <Tooltip text="Add to Queue">
+                  <button
+                    className="p-2 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition flex-shrink-0"
+                    onClick={() => handleAddFromSearch(song)}
+                  >
+                    <span className="material-icons text-gray-700 dark:text-gray-300">
+                      playlist_add
+                    </span>
+                  </button>
+                </Tooltip>
               </div>
             ))
           )}

--- a/src/shared/components/SongEditor.jsx
+++ b/src/shared/components/SongEditor.jsx
@@ -21,6 +21,7 @@ import { Toast } from './Toast.jsx';
 import { LyricRejection } from './LyricRejection.jsx';
 import { LyricSuggestion } from './LyricSuggestion.jsx';
 import { splitLine, canSplitLine } from '../utils/lyricsUtils.js';
+import { Tooltip } from './Tooltip.jsx';
 
 // m:ss.t readout for the playback transport (tenths: precise enough to line up
 // lyric timing by eye, stable enough not to flicker at rAF update rate).
@@ -1315,16 +1316,15 @@ export function SongEditor({ bridge }) {
                   </button>
                   {/* Elapsed time (issue #67 request): tenths so lyric timing can be
                         checked against the start/end numbers while playing. */}
-                  <span
-                    className="font-mono text-xs text-gray-900 dark:text-white tabular-nums px-1.5 whitespace-nowrap"
-                    title={`${currentPosition.toFixed(2)}s`}
-                  >
-                    {formatEditorTime(currentPosition)}
-                    <span className="text-gray-500 dark:text-gray-400">
-                      {' / '}
-                      {formatEditorTime(songDuration)}
+                  <Tooltip text={`${currentPosition.toFixed(2)}s`}>
+                    <span className="font-mono text-xs text-gray-900 dark:text-white tabular-nums px-1.5 whitespace-nowrap">
+                      {formatEditorTime(currentPosition)}
+                      <span className="text-gray-500 dark:text-gray-400">
+                        {' / '}
+                        {formatEditorTime(songDuration)}
+                      </span>
                     </span>
-                  </span>
+                  </Tooltip>
                   <div className="flex gap-1.5 flex-wrap flex-1 items-center">
                     {audioElements.map((el, index) => (
                       <div
@@ -1334,49 +1334,63 @@ export function SongEditor({ bridge }) {
                         <span className="text-[11px] font-semibold text-gray-900 dark:text-white min-w-[45px]">
                           {el.name}
                         </span>
-                        <button
-                          onClick={() => toggleMute(index)}
-                          className={`flex items-center justify-center w-6 h-6 p-0.5 rounded cursor-pointer transition-colors ${el.muted ? 'bg-red-600 text-white hover:bg-red-700' : 'bg-green-600 text-white hover:bg-green-700'}`}
-                          title={el.muted ? 'Unmute' : 'Mute'}
-                        >
-                          <span className="material-icons text-sm">
-                            {el.muted ? 'volume_off' : 'volume_up'}
-                          </span>
-                        </button>
+                        <Tooltip text={el.muted ? 'Unmute' : 'Mute'}>
+                          <button
+                            onClick={() => toggleMute(index)}
+                            className={`flex items-center justify-center w-6 h-6 p-0.5 rounded cursor-pointer transition-colors ${el.muted ? 'bg-red-600 text-white hover:bg-red-700' : 'bg-green-600 text-white hover:bg-green-700'}`}
+                          >
+                            <span className="material-icons text-sm">
+                              {el.muted ? 'volume_off' : 'volume_up'}
+                            </span>
+                          </button>
+                        </Tooltip>
                       </div>
                     ))}
                   </div>
-                  <button
-                    onClick={handleExportLyrics}
-                    className="flex items-center gap-1.5 px-3 py-1 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white cursor-pointer text-xs transition-colors hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
-                    disabled={!lyricsData || lyricsData.length === 0}
-                    title="Export lyrics as text file"
-                  >
-                    <span className="material-icons text-base">download</span>
-                    Export
-                  </button>
-                  <button
-                    onClick={handleResetLyrics}
-                    className="flex items-center gap-1.5 px-3 py-1 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white cursor-pointer text-xs transition-colors hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
-                    disabled={!hasChanges}
-                    title="Reset to original lyrics"
-                  >
-                    <span className="material-icons text-base">restore</span>
-                    Reset
-                  </button>
-                  <button
-                    onClick={handleAddLineAtStart}
-                    className="flex items-center gap-1.5 px-3 py-1 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white cursor-pointer text-xs transition-colors hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
-                    disabled={!canAddLineAtStart()}
-                    title={
+                  {/* Wrapped in a span: these go disabled, and a disabled button
+                      emits no pointer events for the tooltip to hang off. */}
+                  <Tooltip text="Export lyrics as text file">
+                    <span className="inline-flex">
+                      <button
+                        onClick={handleExportLyrics}
+                        className="flex items-center gap-1.5 px-3 py-1 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white cursor-pointer text-xs transition-colors hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                        disabled={!lyricsData || lyricsData.length === 0}
+                      >
+                        <span className="material-icons text-base">download</span>
+                        Export
+                      </button>
+                    </span>
+                  </Tooltip>
+                  <Tooltip text="Reset to original lyrics">
+                    <span className="inline-flex">
+                      <button
+                        onClick={handleResetLyrics}
+                        className="flex items-center gap-1.5 px-3 py-1 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white cursor-pointer text-xs transition-colors hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                        disabled={!hasChanges}
+                      >
+                        <span className="material-icons text-base">restore</span>
+                        Reset
+                      </button>
+                    </span>
+                  </Tooltip>
+                  <Tooltip
+                    text={
                       canAddLineAtStart()
                         ? 'Add line at beginning'
                         : 'Not enough space (need 0.6s gap)'
                     }
                   >
-                    <span className="material-icons text-base">add</span>
-                    Add First Line
-                  </button>
+                    <span className="inline-flex">
+                      <button
+                        onClick={handleAddLineAtStart}
+                        className="flex items-center gap-1.5 px-3 py-1 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-white cursor-pointer text-xs transition-colors hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                        disabled={!canAddLineAtStart()}
+                      >
+                        <span className="material-icons text-base">add</span>
+                        Add First Line
+                      </button>
+                    </span>
+                  </Tooltip>
                 </div>
               )}
 

--- a/src/shared/components/SongInfoBar.jsx
+++ b/src/shared/components/SongInfoBar.jsx
@@ -7,6 +7,7 @@
 
 import { getFormatIcon } from '../formatUtils.js';
 import { ThemeToggle } from './ThemeToggle.jsx';
+import { Tooltip } from './Tooltip.jsx';
 
 export function SongInfoBar({
   currentSong,
@@ -29,42 +30,43 @@ export function SongInfoBar({
     >
       <div className="flex items-center">
         {onMenuClick && (
-          <button
-            onClick={onMenuClick}
-            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition flex items-center justify-center"
-            title={sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
-            aria-label={sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
-          >
-            {sidebarCollapsed ? (
-              <svg
-                className="w-5 h-5 text-gray-700 dark:text-gray-300"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M4 6h16M4 12h16m-7 6h7"
-                />
-              </svg>
-            ) : (
-              <svg
-                className="w-5 h-5 text-gray-700 dark:text-gray-300"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M4 6h16M4 12h16M4 18h16"
-                />
-              </svg>
-            )}
-          </button>
+          <Tooltip text={sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}>
+            <button
+              onClick={onMenuClick}
+              className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition flex items-center justify-center"
+              aria-label={sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
+            >
+              {sidebarCollapsed ? (
+                <svg
+                  className="w-5 h-5 text-gray-700 dark:text-gray-300"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 6h16M4 12h16m-7 6h7"
+                  />
+                </svg>
+              ) : (
+                <svg
+                  className="w-5 h-5 text-gray-700 dark:text-gray-300"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 6h16M4 12h16M4 18h16"
+                  />
+                </svg>
+              )}
+            </button>
+          </Tooltip>
         )}
       </div>
       <div className="flex-1 flex items-center justify-center">

--- a/src/shared/components/StemStrip.jsx
+++ b/src/shared/components/StemStrip.jsx
@@ -6,6 +6,8 @@
  * gain state — two mounted views of one fader must never diverge, §11.13).
  */
 
+import { Tooltip } from './Tooltip.jsx';
+
 export function StemStrip({
   bus,
   name,
@@ -35,21 +37,25 @@ export function StemStrip({
         disabled={disabled}
         onChange={(e) => onGain?.(bus, name, parseInt(e.target.value, 10) / 100)}
         onDoubleClick={() => onGain?.(bus, name, 1)}
-        title={`${name} on ${bus}: ${pct}% (double-click = 100%)`}
       />
-      <div className="text-[11px] font-mono text-gray-600 dark:text-gray-400">{pct}%</div>
-      <button
-        className={`px-2 py-0.5 rounded text-[11px] font-semibold transition ${
-          muted
-            ? 'bg-red-600 hover:bg-red-700 text-white'
-            : 'bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100'
-        }`}
-        disabled={disabled}
-        onClick={() => onMute?.(bus, name, !muted)}
-        title={muted ? 'Unmute' : 'Mute'}
-      >
-        {muted ? 'MUTED' : 'ON'}
-      </button>
+      {/* The hint rides the readout, not the slider: a bubble anchored to the
+          track would sit under the cursor mid-drag. */}
+      <Tooltip text={`${name} on ${bus}: ${pct}% (double-click = 100%)`}>
+        <div className="text-[11px] font-mono text-gray-600 dark:text-gray-400">{pct}%</div>
+      </Tooltip>
+      <Tooltip text={muted ? 'Unmute' : 'Mute'}>
+        <button
+          className={`px-2 py-0.5 rounded text-[11px] font-semibold transition ${
+            muted
+              ? 'bg-red-600 hover:bg-red-700 text-white'
+              : 'bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100'
+          }`}
+          disabled={disabled}
+          onClick={() => onMute?.(bus, name, !muted)}
+        >
+          {muted ? 'MUTED' : 'ON'}
+        </button>
+      </Tooltip>
     </div>
   );
 }

--- a/src/shared/components/ThemeToggle.jsx
+++ b/src/shared/components/ThemeToggle.jsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useEffect } from 'react';
+import { Tooltip } from './Tooltip.jsx';
 
 export function ThemeToggle({ className = '' }) {
   const [theme, setTheme] = useState('dark');
@@ -94,13 +95,14 @@ export function ThemeToggle({ className = '' }) {
   };
 
   return (
-    <button
-      onClick={cycleTheme}
-      className={`p-2 rounded-lg transition-colors hover:bg-gray-200 dark:hover:bg-gray-700 ${className}`}
-      title={getTitle()}
-      aria-label={getTitle()}
-    >
-      {getIcon()}
-    </button>
+    <Tooltip text={getTitle()}>
+      <button
+        onClick={cycleTheme}
+        className={`p-2 rounded-lg transition-colors hover:bg-gray-200 dark:hover:bg-gray-700 ${className}`}
+        aria-label={getTitle()}
+      >
+        {getIcon()}
+      </button>
+    </Tooltip>
   );
 }

--- a/src/shared/components/Tooltip.jsx
+++ b/src/shared/components/Tooltip.jsx
@@ -1,0 +1,192 @@
+/**
+ * Tooltip - hover/focus hint rendered by React instead of the OS.
+ *
+ * DESIGN EXCEPTION, same family as PortalSelect: we prefer native HTML, but a
+ * `title` attribute is not drawn by the page at all — Chromium asks the OS for
+ * a popup surface, and those are broken on Electron's native Wayland (the same
+ * bug class as electron#44607, which is why PortalSelect exists). The symptom
+ * is a tooltip that flashes and vanishes instead of staying put.
+ *
+ * Rendering the hint into document.body keeps it inside Chromium's own
+ * compositing, so it behaves identically on every platform and can be styled
+ * and dark-mode aware.
+ *
+ * Usage — wrap the trigger, don't pass a `title`:
+ *   <Tooltip text="Next Track">
+ *     <button onClick={next}>…</button>
+ *   </Tooltip>
+ *
+ * The child is cloned with the hover/focus handlers and a ref, so it must be a
+ * single element that forwards DOM props (a plain tag, or a component that
+ * spreads the rest onto its root). Focus is a first-class trigger, which the
+ * gamepad focus ring gets for free.
+ *
+ * This workaround should be removed when Electron fixes Wayland popups.
+ */
+
+import React, {
+  useState,
+  useRef,
+  useCallback,
+  useEffect,
+  cloneElement,
+  isValidElement,
+} from 'react';
+import { createPortal } from 'react-dom';
+
+const SHOW_DELAY_MS = 400;
+const GAP_PX = 6;
+const VIEWPORT_MARGIN_PX = 8;
+
+/** True for controls where focus means "typing here", not "highlighted". */
+function isTextEntry(el) {
+  if (!el) return false;
+  const tag = el.tagName;
+  if (tag === 'TEXTAREA') return true;
+  if (tag !== 'INPUT') return el.isContentEditable === true;
+  // Checkboxes/radios/buttons take focus without accepting text.
+  return !['checkbox', 'radio', 'button', 'submit', 'reset', 'range'].includes(el.type);
+}
+
+/** Clamp horizontally so a tooltip near a screen edge stays fully on screen. */
+function clampToViewport(left, width) {
+  const max = window.innerWidth - VIEWPORT_MARGIN_PX - width / 2;
+  const min = VIEWPORT_MARGIN_PX + width / 2;
+  return Math.min(Math.max(left, min), max);
+}
+
+/**
+ * @param suppressed - force-hide while the caller is mid-gesture (a
+ *   hold-to-repeat button shouldn't keep a bubble over the control it repeats).
+ */
+export function Tooltip({
+  text,
+  children,
+  placement = 'top',
+  delay = SHOW_DELAY_MS,
+  suppressed = false,
+}) {
+  const [rect, setRect] = useState(null);
+  const triggerRef = useRef(null);
+  const timerRef = useRef(null);
+  const bubbleRef = useRef(null);
+  const [bubbleWidth, setBubbleWidth] = useState(0);
+
+  const hide = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setRect(null);
+  }, []);
+
+  const show = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      // Measure at show time, not on mount: the trigger may have scrolled or
+      // been laid out since. (The previous per-file tooltip captured this once
+      // and drifted.)
+      if (triggerRef.current) {
+        setRect(triggerRef.current.getBoundingClientRect());
+      }
+    }, delay);
+  }, [delay]);
+
+  // Clear the pending timer if we unmount mid-hover.
+  useEffect(() => () => timerRef.current && clearTimeout(timerRef.current), []);
+
+  // Caller took over (e.g. a press-and-hold started): drop the bubble.
+  useEffect(() => {
+    if (suppressed) hide();
+  }, [suppressed, hide]);
+
+  // A visible tooltip is anchored to a rect that scrolling or resizing
+  // invalidates; drop it rather than leave it floating somewhere wrong.
+  useEffect(() => {
+    if (!rect) return;
+    window.addEventListener('scroll', hide, true);
+    window.addEventListener('resize', hide);
+    return () => {
+      window.removeEventListener('scroll', hide, true);
+      window.removeEventListener('resize', hide);
+    };
+  }, [rect, hide]);
+
+  useEffect(() => {
+    if (rect && bubbleRef.current) {
+      setBubbleWidth(bubbleRef.current.offsetWidth);
+    }
+  }, [rect, text]);
+
+  if (!isValidElement(children)) return children ?? null;
+  // No text means no tooltip, but the child must still render.
+  if (!text) return children;
+
+  // React 19: ref is a regular prop, so read it from props (children.ref is gone).
+  const childRef = children.props.ref;
+
+  const trigger = cloneElement(children, {
+    ref: (node) => {
+      triggerRef.current = node;
+      if (typeof childRef === 'function') childRef(node);
+      else if (childRef && typeof childRef === 'object') childRef.current = node;
+    },
+    onMouseEnter: (e) => {
+      children.props.onMouseEnter?.(e);
+      show();
+    },
+    onMouseLeave: (e) => {
+      children.props.onMouseLeave?.(e);
+      hide();
+    },
+    onFocus: (e) => {
+      children.props.onFocus?.(e);
+      // Keyboard focus should reveal the hint (that's how the gamepad ring gets
+      // it), but not on a field you're typing into — the bubble would sit over
+      // the text. Hover still works on those.
+      if (!isTextEntry(e.currentTarget)) show();
+    },
+    onBlur: (e) => {
+      children.props.onBlur?.(e);
+      hide();
+    },
+    // A click means the user acted; the hint has served its purpose.
+    onClick: (e) => {
+      children.props.onClick?.(e);
+      hide();
+    },
+  });
+
+  const visible = rect && !suppressed;
+  const above = placement !== 'bottom';
+  const style = visible
+    ? {
+        position: 'fixed',
+        left: bubbleWidth
+          ? clampToViewport(rect.left + rect.width / 2, bubbleWidth)
+          : rect.left + rect.width / 2,
+        top: above ? rect.top - GAP_PX : rect.bottom + GAP_PX,
+        transform: above ? 'translate(-50%, -100%)' : 'translate(-50%, 0)',
+        zIndex: 10000,
+      }
+    : null;
+
+  return (
+    <>
+      {trigger}
+      {visible &&
+        createPortal(
+          <div
+            ref={bubbleRef}
+            role="tooltip"
+            style={style}
+            className="px-2 py-1 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded shadow-lg whitespace-nowrap pointer-events-none"
+          >
+            {text}
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}

--- a/src/shared/components/Tooltip.test.jsx
+++ b/src/shared/components/Tooltip.test.jsx
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { Tooltip } from './Tooltip.jsx';
+
+describe('Tooltip', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const hoverIn = (el) => fireEvent.mouseEnter(el);
+  const settle = (ms = 400) => act(() => vi.advanceTimersByTime(ms));
+
+  it('does not show before the delay elapses', () => {
+    render(
+      <Tooltip text="Next Track">
+        <button>next</button>
+      </Tooltip>
+    );
+    hoverIn(screen.getByRole('button'));
+    settle(200);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('shows after the delay and stays visible', () => {
+    render(
+      <Tooltip text="Next Track">
+        <button>next</button>
+      </Tooltip>
+    );
+    hoverIn(screen.getByRole('button'));
+    settle();
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Next Track');
+
+    // The flashing bug: it must still be there once time keeps passing.
+    settle(3000);
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Next Track');
+  });
+
+  it('hides on mouse leave', () => {
+    render(
+      <Tooltip text="Next Track">
+        <button>next</button>
+      </Tooltip>
+    );
+    const btn = screen.getByRole('button');
+    hoverIn(btn);
+    settle();
+    fireEvent.mouseLeave(btn);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('cancels a pending tooltip when the pointer leaves early', () => {
+    render(
+      <Tooltip text="Next Track">
+        <button>next</button>
+      </Tooltip>
+    );
+    const btn = screen.getByRole('button');
+    hoverIn(btn);
+    settle(200);
+    fireEvent.mouseLeave(btn);
+    settle(1000);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('shows on keyboard focus and hides on blur (gamepad focus ring)', () => {
+    render(
+      <Tooltip text="Restart Track">
+        <button>restart</button>
+      </Tooltip>
+    );
+    const btn = screen.getByRole('button');
+    fireEvent.focus(btn);
+    settle();
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Restart Track');
+    fireEvent.blur(btn);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('preserves the child onClick and dismisses the hint', () => {
+    const onClick = vi.fn();
+    render(
+      <Tooltip text="Pause">
+        <button onClick={onClick}>pause</button>
+      </Tooltip>
+    );
+    const btn = screen.getByRole('button');
+    hoverIn(btn);
+    settle();
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it("preserves the child's own hover handlers", () => {
+    const onMouseEnter = vi.fn();
+    render(
+      <Tooltip text="Mute">
+        <button onMouseEnter={onMouseEnter}>mute</button>
+      </Tooltip>
+    );
+    hoverIn(screen.getByRole('button'));
+    expect(onMouseEnter).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the child unchanged when text is empty', () => {
+    render(
+      <Tooltip text="">
+        <button>bare</button>
+      </Tooltip>
+    );
+    hoverIn(screen.getByRole('button'));
+    settle();
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('hides on scroll, since the anchor rect is stale', () => {
+    render(
+      <Tooltip text="Add to Queue">
+        <button>add</button>
+      </Tooltip>
+    );
+    hoverIn(screen.getByRole('button'));
+    settle();
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('does not leave a timer running after unmount', () => {
+    const { unmount } = render(
+      <Tooltip text="Shuffle">
+        <button>shuffle</button>
+      </Tooltip>
+    );
+    hoverIn(screen.getByRole('button'));
+    unmount();
+    // Would throw on a setState-after-unmount if the timer survived.
+    expect(() => settle(1000)).not.toThrow();
+  });
+
+  it('does not show on focus for a text-entry field (bubble would cover the text)', () => {
+    render(
+      <Tooltip text="Start time (d/f to adjust)">
+        <input type="number" />
+      </Tooltip>
+    );
+    const input = screen.getByRole('spinbutton');
+    fireEvent.focus(input);
+    settle();
+    expect(screen.queryByRole('tooltip')).toBeNull();
+
+    // Hover still reveals it.
+    hoverIn(input);
+    settle();
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+  });
+
+  it('still shows on focus for a checkbox (focus is highlight, not typing)', () => {
+    render(
+      <Tooltip text="Vocals in Mono">
+        <input type="checkbox" />
+      </Tooltip>
+    );
+    fireEvent.focus(screen.getByRole('checkbox'));
+    settle();
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+  });
+
+  it('hides while suppressed (hold-to-repeat gesture)', () => {
+    const { rerender } = render(
+      <Tooltip text="Earlier" suppressed={false}>
+        <button>earlier</button>
+      </Tooltip>
+    );
+    hoverIn(screen.getByRole('button'));
+    settle();
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    rerender(
+      <Tooltip text="Earlier" suppressed={true}>
+        <button>earlier</button>
+      </Tooltip>
+    );
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('forwards a ref the caller put on the child', () => {
+    const ref = { current: null };
+    render(
+      <Tooltip text="Master">
+        <button ref={ref}>master</button>
+      </Tooltip>
+    );
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+  });
+});

--- a/src/web/components/SongSearch.jsx
+++ b/src/web/components/SongSearch.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { getFormatIcon, formatDuration } from '../../shared/formatUtils.js';
+import { Tooltip } from '../../shared/components/Tooltip.jsx';
 
 export function SongSearch({ onAddToQueue }) {
   const [searchTerm, setSearchTerm] = useState('');
@@ -146,20 +147,22 @@ export function SongSearch({ onAddToQueue }) {
                     </div>
                   </div>
                   <div className="flex gap-2 flex-shrink-0">
-                    <button
-                      className="btn btn-sm min-w-[32px] px-2 py-1 text-base font-semibold bg-blue-600 dark:bg-blue-500 border-blue-600 dark:border-blue-500 text-white hover:bg-blue-700 dark:hover:bg-blue-600"
-                      onClick={() => handleLoadSong(song)}
-                      title="Load & Play Now"
-                    >
-                      ▶
-                    </button>
-                    <button
-                      className="btn btn-sm min-w-[32px] px-2 py-1 text-base font-semibold bg-green-600 dark:bg-green-500 border-green-600 dark:border-green-500 text-white hover:bg-green-700 dark:hover:bg-green-600"
-                      onClick={() => handleAddToQueue(song)}
-                      title="Add to Queue"
-                    >
-                      +
-                    </button>
+                    <Tooltip text="Load & Play Now">
+                      <button
+                        className="btn btn-sm min-w-[32px] px-2 py-1 text-base font-semibold bg-blue-600 dark:bg-blue-500 border-blue-600 dark:border-blue-500 text-white hover:bg-blue-700 dark:hover:bg-blue-600"
+                        onClick={() => handleLoadSong(song)}
+                      >
+                        ▶
+                      </button>
+                    </Tooltip>
+                    <Tooltip text="Add to Queue">
+                      <button
+                        className="btn btn-sm min-w-[32px] px-2 py-1 text-base font-semibold bg-green-600 dark:bg-green-500 border-green-600 dark:border-green-500 text-white hover:bg-green-700 dark:hover:bg-green-600"
+                        onClick={() => handleAddToQueue(song)}
+                      >
+                        +
+                      </button>
+                    </Tooltip>
                   </div>
                 </div>
               ))}


### PR DESCRIPTION
## Why tooltips flashed

A `title` attribute is not drawn by the page. Chromium asks the OS for a popup surface, and those are broken on Electron's native Wayland — the same bug class as [electron#44607](https://github.com/electron/electron/issues/44607), which is exactly why `PortalSelect.jsx` already exists in this repo for `<select>` dropdowns.

So this had been hit before, twice, and worked around locally each time: `QueueList`'s `TooltipButton`, plus **three separate copies** of the same portal tooltip inside `LyricLine`. What never happened was generalizing it — 40 other hints across 15 components were still plain `title=`, including every transport button in `PlayerControls`.

## What this does

Adds `src/shared/components/Tooltip.jsx` and converts every site. Usage is wrap-the-trigger:

```jsx
<Tooltip text="Next Track">
  <button onClick={next}>…</button>
</Tooltip>
```

Beyond fixing Wayland, it picks up what the hand-rolled copies lacked:

- **measures the anchor at show time**, so a scrolled trigger isn't positioned from a stale rect (the old copies captured it once on hover and drifted)
- **drops the bubble on scroll/resize** instead of leaving it floating somewhere wrong
- **clamps horizontally** so a hint near a screen edge stays fully on screen
- **shows on keyboard focus**, so the gamepad focus ring gets hints for free — except on text-entry fields, where a bubble would cover what you're typing (hover still works there)
- **`suppressed`** for hold-to-repeat controls: `LyricLine`'s time nudgers hide the hint mid-gesture
- **disabled buttons keep their hint** via a span wrapper, since a disabled button emits no pointer events

Sliders and multi-control clusters (`StemStrip`, `MixerPanel`) put the hint on the **readout** rather than the track, so it can't sit under the cursor mid-drag.

Net **−104 lines** despite adding a component plus tests, because three duplicate implementations collapsed into one.

## Verification

Measured in the running app over CDP with the cursor parked on the Next Track button:

```
250ms:no  500ms:YES  750ms:YES  1000ms:YES … 4000ms:YES
```

Absent before the 400 ms delay, then continuously present through 4 seconds. Worth noting the first version of that check reported a false FAIL: a single synthetic `mouseMoved` isn't a sustained hover, so Chromium treated the cursor as having left. The check now re-parks the cursor each sample.

14 unit tests cover the delay, early-leave cancel, focus/blur, text-entry suppression, scroll dismissal, `suppressed`, ref forwarding, and preservation of the child's own handlers. Suite 447 → 461. Renderer and web bundles both build.

## Not verified

Windows/macOS (no machines to hand) — but this path is now pure DOM, so it's less platform-dependent than what it replaced, not more. Worth a quick hover around the app on your setup, particularly the queue rows and the editor's time fields.