### PR TITLE
Release v0.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![React 19](https://img.shields.io/badge/React-19-blue)](https://react.dev/)
 [![Electron 42](https://img.shields.io/badge/Electron-42-blue)](https://www.electronjs.org/)
-[![Tests](https://img.shields.io/badge/tests-447-green)](./.github/workflows/ci.yml)
+[![Tests](https://img.shields.io/badge/tests-466-green)](./.github/workflows/ci.yml)
 
 Loukai is a free, open source karaoke software that runs locally on your computer to **play** and **create** karaoke files from your own music. Built on M4A Stems (MPEG-4 multi-track audio), it uses industry-standard formats compatible with DJ software, giving you full control over your personal karaoke library.
 
@@ -421,7 +421,7 @@ npm run test:coverage
 npm run test:ui
 ```
 
-**Current Coverage:** 447 tests across 23 test files
+**Current Coverage:** 466 tests across 25 test files
 
 ---
 

--- a/com.loukai.app.metainfo.xml
+++ b/com.loukai.app.metainfo.xml
@@ -48,6 +48,16 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="0.12.1" date="2026-08-12">
+      <description>
+        <p>Fixes tooltips, visuals while minimized, and a crash on quit</p>
+        <ul>
+          <li>Tooltips stay visible instead of flashing and vanishing</li>
+          <li>Visuals keep running when the main window is minimized, so projected karaoke and remote viewers no longer freeze while the control window is out of the way</li>
+          <li>Fixes a crash when quitting the app or turning the web server off during a song</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.12.0" date="2026-08-08">
       <description>
         <p>Play from the couch: full gamepad navigation, plus a fix for npx launches</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loukai-app",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loukai-app",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loukai-app",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "type": "module",
   "description": "Loukai Karaoke - Free and open source karaoke system for playing and creating stem-based karaoke files",
   "main": "src/main/main.js",


### PR DESCRIPTION
Patch release for the three fixes merged since 0.12.0.

## In this release
- **Tooltips stay visible** instead of flashing (#114). `title` attributes asked the OS for popup surfaces, which are broken on Electron's native Wayland; hints are now drawn in React. Also consolidated four separate hand-rolled tooltip implementations into one shared component.
- **Visuals keep running while minimized** (#113). Chromium throttled the backgrounded renderer to 0 fps, which froze the projected canvas and WebRTC viewers, since both are fed by a canvas painted in the main window. Measured 0 fps → 30 fps while minimized.
- **No crash on quit** (#112). The web server's appState listeners survived `stop()` and dereferenced a nulled Socket.IO instance. Also fixed disabling the web server mid-song, and duplicate listeners stacking on every restart.

## This PR
- Version 0.12.1 in package.json/lock
- Flathub metainfo release entry (validated with `appstreamcli validate`)
- README test counts 447 → 466

## Verified on merged main
466 tests passing, `npm audit --omit=dev --audit-level=high` clean, lint has only pre-existing warnings.

## After merge
1. `git tag v0.12.1 && git push origin v0.12.1` — builds the desktop artifacts into the GitHub release
2. `npm publish` from tagged main