### PR TITLE
Fix the QR override and port setting not taking effect

### DIFF
--- a/src/main/handlers/webServerHandlers.js
+++ b/src/main/handlers/webServerHandlers.js
@@ -45,7 +45,15 @@ export function registerWebServerHandlers(mainApp) {
   // Update web server settings
   ipcMain.handle('webServer:updateSettings', (event, settings) => {
     if (mainApp.webServer) {
-      return serverSettingsService.updateServerSettings(mainApp.webServer, settings);
+      const result = serverSettingsService.updateServerSettings(mainApp.webServer, settings);
+      // The service broadcasts over Socket.IO, which reaches web admins and
+      // loops back through main's own socket — but that round trip is not
+      // guaranteed (the socket may not be connected yet), and settings saved
+      // from THIS renderer must update it regardless. Tell it directly.
+      if (result.success) {
+        mainApp.sendToRenderer('settings-update', result.settings);
+      }
+      return result;
     }
     return { success: false, error: 'Web server not available' };
   });

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -31,6 +31,7 @@ import { log } from './logger.js';
 
 log('📦 About to import registerAllHandlers...');
 import { registerAllHandlers } from './handlers/index.js';
+import { SERVER_DEFAULTS } from '../shared/defaults.js';
 log('✅ registerAllHandlers imported:', typeof registerAllHandlers);
 
 // ESM equivalent of __dirname
@@ -2164,7 +2165,16 @@ class KaiPlayerApp {
   async initializeWebServer() {
     try {
       this.webServer = new WebServer(this);
-      const port = await this.webServer.start(3069);
+      // Honor a configured port. This used to be hardcoded to 3069, so the port
+      // field in Server settings had no effect no matter what was saved.
+      // (webServer.settings is only populated once listen() succeeds, so read
+      // the persisted value directly here.)
+      const configuredPort = Number(this.settings?.get('server.port', SERVER_DEFAULTS.port));
+      const startPort =
+        Number.isInteger(configuredPort) && configuredPort > 0 && configuredPort < 65536
+          ? configuredPort
+          : SERVER_DEFAULTS.port;
+      const port = await this.webServer.start(startPort);
 
       log(`🌐 Web server started at http://localhost:${port}`);
       // The advertised address is what the QR code and singers' phones use; it
@@ -2284,8 +2294,10 @@ class KaiPlayerApp {
       this.webServer.settings = { ...this.webServer.settings, ...settings };
     }
 
-    // Send settings update to renderer to update UI
-    this.sendToRenderer('settings:update', settings);
+    // Send settings update to renderer to update UI. The channel is
+    // 'settings-update' (hyphen): App.jsx refreshes the canvas QR code on it,
+    // so a colon here silently stopped the QR from following a settings change.
+    this.sendToRenderer('settings-update', settings);
     log('🔧 Settings update sent to renderer');
   }
 

--- a/src/renderer/components/App.jsx
+++ b/src/renderer/components/App.jsx
@@ -52,7 +52,9 @@ export function App({ bridge }) {
         const settings = await window.kaiAPI?.webServer?.getSettings?.();
         const showQrCode = settings?.showQrCode !== false; // Default to true
 
-        // Update both players
+        // Update both players. Push on every settings change, including when a
+        // custom address is switched OFF and `url` reverts to the LAN one — the
+        // QR has to be regenerated either way, not just when it first appears.
         const player = window.app?.player;
         if (player && url) {
           if (player.karaokeRenderer) {

--- a/src/renderer/components/ServerTab.jsx
+++ b/src/renderer/components/ServerTab.jsx
@@ -119,6 +119,14 @@ export function ServerTab({ bridge }) {
   const handleSaveSettings = async () => {
     try {
       await bridge.updateServerSettings(settings);
+      // Re-read the advertised URL immediately instead of waiting for the 5s
+      // poll: turning a custom address on OR off changes what this tab should
+      // show, and a stale URL/QR here reads as "the setting did not work".
+      const url = await bridge.getServerUrl();
+      setServerUrl(url);
+      if (url) {
+        generateQRCode(url, { width: 300 }).then(setQrCodeDataUrl).catch(console.error);
+      }
       showMessage('Settings saved successfully', 'success');
     } catch (error) {
       console.error('Failed to save settings:', error);

--- a/src/shared/services/serverSettingsService.js
+++ b/src/shared/services/serverSettingsService.js
@@ -77,6 +77,10 @@ export function loadSettings(webServer) {
         'server.requireKJApproval',
         webServer.defaultSettings.requireKJApproval
       );
+      savedSettings.port = webServer.mainApp.settings.get(
+        'server.port',
+        webServer.defaultSettings.port
+      );
       savedSettings.maxRequestsPerIP = webServer.mainApp.settings.get(
         'server.maxRequestsPerIP',
         webServer.defaultSettings.maxRequestsPerIP
@@ -125,6 +129,7 @@ export function saveSettings(webServer) {
         'server.requireKJApproval',
         webServer.settings.requireKJApproval
       );
+      webServer.mainApp.settings.set('server.port', webServer.settings.port);
       webServer.mainApp.settings.set(
         'server.maxRequestsPerIP',
         webServer.settings.maxRequestsPerIP


### PR DESCRIPTION
Fixes "the custom QR url doesn't work" and "the custom port stays on 3069". The QR override logic was correct all along — nothing ever told the canvas or the tab to re-read it.

## Three bugs behind the QR symptom

1. **Channel name mismatch.** `main.js` sent `settings:update` (colon); `App.jsx` listens on `settings-update` (hyphen). The effect that regenerates the canvas QR therefore never fired on a settings change. `preload`'s `settings.onUpdate` wrapped the old colon channel and has **no consumers anywhere**, so nothing depended on the typo.
2. **Saving from the Electron UI never notified its own renderer.** The service broadcasts over Socket.IO, which only reaches the local window by looping back through main's own socket — not guaranteed connected, and the wrong mechanism for the window that just saved. `webServer:updateSettings` now sends to the renderer directly.
3. **ServerTab showed a stale URL and QR after saving** until the 5-second poll caught up, which reads as "the setting didn't work". It now re-reads the advertised URL and regenerates its preview immediately — so **turning the override off updates the tab as promptly as turning it on**.

## The port was a separate bug, same shape

`'server.port'` was missing from `serverSettingsService`'s `loadSettings` **and** `saveSettings` — the same hand-enumerated key list that would have swallowed `publicUrl` — and `initializeWebServer` hardcoded `start(3069)`, so the field couldn't have worked even if it had persisted. Both fixed, and the configured value is range-checked before use.

## Verification (real UI driven over CDP)

Override ON → advertised URL, regenerated QR, and tab text all show `https://karaoke.example.com`.
Override OFF → all three revert to the LAN address.

```
--- turn override ON ---
  ok  advertised URL: "https://karaoke.example.com"
  ok  QR regenerated from override: "https://karaoke.example.com"
  ok  tab shows the override: true
--- turn override OFF ---
  ok  advertised URL back to LAN: "http://192.168.68.51:3069"
  ok  QR regenerated from LAN address: "http://192.168.68.51:3069"
```

The QR check hooks `setServerQRCode` and reads the URL the renderer actually built the code from, not just what the IPC returns.

Port: typed `3222` in the field, saved, confirmed persisted to `settings.json`, restarted → `Web server started on http://localhost:3222`.

485 tests passing.

## Note

Changing the port needs an app restart to take effect (the server binds at startup). Worth a UI hint later; not in this PR.
