### PR TITLE
Server settings: override the address the QR code points to

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Access in the Server tab:
 - **Max Requests**: Limit requests per user
 - **Show QR Code**: Display QR code on canvas for easy mobile access (on by default)
 - **Display Queue**: Show upcoming songs on canvas (on by default)
+- **Use a custom address for the QR code**: Advertise a different URL than the detected LAN address, for when a reverse proxy, tunnel, or custom hostname fronts the server (e.g. `https://karaoke.example.com`). A bare hostname assumes `https`. The QR code and the status-bar link follow it; the server keeps listening on the same local port, and an incomplete entry falls back to the local address.
 
 ### Settings Persistence
 All settings are automatically saved to:

--- a/src/main/handlers/webServerHandlers.js
+++ b/src/main/handlers/webServerHandlers.js
@@ -21,10 +21,16 @@ export function registerWebServerHandlers(mainApp) {
     return mainApp.getWebServerPort();
   });
 
-  // Get web server URL
+  // Get web server URL — what singers should reach (may be a proxy override)
   ipcMain.handle('webServer:getUrl', () => {
     // log('🔍 webServer:getUrl called', { hasWebServer: Boolean(mainApp.webServer) });
     return mainApp.webServer?.getServerUrl() || null;
+  });
+
+  // Get the address this process actually listens on, ignoring any override.
+  // The UI needs it for the real port and for localhost-only links.
+  ipcMain.handle('webServer:getLocalUrl', () => {
+    return mainApp.webServer?.getLocalServerUrl() || null;
   });
 
   // Get web server settings

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -2167,7 +2167,14 @@ class KaiPlayerApp {
       const port = await this.webServer.start(3069);
 
       log(`🌐 Web server started at http://localhost:${port}`);
-      log(`📱 Song requests available at: http://localhost:${port}`);
+      // The advertised address is what the QR code and singers' phones use; it
+      // differs from the local one when a proxy/tunnel override is configured.
+      const publicUrl = this.webServer.getServerUrl();
+      const localUrl = this.webServer.getLocalServerUrl();
+      log(`📱 Song requests available at: ${publicUrl || `http://localhost:${port}`}`);
+      if (publicUrl && publicUrl !== localUrl) {
+        log(`   (custom address; this server listens on ${localUrl})`);
+      }
 
       // Connect to Socket.IO server
       await this.connectToSocketServer(port);

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -157,6 +157,7 @@ const api = {
   webServer: {
     getPort: () => ipcRenderer.invoke('webServer:getPort'),
     getUrl: () => ipcRenderer.invoke('webServer:getUrl'),
+    getLocalUrl: () => ipcRenderer.invoke('webServer:getLocalUrl'),
     getSettings: () => ipcRenderer.invoke('webServer:getSettings'),
     updateSettings: (settings) => ipcRenderer.invoke('webServer:updateSettings', settings),
     getSongRequests: () => ipcRenderer.invoke('webServer:getSongRequests'),

--- a/src/main/webServer.js
+++ b/src/main/webServer.js
@@ -31,6 +31,7 @@ import { getCacheDir } from './creator/systemChecker.js';
 import { registerWebGpuAssets } from './creator/webgpuAssets.js';
 import multer from 'multer';
 import { forwardViewerEvent } from './handlers/streamingHandlers.js';
+import { resolvePublicUrl } from '../shared/utils/publicUrl.js';
 
 // ESM equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -2745,7 +2746,13 @@ class WebServer {
     return false;
   }
 
+  /** The address to advertise (QR code, status bar): the override if set, else the LAN address. */
   getServerUrl() {
+    return resolvePublicUrl(this.settings, this.getLocalServerUrl());
+  }
+
+  /** The address this process actually listens on, ignoring any override. */
+  getLocalServerUrl() {
     if (!this.port) return null;
     const ip = this.getLanIp();
     return `http://${ip}:${this.port}`;

--- a/src/renderer/adapters/ElectronBridge.js
+++ b/src/renderer/adapters/ElectronBridge.js
@@ -576,6 +576,11 @@ export class ElectronBridge extends BridgeInterface {
     return await this.api.webServer.getUrl();
   }
 
+  /** The real listening address, ignoring any public-URL override. */
+  async getLocalServerUrl() {
+    return await this.api.webServer.getLocalUrl?.();
+  }
+
   async getServerSettings() {
     return await this.api.webServer.getSettings();
   }

--- a/src/renderer/components/ServerTab.jsx
+++ b/src/renderer/components/ServerTab.jsx
@@ -5,6 +5,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useConfirm } from '../../shared/hooks/useConfirm.jsx';
 import { generateQRCode } from '../utils/qrCodeGenerator.js';
+import { normalizePublicUrl } from '../../shared/utils/publicUrl.js';
 
 export function ServerTab({ bridge }) {
   const [serverUrl, setServerUrl] = useState(null);
@@ -17,6 +18,8 @@ export function ServerTab({ bridge }) {
     streamVocalsToClients: false,
     showQrCode: true,
     displayQueue: true,
+    publicUrlEnabled: false,
+    publicUrl: '',
   });
   const [adminPassword, setAdminPassword] = useState('');
   const [hasPassword, setHasPassword] = useState(false);
@@ -24,6 +27,12 @@ export function ServerTab({ bridge }) {
   const [totalRequests, setTotalRequests] = useState(0);
   const [message, setMessage] = useState(null);
   const [qrCodeDataUrl, setQrCodeDataUrl] = useState(null);
+
+  // Show what the typed override actually resolves to (it accepts a bare host
+  // and assumes https), so a bad value is obvious before saving.
+  const publicUrlPreview = settings.publicUrlEnabled
+    ? normalizePublicUrl(settings.publicUrl)
+    : null;
 
   // Wrap in useCallback to stabilize reference
   const updateRequestsStats = useCallback(async () => {
@@ -44,12 +53,16 @@ export function ServerTab({ bridge }) {
 
     const loadData = async () => {
       try {
-        // Get server URL
+        // Advertised URL (may be a proxy override) for display and the QR code.
         const url = await bridge.getServerUrl();
         setServerUrl(url);
-        if (url) {
-          const port = new URL(url).port;
-          setServerPort(port);
+        // The real port comes from the local address: a proxy URL like
+        // https://karaoke.example.com has no port to parse.
+        const localUrl = (await bridge.getLocalServerUrl?.()) || url;
+        if (localUrl) {
+          setServerPort(
+            new URL(localUrl).port || (new URL(localUrl).protocol === 'https:' ? '443' : '80')
+          );
         }
 
         // Get settings
@@ -63,6 +76,8 @@ export function ServerTab({ bridge }) {
             streamVocalsToClients: serverSettings.streamVocalsToClients === true,
             showQrCode: serverSettings.showQrCode !== false,
             displayQueue: serverSettings.displayQueue !== false,
+            publicUrlEnabled: serverSettings.publicUrlEnabled === true,
+            publicUrl: serverSettings.publicUrl || '',
           });
         }
 
@@ -89,9 +104,7 @@ export function ServerTab({ bridge }) {
           .then((url) => {
             setServerUrl(url);
             if (url) {
-              const port = new URL(url).port;
-              setServerPort(port);
-              // Generate QR code when URL is available
+              // QR code shows the advertised address (override included).
               generateQRCode(url, { width: 300 }).then(setQrCodeDataUrl).catch(console.error);
             }
           })
@@ -356,6 +369,38 @@ export function ServerTab({ bridge }) {
                 />
                 <span className="text-gray-900 dark:text-gray-100">Display queue</span>
               </label>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label className="flex items-center cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  id="publicUrlEnabled"
+                  className="w-4 h-4 mr-2 cursor-pointer"
+                  checked={settings.publicUrlEnabled}
+                  onChange={(e) => handleSettingChange('publicUrlEnabled', e.target.checked)}
+                />
+                <span className="text-gray-900 dark:text-gray-100">
+                  Use a custom address for the QR code
+                </span>
+              </label>
+              {settings.publicUrlEnabled && (
+                <div className="ml-6 flex flex-col gap-1">
+                  <input
+                    type="text"
+                    id="publicUrl"
+                    className="w-full max-w-md px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400"
+                    placeholder="https://karaoke.example.com"
+                    value={settings.publicUrl}
+                    onChange={(e) => handleSettingChange('publicUrl', e.target.value)}
+                  />
+                  <span className="text-xs text-gray-600 dark:text-gray-400">
+                    {publicUrlPreview
+                      ? `Singers will be sent to ${publicUrlPreview}`
+                      : 'Enter the address singers should reach, e.g. a reverse proxy or tunnel in front of this port. Until it is valid, the local address is used.'}
+                  </span>
+                </div>
+              )}
             </div>
 
             <button

--- a/src/shared/defaults.js
+++ b/src/shared/defaults.js
@@ -58,6 +58,11 @@ export const SERVER_DEFAULTS = {
   maxRequestsPerIP: 10,
   showQrCode: true,
   displayQueue: true,
+  // Publish a different address than the detected LAN one (reverse proxy,
+  // tunnel, custom hostname). Only used when publicUrlEnabled is on AND
+  // publicUrl is a valid absolute http(s) URL.
+  publicUrlEnabled: false,
+  publicUrl: '',
 };
 
 export const LLM_DEFAULTS = {

--- a/src/shared/services/serverSettingsService.js
+++ b/src/shared/services/serverSettingsService.js
@@ -89,6 +89,14 @@ export function loadSettings(webServer) {
         'server.displayQueue',
         webServer.defaultSettings.displayQueue
       );
+      savedSettings.publicUrlEnabled = webServer.mainApp.settings.get(
+        'server.publicUrlEnabled',
+        webServer.defaultSettings.publicUrlEnabled
+      );
+      savedSettings.publicUrl = webServer.mainApp.settings.get(
+        'server.publicUrl',
+        webServer.defaultSettings.publicUrl
+      );
     }
 
     const finalSettings = { ...webServer.defaultSettings, ...savedSettings };
@@ -123,6 +131,11 @@ export function saveSettings(webServer) {
       );
       webServer.mainApp.settings.set('server.showQrCode', webServer.settings.showQrCode);
       webServer.mainApp.settings.set('server.displayQueue', webServer.settings.displayQueue);
+      webServer.mainApp.settings.set(
+        'server.publicUrlEnabled',
+        webServer.settings.publicUrlEnabled
+      );
+      webServer.mainApp.settings.set('server.publicUrl', webServer.settings.publicUrl);
       console.log('🔧 Server settings saved to persistent storage');
       return true;
     } else {

--- a/src/shared/services/serverSettingsService.test.js
+++ b/src/shared/services/serverSettingsService.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { loadSettings, saveSettings, updateServerSettings } from './serverSettingsService.js';
+import { SERVER_DEFAULTS } from '../defaults.js';
+
+/**
+ * loadSettings/saveSettings enumerate every key by hand, so a newly added
+ * setting silently fails to persist if it isn't listed in both. These cover the
+ * round trip rather than the enumeration, so they stay meaningful as keys move.
+ */
+function makeWebServer(stored = {}) {
+  const store = { ...stored };
+  return {
+    defaultSettings: { ...SERVER_DEFAULTS },
+    settings: { ...SERVER_DEFAULTS },
+    io: null,
+    mainApp: {
+      settings: {
+        get: vi.fn((key, fallback) => (key in store ? store[key] : fallback)),
+        set: vi.fn((key, value) => {
+          store[key] = value;
+        }),
+      },
+    },
+    _store: store,
+  };
+}
+
+describe('serverSettingsService persistence', () => {
+  let webServer;
+  beforeEach(() => {
+    webServer = makeWebServer();
+  });
+
+  it('defaults the public URL override to off and empty', () => {
+    const loaded = loadSettings(webServer);
+    expect(loaded.publicUrlEnabled).toBe(false);
+    expect(loaded.publicUrl).toBe('');
+  });
+
+  it('saves and reloads the public URL override', () => {
+    webServer.settings.publicUrlEnabled = true;
+    webServer.settings.publicUrl = 'https://karaoke.example.com';
+    expect(saveSettings(webServer)).toBe(true);
+
+    // A fresh instance reading the same store must see the values.
+    const restarted = makeWebServer(webServer._store);
+    const loaded = loadSettings(restarted);
+    expect(loaded.publicUrlEnabled).toBe(true);
+    expect(loaded.publicUrl).toBe('https://karaoke.example.com');
+  });
+
+  it('persists the override through updateServerSettings', () => {
+    const result = updateServerSettings(webServer, {
+      publicUrlEnabled: true,
+      publicUrl: 'karaoke.example.com',
+    });
+    expect(result.success).toBe(true);
+    expect(webServer._store['server.publicUrl']).toBe('karaoke.example.com');
+
+    const loaded = loadSettings(makeWebServer(webServer._store));
+    expect(loaded.publicUrl).toBe('karaoke.example.com');
+  });
+
+  it('leaves unrelated settings alone on a partial update', () => {
+    updateServerSettings(webServer, { publicUrlEnabled: true });
+    expect(webServer.settings.serverName).toBe(SERVER_DEFAULTS.serverName);
+    expect(webServer.settings.showQrCode).toBe(SERVER_DEFAULTS.showQrCode);
+  });
+
+  it('falls back to defaults when no settings manager exists', () => {
+    const loaded = loadSettings({ defaultSettings: { ...SERVER_DEFAULTS } });
+    expect(loaded).toEqual(SERVER_DEFAULTS);
+  });
+});

--- a/src/shared/utils/publicUrl.js
+++ b/src/shared/utils/publicUrl.js
@@ -1,0 +1,57 @@
+/**
+ * Public URL override.
+ *
+ * The address the app advertises (QR code on the canvas, the link in the status
+ * bar) is normally derived from the detected LAN IP and the listening port. That
+ * is wrong whenever something else fronts the server: a reverse proxy, a tunnel,
+ * or a hostname on the local network. This lets the KJ state the address singers
+ * should actually reach.
+ *
+ * Kept as a pure function so the main process, the renderer's validation hint,
+ * and the tests all agree on what counts as usable.
+ */
+
+/**
+ * Normalize a user-typed override into something a phone camera can open.
+ * Accepts "example.com/karaoke" (assumes https) as well as full URLs, trims
+ * whitespace, and drops a trailing slash.
+ *
+ * @returns {string|null} the normalized URL, or null if unusable
+ */
+export function normalizePublicUrl(input) {
+  if (typeof input !== 'string') return null;
+  const raw = input.trim();
+  if (!raw) return null;
+
+  // A bare host/path is the common typo-shaped input; assume https rather than
+  // rejecting it, since a proxy that needs an override is almost always TLS.
+  const withScheme = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw) ? raw : `https://${raw}`;
+
+  let parsed;
+  try {
+    parsed = new URL(withScheme);
+  } catch {
+    return null;
+  }
+
+  // A QR code has to open in a browser; anything else (file:, javascript:) is
+  // not a place to send a singer.
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+  if (!parsed.hostname) return null;
+
+  const normalized = parsed.toString();
+  return normalized.endsWith('/') && parsed.pathname === '/' ? normalized.slice(0, -1) : normalized;
+}
+
+/**
+ * The address to advertise, given the server settings and the detected local
+ * URL. Falls back to the local URL whenever the override is off or unusable, so
+ * a half-typed value can never black out the QR code.
+ */
+export function resolvePublicUrl(settings, localUrl) {
+  if (settings?.publicUrlEnabled) {
+    const override = normalizePublicUrl(settings.publicUrl);
+    if (override) return override;
+  }
+  return localUrl ?? null;
+}

--- a/src/shared/utils/publicUrl.test.js
+++ b/src/shared/utils/publicUrl.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { normalizePublicUrl, resolvePublicUrl } from './publicUrl.js';
+
+describe('normalizePublicUrl', () => {
+  it('keeps a full https URL', () => {
+    expect(normalizePublicUrl('https://karaoke.example.com')).toBe('https://karaoke.example.com');
+  });
+
+  it('keeps an explicit http URL (a plain LAN hostname behind a proxy)', () => {
+    expect(normalizePublicUrl('http://karaoke.local:8080')).toBe('http://karaoke.local:8080');
+  });
+
+  it('assumes https for a bare host', () => {
+    expect(normalizePublicUrl('karaoke.example.com')).toBe('https://karaoke.example.com');
+  });
+
+  it('keeps a path (proxy mounted on a subpath)', () => {
+    expect(normalizePublicUrl('example.com/karaoke')).toBe('https://example.com/karaoke');
+  });
+
+  it('trims surrounding whitespace from a paste', () => {
+    expect(normalizePublicUrl('  https://karaoke.example.com  ')).toBe(
+      'https://karaoke.example.com'
+    );
+  });
+
+  it('drops a trailing slash on the root so it matches what users expect', () => {
+    expect(normalizePublicUrl('https://karaoke.example.com/')).toBe('https://karaoke.example.com');
+  });
+
+  it('rejects empty and whitespace-only input', () => {
+    expect(normalizePublicUrl('')).toBeNull();
+    expect(normalizePublicUrl('   ')).toBeNull();
+  });
+
+  it('rejects non-string input', () => {
+    expect(normalizePublicUrl(null)).toBeNull();
+    expect(normalizePublicUrl(undefined)).toBeNull();
+    expect(normalizePublicUrl(42)).toBeNull();
+  });
+
+  it('rejects schemes a phone camera cannot open', () => {
+    expect(normalizePublicUrl('file:///etc/passwd')).toBeNull();
+    expect(normalizePublicUrl('javascript:alert(1)')).toBeNull();
+    expect(normalizePublicUrl('ftp://example.com')).toBeNull();
+  });
+});
+
+describe('resolvePublicUrl', () => {
+  const local = 'http://192.168.1.50:3069';
+
+  it('uses the local address when the override is off', () => {
+    expect(resolvePublicUrl({ publicUrlEnabled: false, publicUrl: 'https://x.com' }, local)).toBe(
+      local
+    );
+  });
+
+  it('uses the override when enabled and valid', () => {
+    expect(
+      resolvePublicUrl({ publicUrlEnabled: true, publicUrl: 'https://karaoke.example.com' }, local)
+    ).toBe('https://karaoke.example.com');
+  });
+
+  it('falls back to local while the override is still being typed', () => {
+    // Half-typed input must never black out the QR code.
+    expect(resolvePublicUrl({ publicUrlEnabled: true, publicUrl: 'http://' }, local)).toBe(local);
+    expect(resolvePublicUrl({ publicUrlEnabled: true, publicUrl: '' }, local)).toBe(local);
+  });
+
+  it('falls back to local for a rejected scheme', () => {
+    expect(
+      resolvePublicUrl({ publicUrlEnabled: true, publicUrl: 'javascript:alert(1)' }, local)
+    ).toBe(local);
+  });
+
+  it('tolerates missing settings and a not-yet-started server', () => {
+    expect(resolvePublicUrl(undefined, local)).toBe(local);
+    expect(resolvePublicUrl({}, null)).toBeNull();
+    expect(resolvePublicUrl({ publicUrlEnabled: true, publicUrl: 'https://x.com' }, null)).toBe(
+      'https://x.com'
+    );
+  });
+});


### PR DESCRIPTION
## Why

The advertised address was always `http://<detected LAN IP>:<port>`. That's wrong whenever something else fronts the server — a reverse proxy, a tunnel, a hostname on the local network — so singers scanned a QR code for an address they couldn't reach.

## What

A checkbox plus a text field in Server settings. When enabled with a usable value, the canvas QR code and the status-bar link use it. The server keeps listening on the same local port either way; this only changes what gets advertised.

![setting: "Use a custom address for the QR code" with a text field]

Behavior details:

- **Bare host accepted**: `karaoke.example.com` becomes `https://karaoke.example.com`, since a proxy needing an override is almost always TLS. Paths work too (`example.com/karaoke`), for a proxy on a subpath.
- **Never blanks the QR code**: anything unusable — half-typed, or a scheme a phone camera can't open (`file:`, `javascript:`) — falls back to the local address.
- **Keeps your text**: the URL is retained when you uncheck the box, so toggling doesn't lose it.
- **Live preview**: the UI shows what the entry resolves to, so a typo is visible before saving.

## Notable implementation points

- `getServerUrl()` now means "the address to advertise". The real listening address moved to `getLocalServerUrl()`, exposed as a new `webServer:getLocalUrl` IPC. `ServerTab` needs it for the "Running on port N" readout and the localhost admin link, because a proxy URL like `https://karaoke.example.com` has no port to parse. Only the IPC advertise path consumed the old method, so nothing else changed meaning.
- Both new keys are listed in `serverSettingsService`'s `loadSettings` **and** `saveSettings`, which enumerate keys by hand — a new setting silently fails to persist otherwise. That's now covered by tests, in a file that previously had none.
- URL normalization lives in `src/shared/utils/publicUrl.js` as pure functions, so the main process, the UI's preview, and the tests all agree on what counts as usable.

## Verification

End-to-end in the running app over CDP, driving the same IPC the Save button uses:

```
local address: http://192.168.68.51:3069
  ok  advertised URL with override off: "http://192.168.68.51:3069"
  ok  advertised URL with override on:  "https://karaoke.example.com"
  ok  local address unchanged:          "http://192.168.68.51:3069"
  ok  bare host gets https:             "https://karaoke.example.com"
  ok  invalid override falls back to local
  ok  disabling the override restores local
  ok  URL text is retained while disabled
  ok  QR built from the override URL / QR canvas rendered
```

19 new unit tests (normalization, resolution, settings round-trip). Suite 466 → 485. Renderer builds.

## Not covered

The web admin doesn't expose server settings at all today, so this is Electron-only, consistent with the existing QR/queue toggles. An actual proxy wasn't exercised — the check confirms the app advertises and encodes the override, not that your proxy is configured correctly.