### PR TITLE
Release v0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![React 19](https://img.shields.io/badge/React-19-blue)](https://react.dev/)
 [![Electron 42](https://img.shields.io/badge/Electron-42-blue)](https://www.electronjs.org/)
-[![Tests](https://img.shields.io/badge/tests-466-green)](./.github/workflows/ci.yml)
+[![Tests](https://img.shields.io/badge/tests-485-green)](./.github/workflows/ci.yml)
 
 Loukai is a free, open source karaoke software that runs locally on your computer to **play** and **create** karaoke files from your own music. Built on M4A Stems (MPEG-4 multi-track audio), it uses industry-standard formats compatible with DJ software, giving you full control over your personal karaoke library.
 
@@ -422,7 +422,7 @@ npm run test:coverage
 npm run test:ui
 ```
 
-**Current Coverage:** 466 tests across 25 test files
+**Current Coverage:** 485 tests across 27 test files
 
 ---
 

--- a/com.loukai.app.metainfo.xml
+++ b/com.loukai.app.metainfo.xml
@@ -48,10 +48,11 @@
   <content_rating type="oars-1.1" />
 
   <releases>
-    <release version="0.12.1" date="2026-08-12">
+    <release version="0.13.0" date="2026-08-12">
       <description>
-        <p>Fixes tooltips, visuals while minimized, and a crash on quit</p>
+        <p>Custom QR code address, plus fixes for tooltips, minimized visuals and a crash on quit</p>
         <ul>
+          <li>NEW: point the QR code at your own address - useful when a reverse proxy, tunnel or custom hostname fronts the app, so singers scan something they can actually reach (Server settings)</li>
           <li>Tooltips stay visible instead of flashing and vanishing</li>
           <li>Visuals keep running when the main window is minimized, so projected karaoke and remote viewers no longer freeze while the control window is out of the way</li>
           <li>Fixes a crash when quitting the app or turning the web server off during a song</li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loukai-app",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loukai-app",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loukai-app",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "type": "module",
   "description": "Loukai Karaoke - Free and open source karaoke system for playing and creating stem-based karaoke files",
   "main": "src/main/main.js",


### PR DESCRIPTION
Minor release, not a patch: main now contains the QR URL override feature, so shipping it as 0.12.1 would hide a new feature in a patch version.

**0.12.1 was never tagged or published** (no git tag, no GitHub release), so its notes are folded into 0.13.0 rather than left as a phantom version.

## In this release
- **NEW: custom QR code address** (#116). Point the QR code and status-bar link at your own URL, for when a reverse proxy, tunnel, or custom hostname fronts the app. Bare hostnames assume https; anything unusable falls back to the LAN address so the QR code can never go blank. The startup banner now also prints the address singers actually use rather than `localhost`.
- **Tooltips stay visible** (#114). `title` attributes ask the OS for popup surfaces, which are broken on Electron's native Wayland; hints are now drawn in React. Four hand-rolled tooltip implementations consolidated into one shared component.
- **Visuals keep running while minimized** (#113). Chromium throttled the backgrounded renderer to 0 fps, freezing the projected canvas and WebRTC viewers, both of which are fed by a canvas painted in the main window. Measured 0 fps → 30 fps.
- **No crash on quit** (#112). The web server's appState listeners survived `stop()` and dereferenced a nulled Socket.IO instance. Also fixed disabling the web server mid-song and duplicate listeners stacking across restarts.

## This PR
- Version 0.13.0 in package.json/lock
- Flathub metainfo entry for 0.13.0 (validated with `appstreamcli validate`)
- README test counts 466 → 485

## Verified on merged main
485 tests passing, `npm audit --omit=dev --audit-level=high` clean.

## After merge
1. `git tag v0.13.0 && git push origin v0.13.0` — builds the desktop artifacts into the GitHub release
2. `npm publish` from tagged main