### PR TITLE
Release v0.13.1

### DIFF
--- a/com.loukai.app.metainfo.xml
+++ b/com.loukai.app.metainfo.xml
@@ -53,6 +53,7 @@
         <p>Fixes the web pages failing to load when run with npx</p>
         <ul>
           <li>Fixes the song request page and the whole web admin failing to load (server errors) when the app was started with "npx loukai-app"; installed desktop builds were unaffected</li>
+          <li>Fixes the "Powered by Loukai" link on the song request page pointing at the wrong domain</li>
         </ul>
       </description>
     </release>

--- a/com.loukai.app.metainfo.xml
+++ b/com.loukai.app.metainfo.xml
@@ -48,6 +48,14 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="0.13.1" date="2026-08-12">
+      <description>
+        <p>Fixes the web pages failing to load when run with npx</p>
+        <ul>
+          <li>Fixes the song request page and the whole web admin failing to load (server errors) when the app was started with "npx loukai-app"; installed desktop builds were unaffected</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.13.0" date="2026-08-12">
       <description>
         <p>Custom QR code address, plus fixes for tooltips, minimized visuals and a crash on quit</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loukai-app",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loukai-app",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loukai-app",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "module",
   "description": "Loukai Karaoke - Free and open source karaoke system for playing and creating stem-based karaoke files",
   "main": "src/main/main.js",

--- a/src/web/pages/SongRequestPage.jsx
+++ b/src/web/pages/SongRequestPage.jsx
@@ -550,7 +550,7 @@ export function SongRequestPage() {
         {/* Footer */}
         <footer className="mt-8 py-6 text-center">
           <a
-            href="https://loukai.app"
+            href="https://loukai.com"
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors text-sm"


### PR DESCRIPTION
Patch release for the npx web-UI breakage (#118), plus a wrong-domain link fix. Urgent for npm consumers: on published 0.13.0 the song request page returns 500 and the entire web admin 404s under `npx loukai-app`.

## In this release
- **Web pages load under npx again** (#118). `express`/`send` refuse paths containing a dot-segment (`dotfiles` defaults to `'ignore'`), and npx installs live under `~/.npm/_npx/<hash>/` — so the server rejected its own bundled assets purely because of where npm put them. All six `sendFile` calls and six `express.static` mounts now pass `dotfiles: 'allow'`. Installed desktop builds were never affected.
- **Footer link fixed**: the "Powered by Loukai" link on the song request page — the page every singer sees — pointed at `loukai.app`, which isn't the project's domain. Now `loukai.com`. It was the only occurrence in source; the `com.loukai.app` appId is unrelated and untouched.

## This PR
- Version 0.13.1 in package.json/lock
- Flathub metainfo entry for 0.13.1 covering both fixes (validated with `appstreamcli validate`)

## Verified on this exact release candidate
Packed the 0.13.1 tarball, extracted it into a directory named `.rc-test`, and ran it:

| route | result |
|---|---|
| `/` | 200 |
| `/admin/` | 200 |
| `/admin/assets/index-BOyWwMYC.js` | 200 |
| `/admin/check-auth` | 200 |
| `/static/viewer.html` | 200 |

Zero Express errors. Startup banner correctly advertises the LAN address.

For the footer: rebuilt the web bundle and fetched it from the running server — the served JS contains `https://loukai.com` and no `loukai.app`.

485 tests passing, `npm audit --omit=dev --audit-level=high` clean.

## After merge
1. `git tag v0.13.1 && git push origin v0.13.1` — builds the desktop artifacts into the GitHub release
2. `npm publish` — **this is the one that matters here**, since the npx bug only affects npm consumers
